### PR TITLE
Introduce AgentProtocol and improve examples

### DIFF
--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -5,8 +5,14 @@ Most basic usage: call the orchestrator once and print the result.
 Run with:
     OPENAI_API_KEY=sk-... python 00_quickstart.py
 """
-from pydantic_ai_orchestrator import Orchestrator, Task
-from pydantic_ai_orchestrator.infra.agents import review_agent, solution_agent, validator_agent, get_reflection_agent
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    Task,
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+)
 
 # 1️⃣  Create a default orchestrator (uses GPT-4o for all agents)
 orch = Orchestrator(
@@ -22,9 +28,15 @@ task = Task(prompt="Write a short motivational haiku about debugging.")
 # 3️⃣  Synchronous, blocking call – returns a Candidate object
 best = orch.run_sync(task)
 
-# 4️⃣  Inspect the result
-print("Score:", best.score)
-print("\nSolution:\n", best.solution)
-print("\nChecklist:")
-for item in best.checklist.items:
-    print(f" • {item.description:<40}  =>  {item.passed}") 
+# 4️⃣  Inspect the result with null-safety
+if best:
+    print("Score:", best.score)
+    print("\nSolution:\n", best.solution)
+    print("\nChecklist:")
+    if best.checklist:
+        for item in best.checklist.items:
+            print(f" • {item.description:<40}  =>  {item.passed}")
+    else:
+        print("  No checklist was generated for this solution.")
+else:
+    print("No solution was found.")

--- a/examples/01_weighted_scoring.py
+++ b/examples/01_weighted_scoring.py
@@ -5,9 +5,15 @@ Demonstrates **weighted** checklist scoring.  Two items, different weights.
 """
 
 from pydantic_ai import Agent
-from pydantic_ai_orchestrator import Orchestrator, Task
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    Task,
+    make_agent_async,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+)
 from pydantic_ai_orchestrator.infra.settings import settings
-from pydantic_ai_orchestrator.infra.agents import make_agent_async, solution_agent, validator_agent, get_reflection_agent
 from pydantic_ai_orchestrator.domain.models import Checklist
 
 # 📝 Switch to weighted scoring – you can also set this in .env
@@ -57,6 +63,9 @@ best = orch.run_sync(task)
 print("\nSolution:\n", best.solution)
 print("\nWeighted score:", best.score)
 print("\nChecklist:")
-for item in best.checklist.items:
-    weight = next((w['weight'] for w in weights if w['item'] == item.description), 1.0)
-    print(f" • {item.description:<25} passed={item.passed}  weight={weight:.1f}") 
+if best.checklist:
+    for item in best.checklist.items:
+        weight = next((w['weight'] for w in weights if w['item'] == item.description), 1.0)
+        print(f" • {item.description:<25} passed={item.passed}  weight={weight:.1f}")
+else:
+    print("  No checklist was generated for this solution.")

--- a/examples/02_custom_agents.py
+++ b/examples/02_custom_agents.py
@@ -6,8 +6,13 @@ to save tokens.
 """
 
 from pydantic_ai import Agent
-from pydantic_ai_orchestrator import Orchestrator, Task
-from pydantic_ai_orchestrator.infra.agents import review_agent, validator_agent, get_reflection_agent
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    Task,
+    review_agent,
+    validator_agent,
+    get_reflection_agent,
+)
 
 # Build a single cheaper agent
 solution_agent = Agent(

--- a/examples/03_reward_scorer.py
+++ b/examples/03_reward_scorer.py
@@ -5,9 +5,15 @@ Enable the experimental reward-model scorer (extra LLM judge).
 """
 
 import os
-from pydantic_ai_orchestrator import Orchestrator, Task
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    Task,
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+)
 from pydantic_ai_orchestrator.infra.settings import settings
-from pydantic_ai_orchestrator.infra.agents import review_agent, solution_agent, validator_agent, get_reflection_agent
 
 # 🔑 Make sure you have a paid API key – the reward model is another call
 os.environ["REWARD_ENABLED"] = "true"

--- a/examples/04_batch_processing.py
+++ b/examples/04_batch_processing.py
@@ -11,8 +11,14 @@ CSV schema:
 import csv
 import pathlib
 import time
-from pydantic_ai_orchestrator import Orchestrator, Task
-from pydantic_ai_orchestrator.infra.agents import review_agent, solution_agent, validator_agent, get_reflection_agent
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    Task,
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+)
 
 INPUT = pathlib.Path("prompts.csv")
 OUTPUT = pathlib.Path("results.csv")

--- a/pydantic_ai_orchestrator/__init__.py
+++ b/pydantic_ai_orchestrator/__init__.py
@@ -9,6 +9,33 @@ except Exception:
 from .application.orchestrator import Orchestrator
 from .infra.settings import settings
 from .infra.telemetry import init_telemetry
-from .domain.models import Task
 
