### PR TITLE
Add weights format validation in CLI

### DIFF
--- a/pydantic_ai_orchestrator/cli/main.py
+++ b/pydantic_ai_orchestrator/cli/main.py
@@ -48,6 +48,14 @@ def solve(
                         weights = yaml.safe_load(f)
                     else:
                         weights = json.load(f)
+                if not isinstance(weights, list) or not all(
+                    isinstance(w, dict) and "item" in w and "weight" in w for w in weights
+                ):
+                    typer.echo(
+                        "[red]Weights file must be a list of objects with 'item' and 'weight'",
+                        err=True,
+                    )
+                    raise typer.Exit(1)
                 metadata["weights"] = weights
             except Exception as e:
                 typer.echo(f"[red]Error loading weights file: {e}", err=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -92,6 +92,21 @@ def test_cli_solve_weights_file_invalid_json(tmp_path):
     assert result.exit_code == 1
     assert "Error" in result.stdout or "Traceback" in result.stdout or result.stderr
 
+def test_cli_solve_weights_invalid_structure(tmp_path):
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{\"item\": \"a\", \"weight\": 1}")
+    result = runner.invoke(app, ["solve", "prompt", "--weights-path", str(bad_file)])
+    assert result.exit_code == 1
+    assert "list of objects" in result.stderr
+
+def test_cli_solve_weights_missing_keys(tmp_path):
+    weights = [{"item": "a"}]
+    file = tmp_path / "weights.json"
+    file.write_text(json.dumps(weights))
+    result = runner.invoke(app, ["solve", "prompt", "--weights-path", str(file)])
+    assert result.exit_code == 1
+    assert "list of objects" in result.stderr
+
 def test_cli_solve_keyboard_interrupt(monkeypatch):
     def raise_keyboard(*args, **kwargs):
         raise KeyboardInterrupt()


### PR DESCRIPTION
## Summary
- verify parsed weights are list of dicts with `item` and `weight`
- show user-friendly error on validation failure
- test invalid weights formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d3b33e4832ca76d7cd963244f0c