### PR TITLE
Fix Codecov token handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
         run: pytest --cov=pydantic_ai_orchestrator --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
 


### PR DESCRIPTION
## Summary
- pass CODECOV_TOKEN via env in the CI workflow

## Testing
- `pytest -q` *(fails: OrchestratorRetryError)*

------
https://chatgpt.com/codex/tasks/task_e_684b646d182c832cbc25de5c8ef0ce72