### PR TITLE
Add validation for weighted_score inputs

### DIFF
--- a/pydantic_ai_orchestrator/domain/scoring.py
+++ b/pydantic_ai_orchestrator/domain/scoring.py
@@ -26,7 +26,14 @@ def weighted_score(check: Checklist, weights: List[Dict[str, float]]) -> float:
     if not check.items:
         return 0.0
 
-    weight_map = {w["item"]: w["weight"] for w in weights}
+    if not isinstance(weights, list):
+        raise ValueError("weights must be a list of dicts with 'item' and 'weight'")
+
+    weight_map = {}
+    for w in weights:
+        if not isinstance(w, dict) or "item" not in w or "weight" not in w:
+            raise ValueError("weights must be a list of dicts with 'item' and 'weight'")
+        weight_map[w["item"]] = w["weight"]
     total_weight = sum(weight_map.get(item.description, 1.0) for item in check.items)
     if total_weight == 0:
         return 0.0

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -135,4 +135,18 @@ def test_weighted_score_all_weights_present():
         {"item": "c", "weight": 0.2},
     ]
     # All passed, so score = sum(weights) / sum(weights) = 1.0
-    assert weighted_score(check, weights) == pytest.approx(1.0) 
+    assert weighted_score(check, weights) == pytest.approx(1.0)
+
+
+def test_weighted_score_invalid_weight_type():
+    from pydantic_ai_orchestrator.domain.models import Checklist, ChecklistItem
+    check = Checklist(items=[ChecklistItem(description="a", passed=True)])
+    with pytest.raises(ValueError):
+        weighted_score(check, ["not-a-dict"])
+
+
+def test_weighted_score_missing_keys():
+    from pydantic_ai_orchestrator.domain.models import Checklist, ChecklistItem
+    check = Checklist(items=[ChecklistItem(description="a", passed=True)])
+    with pytest.raises(ValueError):
+        weighted_score(check, [{"item": "a"}])


### PR DESCRIPTION
## Summary
- validate each weight item for 'item' and 'weight' keys in `weighted_score`
- add tests for malformed weight data

## Testing
- `OPENAI_API_KEY=sk-test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d2d82a0832caebb2f747d4bd90a