### PR TITLE
Add numpy optional bench dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ orch solve "Write a haiku about AI."
 
 - `orch solve "prompt"` – Solve a task
 - `orch show-config` – Show current config (secrets masked)
-- `orch bench --prompt "hi" --rounds 5` – Benchmark
+- `orch bench --prompt "hi" --rounds 5` – Benchmark (requires `numpy`; install with `pip install pydantic-ai-orchestrator[bench]`)
 - `orch --profile` – Enable Logfire span viewer
 
 ## Environment Variables

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,12 @@ orch bench --prompt "hi" --rounds 3
 orch --profile
 ```
 
+`orch bench` depends on `numpy`. Install with the optional `[bench]` extra:
+
+```bash
+pip install pydantic-ai-orchestrator[bench]
+```
+
 ## API
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "rich"
 ]
 opentelemetry = ["opentelemetry-sdk>=1.26"]
+bench = ["numpy"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- add `bench` optional dependency group with `numpy`
- document numpy requirement in CLI usage and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vcr', openai api key error)*

------
https://chatgpt.com/codex/tasks/task_e_684b3300a118832cb96d2fab16a92aaa