### PR TITLE
Finalize Orchestrator v2.0

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -27,3 +27,21 @@ pipeline = (
 
 result = PipelineRunner(pipeline).run("Write a poem")
 ```
+
+### Creating Custom Step Factories with Pre-configured Plugins
+
+If you frequently use a step with the same set of plugins, you can create your own factory function:
+
+```python
+from pydantic_ai_orchestrator import Step
+from my_app.plugins import MyCustomValidator
+
+def ReusableSQLStep(agent, **config) -> Step:
+    '''A solution step that always includes MyCustomValidator.'''
+    step = Step.solution(agent, **config)
+    step.add_plugin(MyCustomValidator(), priority=10)
+    return step
+
+# Usage:
+pipeline = ReusableSQLStep(my_sql_agent) >> Step.validate(...)
+```

--- a/pydantic_ai_orchestrator/domain/plugins.py
+++ b/pydantic_ai_orchestrator/domain/plugins.py
@@ -13,11 +13,14 @@ class PluginOutcome(BaseModel):
     success: bool
     feedback: str | None = None
     redirect_to: AgentProtocol | None = None
+    new_solution: Any | None = None
 
 
 @runtime_checkable
 class ValidationPlugin(Protocol):
     """Protocol that all validation plugins must implement."""
 
-    async def validate(self, data: dict[str, Any]) -> PluginOutcome:  # pragma: no cover - signature only
+    async def validate(
+        self, data: dict[str, Any]
+    ) -> PluginOutcome:  # pragma: no cover - signature only
         ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "hypothesis",
   "vcrpy",
   "rich",
+  "pytest-benchmark",
 ]
 docs = ["mkdocs", "mkdocstrings[python]"]
 opentelemetry = ["opentelemetry-sdk>=1.26"]

--- a/tests/benchmarks/test_engine_overhead.py
+++ b/tests/benchmarks/test_engine_overhead.py
@@ -1,0 +1,20 @@
+import pytest
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+pytest.importorskip("pytest_benchmark")
+
+
+@pytest.mark.benchmark(group="engine-overhead")
+def test_pipeline_runner_overhead(benchmark):
+    """Measures the execution time of the runner minus agent time."""
+    agent = StubAgent(["output"])
+    pipeline = (
+        Step("s1", agent) >> Step("s2", agent) >> Step("s3", agent) >> Step("s4", agent)
+    )
+    runner = PipelineRunner(pipeline)
+
+    @benchmark
+    def run_pipeline():
+        runner.run("initial input")

--- a/tests/mypy_success.py
+++ b/tests/mypy_success.py
@@ -1,0 +1,25 @@
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+from pydantic import BaseModel
+
+
+class UserInfo(BaseModel):
+    name: str
+
+
+class Report(BaseModel):
+    summary: str
+
+
+def test_pipeline_type_continuity() -> None:
+    agent1 = StubAgent([UserInfo(name="test")])
+    agent2 = StubAgent([Report(summary="report")])
+    step1: Step[str, UserInfo] = Step.solution(agent1)
+    step2: Step[UserInfo, Report] = Step.solution(agent2)
+    _pipeline = step1 >> step2
+
+    # pipeline should type check
+    # The following should fail mypy if uncommented:
+    # agent3 = StubAgent(["raw_string"])
+    # step3: Step[int, str] = Step.solution(agent3)
+    # bad_pipeline = step1 >> step3


### PR DESCRIPTION
## Summary
- add generic Step typing with plugin priority support
- extend PluginOutcome with `new_solution`
- allow PipelineRunner to use plugin-provided solutions
- document plugin factory pattern
- add benchmarking test and mypy type check
- include pytest-benchmark in dev extras

## Testing
- `ruff check pydantic_ai_orchestrator/domain/pipeline_dsl.py pydantic_ai_orchestrator/domain/plugins.py pydantic_ai_orchestrator/application/pipeline_runner.py tests/benchmarks/test_engine_overhead.py tests/mypy_success.py`
- `poetry run mypy tests/mypy_success.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd3725d88832c81fadff3476a9d9a