### PR TITLE
Add generic DSL constructs and plugin outcome enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Production-ready orchestration for Pydantic-based AI agents.
 * Pluggable scoring (ratio, weighted, reward-model)
 * CLI and API
 * Extensible agent and reflection system
+* **New:** Flexible pipeline DSL for custom workflows
 
 ## Installation
 
@@ -56,6 +57,25 @@ best = orch.run_sync(task)
 print("Solution:\n", best.solution)
 ```
 
+### Pipeline DSL
+
+Use the `Step` and `PipelineRunner` classes to build custom workflows:
+
+```python
+from pydantic_ai_orchestrator import Step, PipelineRunner
+from pydantic_ai_orchestrator.plugins.sql_validator import SQLSyntaxValidator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+solution_agent = StubAgent(["SELECT FROM"])  # invalid SQL
+validator_agent = StubAgent([None])
+
+pipeline = Step.solution(solution_agent) >> Step.validate(
+    validator_agent, plugins=[SQLSyntaxValidator()]
+)
+runner = PipelineRunner(pipeline)
+result = runner.run("SELECT FROM")
+```
+
 For more examples, see the `examples` folder.
 
 ## Architecture
@@ -76,6 +96,7 @@ For more examples, see the `examples` folder.
 * `orch solve "prompt"` – Solve a task
 * `orch show-config` – Display config (secrets masked)
 * `orch bench --prompt "hi" --rounds 5` – Benchmark (requires `numpy`; install with `pip install pydantic-ai-orchestrator[bench]`)
+* `orch explain pipeline.py` – Print steps defined in a pipeline file
 * `orch --profile` – Enable Logfire span viewer
 
 ## Environment Variables
@@ -143,6 +164,7 @@ The `examples` directory includes practical demonstrations:
 | **02\_custom\_agents.py**    | Custom LLM or agent logic            |
 | **03\_reward\_scorer.py**    | Reward model scoring                 |
 | **04\_batch\_processing.py** | Batch processing of multiple prompts |
+| **05\_pipeline_sql.py**      | Pipeline DSL with SQL validation     |
 
 ### Running Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Production-ready orchestration for Pydantic-based AI agents.
 - Pluggable scoring (ratio, weighted, reward-model)
 - CLI and API
 - Extensible agent and reflection system
+- Flexible pipeline DSL and runner
 
 ## Installation
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -265,4 +265,20 @@ This concludes our tour! You've journeyed from a simple prompt to a sophisticate
 -   Generate clean, **structured JSON** using Pydantic models.
 -   Empower agents with **external tools** to overcome their knowledge limitations.
 
+## 6. Building Custom Pipelines
+
+The new Pipeline DSL lets you compose your own workflow using `Step` objects. Execute the pipeline with `PipelineRunner`:
+
+```python
+from pydantic_ai_orchestrator import Step, PipelineRunner
+from pydantic_ai_orchestrator.plugins.sql_validator import SQLSyntaxValidator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+sql_step = Step.solution(StubAgent(["SELECT FROM"]))
+check_step = Step.validate(StubAgent([None]), plugins=[SQLSyntaxValidator()])
+runner = PipelineRunner(sql_step >> check_step)
+result = runner.run("SELECT FROM")
+print(result.step_history[-1].feedback)
+```
+
 You're now ready to build powerful and intelligent AI applications. Happy orchestrating

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,7 @@ Environment variables are loaded automatically from this file.
 orch solve "Write a summary of this document."
 orch show-config
 orch bench --prompt "hi" --rounds 3
+orch explain path/to/pipeline.py
 orch --profile
 ```
 
@@ -38,6 +39,21 @@ For custom reflection behavior, use the `get_reflection_agent()` factory to
 instantiate a reflection agent with a different model or configuration.
 
 Call `init_telemetry()` once at startup to configure logging and tracing for your application.
