### PR TITLE
Load env with python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install and configure:
 ```bash
 pip install pydantic-ai-orchestrator
 cp .env.example .env  # then edit the file
-export OPENAI_API_KEY=sk-...
+# Environment variables in .env are loaded automatically
 orch solve "Write a haiku about AI."
 ```
 
@@ -79,6 +79,8 @@ For more examples, see the `examples` folder.
 * `orch --profile` – Enable Logfire span viewer
 
 ## Environment Variables
+Environment variables can be placed in a `.env` file and will be loaded
+automatically by the CLI using `python-dotenv`.
 
 * `OPENAI_API_KEY` (optional, for OpenAI models)
 * `GOOGLE_API_KEY` (optional, for Gemini models)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -18,7 +18,8 @@ We welcome contributions! Please follow this guide.
     ```
 
 3.  **Set up environment**
-    Copy the `.env.example` to `.env` and fill in your API keys.
+    Copy the `.env.example` to `.env` and fill in your API keys. The CLI
+    will automatically load variables from this file using `python-dotenv`.
     ```bash
     cp .env.example .env
     # Now edit .env

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,6 @@
 # Usage
-Copy `.env.example` to `.env` and add your API keys before running the CLI.
+Copy `.env.example` to `.env` and add your API keys. The CLI automatically
+loads variables from this file using `python-dotenv`.
 
 ## CLI
 

--- a/pydantic_ai_orchestrator/cli/main.py
+++ b/pydantic_ai_orchestrator/cli/main.py
@@ -1,4 +1,7 @@
-"""CLI entry point for pydantic-ai-orchestrator.""" 
+"""CLI entry point for pydantic-ai-orchestrator."""
+
+import dotenv
+dotenv.load_dotenv()
 
 import typer
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "rich>=13.7",
   "pyyaml>=6.0",
   "logfire>=0.3",
+  "python-dotenv",
   # Add any other core dependencies here
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- add `python-dotenv` to main dependencies
- automatically load `.env` in the CLI
- document automatic `.env` loading in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6ddd77e0832cb197db47c12327d2