### PR TITLE
Add simple pipeline runner with retries

### DIFF
--- a/pydantic_ai_orchestrator/pipeline/__init__.py
+++ b/pydantic_ai_orchestrator/pipeline/__init__.py
@@ -1,0 +1,11 @@
+"""Pipeline utilities for pydantic-ai-orchestrator."""
+
+from .runner import PipelineRunner, Step, StepConfig, PipelineResult, StepResult
+
+__all__ = [
+    "PipelineRunner",
+    "Step",
+    "StepConfig",
+    "PipelineResult",
+    "StepResult",
+]

--- a/pydantic_ai_orchestrator/pipeline/runner.py
+++ b/pydantic_ai_orchestrator/pipeline/runner.py
@@ -1,0 +1,82 @@
+"""Sequential pipeline execution utilities."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, List
+
+from pydantic import BaseModel, Field
+
+
+class StepConfig(BaseModel):
+    """Configuration for an individual step."""
+
+    max_retries: int = 0
+
+
+class Step(BaseModel):
+    """Represents a single pipeline step."""
+
+    name: str
+    func: Callable[[Any], Awaitable[Any]]
+    config: StepConfig = Field(default_factory=StepConfig)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class StepResult(BaseModel):
+    """Outcome of a step execution."""
+
+    name: str
+    attempts: int
+    output: Any | None = None
+    success: bool = True
+
+
+class PipelineResult(BaseModel):
+    """Aggregated result of running a pipeline."""
+
+    steps: List[StepResult] = Field(default_factory=list)
+    output: Any | None = None
+
+
+class PipelineRunner:
+    """Executes steps sequentially with retry support."""
+
+    def __init__(self, steps: List[Step]) -> None:
+        self.steps = steps
+
+    async def run(self, data: Any) -> PipelineResult:
+        """Run the pipeline returning a ``PipelineResult``."""
+        history: List[StepResult] = []
+        current = data
+        for step in self.steps:
+            attempts = 0
+            while True:
+                try:
+                    attempts += 1
+                    current = await step.func(current)
+                    history.append(
+                        StepResult(
+                            name=step.name,
+                            attempts=attempts,
+                            output=current,
+                            success=True,
+                        )
+                    )
+                    break
+                except Exception as exc:
+                    if attempts > step.config.max_retries:
+                        history.append(
+                            StepResult(
+                                name=step.name,
+                                attempts=attempts,
+                                output=None,
+                                success=False,
+                            )
+                        )
+                        raise exc
+                    await asyncio.sleep(0)
+                    continue
+        return PipelineResult(steps=history, output=current)

--- a/tests/integration/test_pipeline_runner.py
+++ b/tests/integration/test_pipeline_runner.py
@@ -1,0 +1,46 @@
+import pytest
+
+from pydantic_ai_orchestrator.pipeline import (
+    PipelineRunner,
+    Step,
+    StepConfig,
+    PipelineResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runner_returns_result():
+    async def step1(x: int) -> int:
+        return x + 1
+
+    async def step2(x: int) -> int:
+        return x * 2
+
+    runner = PipelineRunner(
+        [Step(name="one", func=step1), Step(name="two", func=step2)]
+    )
+
+    result = await runner.run(1)
+    assert isinstance(result, PipelineResult)
+    assert result.output == 4
+    assert len(result.steps) == 2
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runner_retries():
+    calls = 0
+
+    async def flaky(x: int) -> int:
+        nonlocal calls
+        calls += 1
+        if calls < 2:
+            raise ValueError("fail")
+        return x + 1
+
+    runner = PipelineRunner([
+        Step(name="flaky", func=flaky, config=StepConfig(max_retries=1))
+    ])
+
+    result = await runner.run(1)
+    assert result.output == 2
+    assert result.steps[0].attempts == 2


### PR DESCRIPTION
## Summary
- implement `PipelineRunner` and supporting models
- expose pipeline module
- test pipeline runner retry and result type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca4a85b18832cb7931673843ea763