### PR TITLE
Add default reflection agent for simplified API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example usage in Python:
 ```python
 from pydantic_ai_orchestrator import Orchestrator, Task
 from pydantic_ai_orchestrator.infra.agents import (
-    review_agent, solution_agent, validator_agent, get_reflection_agent
+    review_agent, solution_agent, validator_agent, reflection_agent
 )
 
 # Create orchestrator
@@ -43,7 +43,7 @@ orch = Orchestrator(
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent()
+    reflection_agent
 )
 
 # Create task

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -7,3 +7,28 @@ from pydantic_ai import Agent
 class MyAgent(Agent):
     ...
 ```
+
+## Customizing the Reflection Agent
+
+While the library provides a default `reflection_agent`, you may want to use a
+different model or configuration for the reflection step. Use the factory
+function `get_reflection_agent()` to create a custom instance.
+
+```python
+from pydantic_ai_orchestrator import (
+    Orchestrator,
+    review_agent,
+    solution_agent,
+    validator_agent,
+    get_reflection_agent,  # Import the factory
+)
+
+custom_reflection_agent = get_reflection_agent(model="anthropic:claude-3-haiku")
+
+orch = Orchestrator(
+    review_agent,
+    solution_agent,
+    validator_agent,
+    reflection_agent=custom_reflection_agent,
+)
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,15 +20,22 @@ pip install pydantic-ai-orchestrator[bench]
 ## API
 
 ```python
-from pydantic_ai_orchestrator import Orchestrator, init_telemetry
+from pydantic_ai_orchestrator import (
+    Orchestrator, Task, init_telemetry,
+    review_agent, solution_agent, validator_agent, reflection_agent
+)
 
 # Initialize telemetry (optional)
 init_telemetry()
 
-orch = Orchestrator()
-result = orch.run_sync("Write a poem.")
+# Create an orchestrator with default agents
+orch = Orchestrator(review_agent, solution_agent, validator_agent, reflection_agent)
+result = orch.run_sync(Task(prompt="Write a poem."))
 print(result)
 ```
+
+For custom reflection behavior, use the `get_reflection_agent()` factory to
+instantiate a reflection agent with a different model or configuration.
 
 Call `init_telemetry()` once at startup to configure logging and tracing for your application.
 

--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -11,7 +11,7 @@ from pydantic_ai_orchestrator import (
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent,
+    reflection_agent,
 )
 
 # 1️⃣  Create a default orchestrator (uses GPT-4o for all agents)
@@ -19,7 +19,7 @@ orch = Orchestrator(
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent()
+    reflection_agent
 )
 
 # 2️⃣  Wrap your prompt in a Task (metadata optional)

--- a/examples/01_weighted_scoring.py
+++ b/examples/01_weighted_scoring.py
@@ -11,7 +11,7 @@ from pydantic_ai_orchestrator import (
     make_agent_async,
     solution_agent,
     validator_agent,
-    get_reflection_agent,
+    reflection_agent,
 )
 from pydantic_ai_orchestrator.infra.settings import settings
 from pydantic_ai_orchestrator.domain.models import Checklist
@@ -55,7 +55,7 @@ orch = Orchestrator(
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent()
+    reflection_agent
 )
 
 best = orch.run_sync(task)

--- a/examples/02_custom_agents.py
+++ b/examples/02_custom_agents.py
@@ -11,7 +11,7 @@ from pydantic_ai_orchestrator import (
     Task,
     review_agent,
     validator_agent,
-    get_reflection_agent,
+    reflection_agent,
 )
 
 # Build a single cheaper agent
@@ -25,11 +25,11 @@ orch = Orchestrator(
     review_agent=review_agent,          # keep the "review" step on GPT-4o
     solution_agent=solution_agent,      # cheaper generation
     validator_agent=validator_agent,
-    reflection_agent=get_reflection_agent(),
+    reflection_agent=reflection_agent,
     max_iters=2,
     k_variants=1,
 )
 
 # Wrap the prompt in a Task object
 task = Task(prompt="Write a limerick that scans.")
-print(orch.run_sync(task).solution) 
+print(orch.run_sync(task).solution)

--- a/examples/03_reward_scorer.py
+++ b/examples/03_reward_scorer.py
@@ -11,7 +11,7 @@ from pydantic_ai_orchestrator import (
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent,
+    reflection_agent,
 )
 from pydantic_ai_orchestrator.infra.settings import settings
 
@@ -24,9 +24,9 @@ orch = Orchestrator(
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent()
+    reflection_agent
 )
 
 best = orch.run_sync(Task(prompt="Summarise the Zen of Python in two sentences."))
 print("Reward-model score:", best.score)
-print("\nSolution:\n", best.solution) 
+print("\nSolution:\n", best.solution)

--- a/examples/04_batch_processing.py
+++ b/examples/04_batch_processing.py
@@ -17,7 +17,7 @@ from pydantic_ai_orchestrator import (
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent,
+    reflection_agent,
 )
 
 INPUT = pathlib.Path("prompts.csv")
@@ -28,7 +28,7 @@ orch = Orchestrator(
     review_agent,
     solution_agent,
     validator_agent,
-    get_reflection_agent()
+    reflection_agent
 )
 
 with INPUT.open() as f_in, OUTPUT.open("w", newline="") as f_out:
@@ -51,4 +51,4 @@ with INPUT.open() as f_in, OUTPUT.open("w", newline="") as f_out:
             }
         )
 
-print(f"\nSaved results ➜ {OUTPUT}") 
+print(f"\nSaved results ➜ {OUTPUT}")

--- a/pydantic_ai_orchestrator/__init__.py
+++ b/pydantic_ai_orchestrator/__init__.py
@@ -16,6 +16,7 @@ from .infra.agents import (
     review_agent,
     solution_agent,
     validator_agent,
+    reflection_agent,
     get_reflection_agent,
     make_agent_async,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "review_agent",
     "solution_agent",
     "validator_agent",
+    "reflection_agent",
     "get_reflection_agent",
     "make_agent_async",
     "OrchestratorError",

--- a/pydantic_ai_orchestrator/infra/agents.py
+++ b/pydantic_ai_orchestrator/infra/agents.py
@@ -163,6 +163,9 @@ def get_reflection_agent(model: str | None = None) -> AsyncAgentWrapper | NoOpRe
         logfire.error(f"Failed to create reflection agent: {e}")
         return NoOpReflectionAgent()
 
+# Create a default instance for convenience and API consistency
+reflection_agent = get_reflection_agent()
+
 # Add a wrapper for review_agent to log API errors
 class LoggingReviewAgent:
     def __init__(self, agent: AgentProtocol[Any, Any]) -> None:


### PR DESCRIPTION
## Summary
- instantiate reflection agent at import time
- re-export new `reflection_agent` in public API
- update examples and docs for the simplified constructor
- ensure newline at end of docs and example files

## Testing
- `pytest -q`
- `python examples/00_quickstart.py` *(fails: OrchestratorRetryError)*
- `python examples/01_weighted_scoring.py` *(fails: OrchestratorRetryError)*
- `python examples/02_custom_agents.py` *(fails: OrchestratorRetryError)*
- `python examples/03_reward_scorer.py` *(fails: OrchestratorRetryError)*
- `python examples/04_batch_processing.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684c60d5549c832caf37bcf0b1d7281e