+
+### Pipeline DSL
+
+You can define custom workflows using the `Step` class and execute them with `PipelineRunner`:
+
+```python
+from pydantic_ai_orchestrator import Step, PipelineRunner
+from pydantic_ai_orchestrator.plugins.sql_validator import SQLSyntaxValidator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+solution_step = Step.solution(StubAgent(["SELECT FROM"]))
+validate_step = Step.validate(StubAgent([None]), plugins=[SQLSyntaxValidator()])
+pipeline = solution_step >> validate_step
+result = PipelineRunner(pipeline).run("SELECT FROM")
+```
 
 ## Environment Variables
 

--- a/examples/05_pipeline_sql.py
+++ b/examples/05_pipeline_sql.py
@@ -1,0 +1,24 @@
+"""
+05_pipeline_sql.py
+-------------------
+Demonstrates the Pipeline DSL and SQL validator plugin.
+"""
+
+from pydantic_ai_orchestrator import Step, PipelineRunner
+from pydantic_ai_orchestrator.plugins.sql_validator import SQLSyntaxValidator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+# Solution agent that returns an invalid SQL statement
+solution = StubAgent(["SELECT FROM"])
+# Validator agent doesn't matter for syntax check
+validator = StubAgent([None])
+
+solution_step = Step.solution(solution)
+validation_step = Step.validate(validator, plugins=[SQLSyntaxValidator()])
+
+pipeline = solution_step >> validation_step
+runner = PipelineRunner(pipeline)
+
+result = runner.run("SELECT FROM")
+for step_result in result.step_history:
+    print(step_result.name, step_result.success, step_result.feedback)

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@
 | **02_custom_agents.py** | Mixing models / replacing the solution agent. |
 | **03_reward_scorer.py** | Using the reward-model scorer. |
 | **04_batch_processing.py** | Running many prompts from a CSV and exporting results. |
+| **05_pipeline_sql.py** | DSL pipeline with SQL validation plugin. |
 
 Each script is standalone – activate your virtualenv, set `OPENAI_API_KEY`, then:
 

--- a/pydantic_ai_orchestrator/__init__.py
+++ b/pydantic_ai_orchestrator/__init__.py
@@ -11,6 +11,16 @@ from .infra.settings import settings
 from .infra.telemetry import init_telemetry
 
 from .domain.models import Task, Candidate, Checklist, ChecklistItem
