### PR TITLE
Add dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install and configure:
 ```bash
 pip install pydantic-ai-orchestrator
 cp .env.example .env  # then edit the file
-export OPENAI_API_KEY=sk-...
+# Environment variables are loaded automatically
 orch solve "Write a haiku about AI."
 ```
 
@@ -86,6 +86,9 @@ For more examples, see the `examples` folder.
 * `LOGFIRE_API_KEY` (optional)
 * `REFLECTION_ENABLED` (default: `true`)
 * `MAX_ITERS`, `K_VARIANTS`
+
+Environment variables can be stored in a `.env` file. The CLI loads this file
+automatically using `python-dotenv`.
 
 ## API Usage
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -23,6 +23,8 @@ We welcome contributions! Please follow this guide.
     cp .env.example .env
     # Now edit .env
     ```
+    The orchestrator automatically loads variables from this file using
+    `python-dotenv`, so you don't need to call `load_dotenv()` yourself.
 
 ## Running Tests
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,6 @@
 # Usage
 Copy `.env.example` to `.env` and add your API keys before running the CLI.
+Environment variables are loaded automatically from this file.
 
 ## CLI
 

--- a/pydantic_ai_orchestrator/infra/settings.py
+++ b/pydantic_ai_orchestrator/infra/settings.py
@@ -1,6 +1,9 @@
 """Settings and configuration for pydantic-ai-orchestrator."""
 
 import os
+import dotenv
+
+dotenv.load_dotenv()
 from pydantic_settings import BaseSettings
 from pydantic import ValidationError, SecretStr, field_validator, ConfigDict, Field
 from typing import Optional, Literal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "rich>=13.7",
   "pyyaml>=6.0",
   "logfire>=0.3",
+  "python-dotenv>=1.0",
   # Add any other core dependencies here
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- add python-dotenv dep
- load `.env` automatically in `settings`
- document env file handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7068a8e4832caac4f712aacde51b