-__all__ = ["Orchestrator", "settings", "Task", "init_telemetry"]
+from .domain.models import Task, Candidate, Checklist, ChecklistItem
+
+from .infra.agents import (
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+    make_agent_async,
+)
+
+from .exceptions import OrchestratorError, ConfigurationError, SettingsError
+
+__all__ = [
+    "Orchestrator",
+    "Task",
+    "Candidate",
+    "Checklist",
+    "ChecklistItem",
+    "settings",
+    "init_telemetry",
+    "review_agent",
+    "solution_agent",
+    "validator_agent",
+    "get_reflection_agent",
+    "make_agent_async",
+    "OrchestratorError",
+    "ConfigurationError",
+    "SettingsError",
+]

--- a/pydantic_ai_orchestrator/domain/agent_protocol.py
+++ b/pydantic_ai_orchestrator/domain/agent_protocol.py
@@ -1,0 +1,13 @@
+"""Defines the protocol for agent-like objects in the orchestrator."""
+from typing import Protocol, TypeVar, Any, Optional, runtime_checkable
+
+T_Input = TypeVar("T_Input", contravariant=True)
+T_Output = TypeVar("T_Output", covariant=True)
+
+@runtime_checkable
+class AgentProtocol(Protocol[T_Input, T_Output]):
+    """Essential interface for all agent types used by the Orchestrator."""
+
+    async def run(self, input_data: Optional[T_Input] = None, **kwargs: Any) -> T_Output:
+        """Asynchronously run the agent with the given input and return a result."""
+        ...

--- a/pydantic_ai_orchestrator/domain/models.py
+++ b/pydantic_ai_orchestrator/domain/models.py
@@ -1,12 +1,12 @@
 """Domain models for pydantic-ai-orchestrator.""" 
 
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Any
 
 class Task(BaseModel):
     """Represents a task to be solved by the orchestrator."""
     prompt: str
-    metadata: dict = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 class ChecklistItem(BaseModel):
     """A single item in a checklist for evaluating a solution."""
@@ -24,8 +24,14 @@ class Candidate(BaseModel):
     score: float
     checklist: Optional[Checklist] = Field(None, description="Checklist evaluation for this candidate.")
 
-    def __repr__(self):
-        return f"<Candidate score={self.score:.2f} solution={self.solution!r} checklist_items={len(self.checklist.items) if self.checklist else 0}>"
+    def __repr__(self) -> str:
+        return (
+            f"<Candidate score={self.score:.2f} solution={self.solution!r} "
+            f"checklist_items={len(self.checklist.items) if self.checklist else 0}>"
+        )
 
-    def __str__(self):
-        return f"Candidate(score={self.score:.2f}, solution={self.solution!r}, checklist_items={len(self.checklist.items) if self.checklist else 0})" 
+    def __str__(self) -> str:
+        return (
+            f"Candidate(score={self.score:.2f}, solution={self.solution!r}, "
+            f"checklist_items={len(self.checklist.items) if self.checklist else 0})"
+        )

--- a/pydantic_ai_orchestrator/infra/telemetry.py
+++ b/pydantic_ai_orchestrator/infra/telemetry.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 _initialized = False
 
-def init_telemetry():
+def init_telemetry() -> None:
     """
     Initialize Logfire telemetry for the orchestrator.
     This function is idempotent and safe to call multiple times.
@@ -22,13 +22,13 @@ def init_telemetry():
     additional_processors: list['SpanProcessor'] = []
     if settings.otlp_export_enabled:
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-        from opentelemetry.sdk.trace import BatchSpanProcessor
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-        exporter_args = {}
+        exporter_args: dict[str, object] = {}
         if settings.otlp_endpoint:
             exporter_args["endpoint"] = settings.otlp_endpoint
         
-        exporter = OTLPSpanExporter(**exporter_args)
+        exporter = OTLPSpanExporter(**exporter_args)  # type: ignore[arg-type]
         additional_processors.append(BatchSpanProcessor(exporter))
 
     logfire.configure(

--- a/tests/unit/test_orchestrator_typing.py
+++ b/tests/unit/test_orchestrator_typing.py
@@ -1,0 +1,16 @@
+import pytest
+from pydantic_ai_orchestrator.domain.agent_protocol import AgentProtocol
+from pydantic_ai_orchestrator.infra.agents import (
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,
+    NoOpReflectionAgent,
+)
+
+def test_agents_conform_to_protocol():
+    assert isinstance(review_agent, AgentProtocol)
+    assert isinstance(solution_agent, AgentProtocol)
+    assert isinstance(validator_agent, AgentProtocol)
+    assert isinstance(get_reflection_agent(), AgentProtocol)
+    assert isinstance(NoOpReflectionAgent(), AgentProtocol)


### PR DESCRIPTION
## Summary
- define `AgentProtocol` and use it in `Orchestrator`
- re-export public API in package `__init__`
- update examples to use new imports and safer checklist access
- add protocol conformance unit test
- fix type errors in models, settings, agents, telemetry

## Testing
- `pytest -q`
- `poetry run mypy pydantic_ai_orchestrator/domain/models.py pydantic_ai_orchestrator/infra/settings.py pydantic_ai_orchestrator/infra/agents.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5a13e24c832ca54d9382a5e0f1aa