+from .domain import (
+    Step,
+    Pipeline,
+    StepConfig,
+    PluginOutcome,
+    ValidationPlugin,
+)
+from .application.pipeline_runner import PipelineRunner, PipelineResult, StepResult
+from .testing.utils import StubAgent, DummyPlugin
+from .plugins.sql_validator import SQLSyntaxValidator
 
 from .infra.agents import (
     review_agent,
@@ -29,6 +39,14 @@ __all__ = [
     "Candidate",
     "Checklist",
     "ChecklistItem",
+    "Step",
+    "Pipeline",
+    "StepConfig",
+    "PluginOutcome",
+    "ValidationPlugin",
+    "PipelineRunner",
+    "PipelineResult",
+    "StepResult",
     "settings",
     "init_telemetry",
     "review_agent",
@@ -40,4 +58,10 @@ __all__ = [
     "OrchestratorError",
     "ConfigurationError",
     "SettingsError",
+    "PipelineRunner",
+    "PipelineResult",
+    "StepResult",
+    "StubAgent",
+    "DummyPlugin",
+    "SQLSyntaxValidator",
 ]

--- a/pydantic_ai_orchestrator/application/pipeline_runner.py
+++ b/pydantic_ai_orchestrator/application/pipeline_runner.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, List
+
+from pydantic import BaseModel, Field
+
+from ..infra.telemetry import logfire
+from ..exceptions import OrchestratorError
+from ..domain.pipeline_dsl import Pipeline, Step
+from ..domain.plugins import ValidationPlugin, PluginOutcome
+
+
+class InfiniteRedirectError(OrchestratorError):
+    """Raised when a redirect loop is detected."""
+
+
+class StepStats(BaseModel):
+    attempts: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    latency_s: float = 0.0
+    cost_usd: float = 0.0
+
+
+class StepResult(BaseModel):
+    name: str
+    output: Any | None = None
+    success: bool = True
+    feedback: str | None = None
+    stats: StepStats = Field(default_factory=StepStats)
+    plugin_results: List[PluginOutcome] = Field(default_factory=list)
+
+    @property
+    def attempts(self) -> int:  # pragma: no cover - passthrough
+        return self.stats.attempts
+
+    @property
+    def latency_s(self) -> float:  # pragma: no cover - passthrough
+        return self.stats.latency_s
+
+    @property
+    def cost_usd(self) -> float:  # pragma: no cover - passthrough
+        return self.stats.cost_usd
+
+    @property
+    def token_counts(self) -> int:  # pragma: no cover - passthrough
+        return self.stats.tokens_out
+
+
+class PipelineResult(BaseModel):
+    step_history: List[StepResult] = Field(default_factory=list)
+    total_cost_usd: float = 0.0
+
+
+class PipelineRunner:
+    """Execute a pipeline sequentially."""
+
+    def __init__(self, pipeline: Pipeline | Step):
+        if isinstance(pipeline, Step):
+            pipeline = Pipeline.model_construct(steps=[pipeline])
+        self.pipeline = pipeline
+
+    async def _run_step(self, step: Step, data: Any) -> StepResult:
+        visited: set[Any] = set()
+        result = StepResult(name=step.name)
+        for attempt in range(1, step.config.max_retries + 1):
+            result.stats.attempts = attempt
+            agent = step.agent
+            if agent is None:
+                raise OrchestratorError(f"Step {step.name} has no agent")
+            start = time.monotonic()
+            output = await agent.run(data)
+            result.stats.latency_s += time.monotonic() - start
+            success = True
+            feedback: str | None = None
+            redirect_agent = None
+            for plugin in step.plugins:
+                try:
+                    plugin_result: PluginOutcome = await asyncio.wait_for(
+                        plugin.validate({"input": data, "output": output}),
+                        timeout=step.config.timeout_s,
+                    )
+                except asyncio.TimeoutError as e:
+                    raise TimeoutError(f"Plugin timeout in step {step.name}") from e
+                result.plugin_results.append(plugin_result)
+                if not plugin_result.ok:
+                    success = False
+                    if plugin_result.new_feedback:
+                        feedback = plugin_result.new_feedback
+                    if plugin_result.redirect_agent:
+                        redirect_agent = plugin_result.redirect_agent
+                    if plugin_result.new_solution is not None:
+                        output = plugin_result.new_solution
+            if success:
+                result.output = output
+                result.success = True
+                result.feedback = feedback
+                result.stats.tokens_out += getattr(output, "token_counts", 1)
+                result.stats.cost_usd += getattr(output, "cost_usd", 0.0)
+                return result
+            # failure -> prepare for retry
+            if redirect_agent:
+                if redirect_agent in visited:
+                    raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
+                visited.add(redirect_agent)
+                step.agent = redirect_agent
+            if feedback:
+                if isinstance(data, str):
+                    data = f"{data}\n{feedback}"
+            for handler in step.failure_handlers:
+                handler()
+        result.output = output
+        result.success = False
+        result.feedback = feedback
+        result.stats.tokens_out += getattr(output, "token_counts", 1)
+        result.stats.cost_usd += getattr(output, "cost_usd", 0.0)
+        return result
+
+    async def run_async(self, initial_input: Any) -> PipelineResult:
+        data = initial_input
+        result = PipelineResult()
+        try:
+            for step in self.pipeline.steps:
+                with logfire.span(step.name):
+                    step_result = await self._run_step(step, data)
+                result.step_history.append(step_result)
+                result.total_cost_usd += step_result.cost_usd
+                data = step_result.output
+        except asyncio.CancelledError:
+            logfire.info("Pipeline cancelled")
+            return result
+        return result
+
+    def run(self, initial_input: Any) -> PipelineResult:
+        return asyncio.run(self.run_async(initial_input))

--- a/pydantic_ai_orchestrator/domain/__init__.py
+++ b/pydantic_ai_orchestrator/domain/__init__.py
@@ -1,1 +1,12 @@
-"""Domain layer package.""" 
+"""Domain layer package."""
+
+from .pipeline_dsl import Step, Pipeline, StepConfig
+from .plugins import PluginOutcome, ValidationPlugin
+
+__all__ = [
+    "Step",
+    "Pipeline",
+    "StepConfig",
+    "PluginOutcome",
+    "ValidationPlugin",
+]

--- a/pydantic_ai_orchestrator/domain/pipeline_dsl.py
+++ b/pydantic_ai_orchestrator/domain/pipeline_dsl.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import List, Any, Optional, Callable, TypeVar, Generic
+from pydantic import BaseModel, Field
+from .agent_protocol import AgentProtocol
+from .plugins import ValidationPlugin
+
+
+class StepConfig(BaseModel):
+    """Configuration options for a pipeline step."""
+
+    max_retries: int = 1
+    timeout_s: float | None = None
+
+
+InT = TypeVar("InT")
+OutT = TypeVar("OutT")
+
+
+class Step(BaseModel, Generic[InT, OutT]):
+    """Represents a single step in a pipeline."""
+
+    name: str
+    agent: Optional[Any] = None
+    config: StepConfig = Field(default_factory=StepConfig)
+    plugins: List[ValidationPlugin] = Field(default_factory=list)
+    failure_handlers: List[Callable[[], None]] = Field(default_factory=list)
+
+    model_config = {
+        "arbitrary_types_allowed": True,
+    }
+
+    def __init__(
+        self,
+        name: str,
+        agent: Optional[Any] = None,
+        plugins: Optional[List[ValidationPlugin]] = None,
+        on_failure: Optional[List[Callable[[], None]]] = None,
+        **config: Any,
+    ) -> None:  # type: ignore[override]
+        cfg = config.get("config") if "config" in config else None
+        if isinstance(cfg, StepConfig):
+            step_cfg = cfg
+        else:
+            step_cfg = StepConfig(**config)
+        super().__init__(
+            name=name,
+            agent=agent,
+            config=step_cfg,
+            plugins=plugins or [],
+            failure_handlers=on_failure or [],
+        )
+
+    def __rshift__(self, other: "Step[Any, Any]" | "Pipeline[Any, Any]") -> "Pipeline[Any, Any]":
+        if isinstance(other, Step):
+            return Pipeline.model_construct(steps=[self, other])
+        if isinstance(other, Pipeline):
+            return Pipeline.model_construct(steps=[self, *other.steps])
+        raise TypeError("Can only chain Step with Step or Pipeline")
+
+    @classmethod
+    def review(cls, agent: AgentProtocol[Any, Any], **config: Any) -> "Step[Any, Any]":
+        return cls("review", agent, **config)
+
+    @classmethod
+    def solution(cls, agent: AgentProtocol[Any, Any], **config: Any) -> "Step[Any, Any]":
+        return cls("solution", agent, **config)
+
+    @classmethod
+    def validate(cls, agent: AgentProtocol[Any, Any], **config: Any) -> "Step[Any, Any]":
+        """Construct a validation step using the provided agent."""
+        return cls("validate", agent, **config)
+
+    def add_plugin(self, plugin: ValidationPlugin) -> "Step":
+        self.plugins.append(plugin)
+        return self
+
+    def on_failure(self, handler: Callable[[], None]) -> "Step":
+        self.failure_handlers.append(handler)
+        return self
+
+
+class Pipeline(BaseModel, Generic[InT, OutT]):
+    """A sequential pipeline of steps."""
+
+    steps: List[Step[Any, Any]]
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __rshift__(self, other: Step | "Pipeline") -> "Pipeline":
+        if isinstance(other, Step):
+            return Pipeline.model_construct(steps=[*self.steps, other])
+        if isinstance(other, Pipeline):
+            return Pipeline.model_construct(steps=[*self.steps, *other.steps])
+        raise TypeError("Can only chain Pipeline with Step or Pipeline")
+
+    def __iter__(self):  # pragma: no cover - convenience
+        return iter(self.steps)

--- a/pydantic_ai_orchestrator/domain/plugins.py
+++ b/pydantic_ai_orchestrator/domain/plugins.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable, Any
+from pydantic import BaseModel
+from .agent_protocol import AgentProtocol
+
+
+class PluginOutcome(BaseModel):
+    """Result returned by a validation plugin."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    ok: bool
+    new_solution: Any | None = None
+    new_feedback: str | None = None
+    redirect_agent: AgentProtocol | None = None
+
+
+@runtime_checkable
+class ValidationPlugin(Protocol):
+    """Protocol that all validation plugins must implement."""
+
+    async def validate(self, data: dict[str, Any]) -> PluginOutcome:  # pragma: no cover - signature only
+        ...

--- a/pydantic_ai_orchestrator/exceptions.py
+++ b/pydantic_ai_orchestrator/exceptions.py
@@ -24,3 +24,8 @@ class FeatureDisabled(OrchestratorError):
 class ConfigurationError(SettingsError):
     """Raised when a required configuration for a provider is missing."""
     pass
+
+
+class InfiniteRedirectError(OrchestratorError):
+    """Raised when a redirect loop is detected in pipeline execution."""
+    pass

--- a/pydantic_ai_orchestrator/plugins/__init__.py
+++ b/pydantic_ai_orchestrator/plugins/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["SQLSyntaxValidator"]

--- a/pydantic_ai_orchestrator/plugins/sql_validator.py
+++ b/pydantic_ai_orchestrator/plugins/sql_validator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+from sqlvalidator import parse
+
+from ..domain.plugins import ValidationPlugin, PluginOutcome
+
+
+class SQLSyntaxValidator:
+    """Validation plugin that checks SQL syntax."""
+
+    async def validate(self, data: dict[str, Any]) -> PluginOutcome:
+        query = data.get("output") or data.get("solution") or data.get("query") or ""
+        try:
+            result = parse(query)
+            try:
+                valid = result.is_valid()
+                errors = "; ".join(result.errors)
+            except Exception as e:
+                valid = False
+                errors = str(e)
+            if valid:
+                return PluginOutcome(ok=True)
+            return PluginOutcome(ok=False, new_feedback=errors or "invalid SQL")
+        except Exception as e:  # pragma: no cover - unexpected parse errors
+            return PluginOutcome(ok=False, new_feedback=str(e))

--- a/pydantic_ai_orchestrator/testing/utils.py
+++ b/pydantic_ai_orchestrator/testing/utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..domain.plugins import PluginOutcome
+
+
+class StubAgent:
+    """Simple agent for testing that returns preset outputs."""
+
+    def __init__(self, outputs: List[Any]):
+        self.outputs = outputs
+        self.call_count = 0
+        self.inputs: List[Any] = []
+
+    async def run(self, input_data: Any = None, **_: Any) -> Any:
+        self.inputs.append(input_data)
+        idx = min(self.call_count, len(self.outputs) - 1)
+        self.call_count += 1
+        return self.outputs[idx]
+
+
+class DummyPlugin:
+    """A validation plugin used for testing."""
+
+    def __init__(self, outcomes: List[PluginOutcome]):
+        self.outcomes = outcomes
+        self.call_count = 0
+
+    async def validate(self, data: dict[str, Any]) -> PluginOutcome:
+        idx = min(self.call_count, len(self.outcomes) - 1)
+        self.call_count += 1
+        return self.outcomes[idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "typer[all]>=0.12",
   "rich>=13.7",
   "logfire>=0.3",
+  "sqlvalidator>=0.0.8",
 ]
 
 # Optional dependency groups (install with: `pip install .[dev]`, `poetry install --with dev`, etc.)

--- a/tests/e2e/test_e2e_pipelines.py
+++ b/tests/e2e/test_e2e_pipelines.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.plugins.sql_validator import SQLSyntaxValidator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+
+@pytest.mark.e2e
+async def test_sql_pipeline_with_real_validator():
+    sql_agent = StubAgent(["SELECT FROM"])  # invalid SQL
+    validator_agent = StubAgent([None])
+    solution_step = Step.solution(sql_agent)
+    validation_step = Step.validate(validator_agent, plugins=[SQLSyntaxValidator()])
+    pipeline = solution_step >> validation_step
+    runner = PipelineRunner(pipeline)
+    result = await runner.run_async("prompt")
+    assert result.step_history[-1].success is False
+    assert result.step_history[-1].feedback

--- a/tests/integration/test_backward_compatibility.py
+++ b/tests/integration/test_backward_compatibility.py
@@ -1,0 +1,13 @@
+from pydantic_ai_orchestrator.application.orchestrator import Orchestrator
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+from pydantic_ai_orchestrator.domain.models import Task, Checklist
+
+
+async def test_orchestrator_init_backward_compatible():
+    review = StubAgent([Checklist(items=[])])
+    solution = StubAgent(["sol"])
+    validator = StubAgent([Checklist(items=[])])
+    reflection = StubAgent([None])
+    orch = Orchestrator(review, solution, validator, reflection)
+    result = await orch.run_async(Task(prompt="hi"))
+    assert result is None or hasattr(result, "score")

--- a/tests/integration/test_pipeline_runner.py
+++ b/tests/integration/test_pipeline_runner.py
@@ -1,0 +1,108 @@
+import asyncio
+from unittest.mock import Mock
+import pytest
+
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.application.pipeline_runner import (
+    PipelineRunner,
+    PipelineResult,
+)
+from pydantic_ai_orchestrator.testing.utils import StubAgent, DummyPlugin
+from pydantic_ai_orchestrator.domain.plugins import PluginOutcome
+
+
+async def test_runner_respects_max_retries():
+    agent = StubAgent(["a", "b", "c"])
+    plugin = DummyPlugin([
+        PluginOutcome(ok=False),
+        PluginOutcome(ok=False),
+        PluginOutcome(ok=True),
+    ])
+    step = Step("test", agent, max_retries=3, plugins=[plugin])
+    pipeline = step
+    runner = PipelineRunner(pipeline)
+    result = await runner.run_async("in")
+    assert agent.call_count == 3
+    assert isinstance(result, PipelineResult)
+    assert result.step_history[0].attempts == 3
+
+
+async def test_feedback_enriches_prompt():
+    sol_agent = StubAgent(["sol1", "sol2"])
+    plugin = DummyPlugin([
+        PluginOutcome(ok=False, new_feedback="SQL Error: XYZ"),
+        PluginOutcome(ok=True),
+    ])
+    step = Step.solution(sol_agent, max_retries=2, plugins=[plugin])
+    runner = PipelineRunner(step)
+    await runner.run_async("SELECT *")
+    assert sol_agent.call_count == 2
+    assert "SQL Error: XYZ" in sol_agent.inputs[1]
+
+
+async def test_conditional_redirection():
+    primary = StubAgent(["first"])
+    fixit = StubAgent(["fixed"])
+    plugin = DummyPlugin([
+        PluginOutcome(ok=False, redirect_agent=fixit),
+        PluginOutcome(ok=True),
+    ])
+    step = Step("s", primary, max_retries=2, plugins=[plugin])
+    pipeline = step
+    runner = PipelineRunner(pipeline)
+    await runner.run_async("prompt")
+    assert primary.call_count == 1
+    assert fixit.call_count == 1
+
+
+async def test_on_failure_called():
+    agent = StubAgent(["out"])
+    plugin = DummyPlugin([PluginOutcome(ok=False)])
+    handler = Mock()
+    step = Step("s", agent, max_retries=1, plugins=[plugin])
+    step.on_failure(handler)
+    runner = PipelineRunner(step)
+    await runner.run_async("prompt")
+    handler.assert_called_once()
+
+
+async def test_timeout_and_redirect_loop_detection():
+    async def slow_validate(data):
+        await asyncio.sleep(0.05)
+        return PluginOutcome(ok=True)
+
+    class SlowPlugin:
+        async def validate(self, data):
+            return await slow_validate(data)
+
+    plugin = SlowPlugin()
+    agent = StubAgent(["ok"])
+    step = Step("s", agent, plugins=[plugin], max_retries=1, timeout_s=0.01)
+    runner = PipelineRunner(step)
+    try:
+        await runner.run_async("prompt")
+    except TimeoutError:
+        pass
+
+    # Redirect loop
+    a1 = StubAgent(["a1"])
+    a2 = StubAgent(["a2"])
+    plugin_loop = DummyPlugin([
+        PluginOutcome(ok=False, redirect_agent=a2),
+        PluginOutcome(ok=False, redirect_agent=a1),
+    ])
+    step2 = Step("loop", a1, max_retries=3, plugins=[plugin_loop])
+    runner2 = PipelineRunner(step2)
+    with pytest.raises(Exception):
+        await runner2.run_async("p")
+
+
+async def test_pipeline_cancellation():
+    agent = StubAgent(["out"])
+    step = Step("s", agent)
+    runner = PipelineRunner(step)
+    task = asyncio.create_task(runner.run_async("prompt"))
+    await asyncio.sleep(0)
+    task.cancel()
+    result = await task
+    assert isinstance(result, PipelineResult)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -175,3 +175,18 @@ def test_cli_solve_configuration_error(monkeypatch):
     assert result.exit_code == 2
     assert "Configuration Error: Missing API key!" in result.stderr
 
+
+def test_cli_explain(tmp_path):
+    from pydantic_ai_orchestrator.domain import Step
+
+    file = tmp_path / "pipe.py"
+    file.write_text(
+        "from pydantic_ai_orchestrator.domain import Step\n"
+        "pipeline = Step('A') >> Step('B')\n"
+    )
+
+    result = runner.invoke(app, ["explain", str(file)])
+    assert result.exit_code == 0
+    assert "A" in result.stdout
+    assert "B" in result.stdout
+

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -1,0 +1,29 @@
+from pydantic_ai_orchestrator.domain import Step, Pipeline
+from unittest.mock import AsyncMock
+
+
+def test_step_chaining_operator():
+    a = Step("A")
+    b = Step("B")
+    pipeline = a >> b
+    assert isinstance(pipeline, Pipeline)
+    assert [s.name for s in pipeline.steps] == ["A", "B"]
+
+    c = Step("C")
+    pipeline2 = pipeline >> c
+    assert [s.name for s in pipeline2.steps] == ["A", "B", "C"]
+
+
+def test_role_based_constructor():
+    agent = AsyncMock()
+    step = Step.review(agent)
+    assert step.name == "review"
+    assert step.agent is agent
+
+    vstep = Step.validate(agent)
+    assert vstep.name == "validate"
+
+
+def test_step_configuration():
+    step = Step("A", max_retries=5)
+    assert step.config.max_retries == 5

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,0 +1,13 @@
+from pydantic_ai_orchestrator.domain import PluginOutcome, ValidationPlugin
+from typing import Any
+
+
+class DummyPlugin:
+    async def validate(self, data: dict[str, Any]) -> PluginOutcome:
+        return PluginOutcome(ok=True)
+
+
+def test_plugin_protocol_instance():
+    dummy = DummyPlugin()
+    assert isinstance(dummy, ValidationPlugin)
+


### PR DESCRIPTION
## Summary
- refine `Step` initialization to handle existing configs
- make `Pipeline` and chaining helpers preserve step settings
- expand `PluginOutcome` with new fields
- track plugin outcomes and metrics via `StepStats`
- update tests for new plugin fields and ensure retries work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca99025b8832cb23845b49fae0f9f