### PR TITLE
Fix ruff violations

### DIFF
--- a/examples/01_weighted_scoring.py
+++ b/examples/01_weighted_scoring.py
@@ -4,7 +4,6 @@
 Demonstrates **weighted** checklist scoring.  Two items, different weights.
 """
 
-from pydantic_ai import Agent
 from pydantic_ai_orchestrator import (
     Orchestrator,
     Task,
@@ -25,7 +24,7 @@ weights = [
 ]
 
 # Create a custom review agent with our specific criteria
-CUSTOM_REVIEW_SYS = f"""You are an expert software engineer.
+CUSTOM_REVIEW_SYS = """You are an expert software engineer.
 Your task is to generate a checklist of criteria to evaluate a solution for the user's request.
 The checklist MUST include EXACTLY these items (copy them verbatim):
 1. "Includes a docstring"
@@ -35,12 +34,12 @@ Return **JSON only** that conforms to this schema:
 Checklist(items=[ChecklistItem(description:str, passed:bool|None, feedback:str|None)])
 
 Example:
-{{
+{
   "items": [
-    {{"description": "Includes a docstring", "passed": null, "feedback": null}},
-    {{"description": "Uses type hints", "passed": null, "feedback": null}}
+    {"description": "Includes a docstring", "passed": null, "feedback": null},
+    {"description": "Uses type hints", "passed": null, "feedback": null}
   ]
-}}
+}
 """
 
 review_agent = make_agent_async(settings.default_review_model, CUSTOM_REVIEW_SYS, Checklist)

--- a/pydantic_ai_orchestrator/cli/main.py
+++ b/pydantic_ai_orchestrator/cli/main.py
@@ -14,7 +14,6 @@ from pydantic_ai_orchestrator.infra.agents import (
     REVIEW_SYS,
     SOLUTION_SYS,
     VALIDATE_SYS,
-    REFLECT_SYS,
 )
 from pydantic_ai_orchestrator.application.orchestrator import Orchestrator
 from pydantic_ai_orchestrator.infra.settings import settings, SettingsError

--- a/pydantic_ai_orchestrator/infra/settings.py
+++ b/pydantic_ai_orchestrator/infra/settings.py
@@ -1,13 +1,15 @@
 """Settings and configuration for pydantic-ai-orchestrator."""
 
 import os
+from typing import ClassVar, Literal, Optional
+
 import dotenv
+from pydantic import Field, SecretStr, ValidationError, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from ..exceptions import SettingsError
 
 dotenv.load_dotenv()
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import ValidationError, SecretStr, field_validator, Field
-from typing import Optional, Literal, ClassVar
-from ..exceptions import SettingsError
 
 
 class Settings(BaseSettings):

--- a/tests/integration/test_settings_validation.py
+++ b/tests/integration/test_settings_validation.py
@@ -1,5 +1,3 @@
-import pytest
-from pydantic import ValidationError
 from pydantic_ai_orchestrator.infra.settings import Settings
 
 def test_invalid_env_vars(monkeypatch):

--- a/tests/unit/test_orchestrator_typing.py
+++ b/tests/unit/test_orchestrator_typing.py
@@ -1,4 +1,3 @@
-import pytest
 from pydantic_ai_orchestrator.domain.agent_protocol import AgentProtocol
 from pydantic_ai_orchestrator.infra.agents import (
     review_agent,

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic_ai_orchestrator.domain.models import Checklist, ChecklistItem
 from pydantic_ai_orchestrator.domain.scoring import ratio_score, weighted_score, RewardScorer
 from pydantic_ai_orchestrator.infra.settings import Settings
-from pydantic import ValidationError, SecretStr
+from pydantic import SecretStr
 
 def test_ratio_score():
     check_pass = Checklist(items=[ChecklistItem(description="a", passed=True), ChecklistItem(description="b", passed=True)])

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,5 +1,3 @@
-import pytest
-from pydantic import ValidationError
 from pydantic_ai_orchestrator.infra.settings import Settings
 
 def test_env_var_precedence(monkeypatch):


### PR DESCRIPTION
## Summary
- address `E402` import order issue in infra settings
- clean up unused imports across examples, CLI, and tests

## Testing
- `ruff check . --fix`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c65711c9c832c9ddf3246f1a1c536