### PR TITLE
Document numpy requirement for bench command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ orch solve "Write a haiku about AI."
 
 - `orch solve "prompt"` – Solve a task
 - `orch show-config` – Show current config (secrets masked)
-- `orch bench --prompt "hi" --rounds 5` – Benchmark
+- `orch bench --prompt "hi" --rounds 5` – Benchmark (requires `numpy`)
 - `orch --profile` – Enable Logfire span viewer
 
 ## Environment Variables

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,8 @@ orch bench --prompt "hi" --rounds 3
 orch --profile
 ```
 
+Benchmarking requires the optional `numpy` dependency. Install it with `pip install numpy` if not already available.
+
 ## API
 
 ```python


### PR DESCRIPTION
## Summary
- mention numpy requirement in CLI usage
- document numpy dependency for benchmarking in usage docs

## Testing
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684b33040964832c9d7f8865824657be