### PR TITLE
Fix reflection toggle env name

### DIFF
--- a/pydantic_ai_orchestrator/infra/settings.py
+++ b/pydantic_ai_orchestrator/infra/settings.py
@@ -1,20 +1,22 @@
-"""Settings and configuration for pydantic-ai-orchestrator.""" 
+"""Settings and configuration for pydantic-ai-orchestrator."""
 
 from pydantic_settings import BaseSettings
 from pydantic import ValidationError, SecretStr, field_validator, ConfigDict, Field
 from typing import Optional, Literal
 from ..exceptions import SettingsError
 
+
 class Settings(BaseSettings):
     """
     Application settings loaded from environment variables or .env file.
     Critical secrets are validated at startup.
     """
+
     openai_api_key: SecretStr
     logfire_api_key: Optional[SecretStr] = None
-    
+
     # Feature Toggles
-    reflection_enabled: bool = Field(True, alias="reflexion_enabled")
+    reflection_enabled: bool = Field(True)
     reward_enabled: bool = Field(True, alias="reward_enabled")
     telemetry_export_enabled: bool = False
     otlp_export_enabled: bool = False
@@ -41,9 +43,10 @@ class Settings(BaseSettings):
             raise ValueError("t_schedule must not be empty")
         return v
 
+
 # Singleton instance, fail fast if critical vars missing
 try:
     settings = Settings()
 except ValidationError as e:
     # Use custom exception for better error handling downstream
-    raise SettingsError(f"Invalid or missing environment variables for Settings:\n{e}") 
+    raise SettingsError(f"Invalid or missing environment variables for Settings:\n{e}")


### PR DESCRIPTION
## Summary
- remove deprecated `reflexion_enabled` alias from settings
- keep docs and tests using `ORCH_REFLECTION_ENABLED`

## Testing
- `ruff check .`
- `black pydantic_ai_orchestrator/infra/settings.py`
- `mypy pydantic_ai_orchestrator/infra/settings.py` *(fails: Extra keys for TypedDict)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vcr')*

------
https://chatgpt.com/codex/tasks/task_e_684b3d40f6fc832cbd0c88cab14ec642