### PR TITLE
Fix SpanProcessor type hint

### DIFF
--- a/pydantic_ai_orchestrator/infra/telemetry.py
+++ b/pydantic_ai_orchestrator/infra/telemetry.py
@@ -19,7 +19,7 @@ def init_telemetry():
     if _initialized:
         return
 
-    additional_processors: list[SpanProcessor] = []
+    additional_processors: list['SpanProcessor'] = []
     if settings.otlp_export_enabled:
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
         from opentelemetry.sdk.trace import BatchSpanProcessor


### PR DESCRIPTION
## Summary
- quote SpanProcessor type hint to avoid runtime import

## Testing
- `pytest tests/unit/test_telemetry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d401f84832c9e8ff89f805985f1