### PR TITLE
Add env overrides for default agent models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ AGENT_TIMEOUT=60
 TELEMETRY_EXPORT_ENABLED=false
 # OTLP_EXPORT_ENABLED=true
 # OTLP_ENDPOINT=https://otlp.example.com
+
+# Default models for orchestrator agents
+ORCH_DEFAULT_SOLUTION_MODEL=openai:gpt-4o
+ORCH_DEFAULT_REVIEW_MODEL=openai:gpt-4o
+ORCH_DEFAULT_VALIDATOR_MODEL=openai:gpt-4o
+ORCH_DEFAULT_REFLECTION_MODEL=openai:gpt-4o

--- a/pydantic_ai_orchestrator/infra/settings.py
+++ b/pydantic_ai_orchestrator/infra/settings.py
@@ -26,10 +26,18 @@ class Settings(BaseSettings):
     otlp_export_enabled: bool = Field(False, validation_alias="orch_otlp_export_enabled")
 
     # Default models for each agent
-    default_solution_model: str = "openai:gpt-4o"
-    default_review_model: str = "openai:gpt-4o"
-    default_validator_model: str = "openai:gpt-4o"
-    default_reflection_model: str = "openai:gpt-4o"
+    default_solution_model: str = Field(
+        "openai:gpt-4o", validation_alias="orch_default_solution_model"
+    )
+    default_review_model: str = Field(
+        "openai:gpt-4o", validation_alias="orch_default_review_model"
+    )
+    default_validator_model: str = Field(
+        "openai:gpt-4o", validation_alias="orch_default_validator_model"
+    )
+    default_reflection_model: str = Field(
+        "openai:gpt-4o", validation_alias="orch_default_reflection_model"
+    )
 
     # Orchestrator Tuning
     max_iters: int = 5


### PR DESCRIPTION
## Summary
- allow specifying default LLM models via environment variables
- document these options in `.env.example`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b71d048f0832c85b56fb97e642e60