### PR TITLE
Configure documentation deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,48 @@
+name: Deploy Documentation
+
+on:
+  # Run on every push to the main branch
+  push:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        # Install the project with the 'docs' extra dependencies
+        run: pip install .[docs]
+
+      - name: Build the documentation site
+        run: mkdocs build
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,19 +1,48 @@
 site_name: pydantic-ai-orchestrator
+site_url: https://aandresalvarez.github.io/rloop/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - toc.integrate
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+  language: en
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
 nav:
   - Home: index.md
   - Usage: usage.md
   - Tutorial: tutorial.md
-  - Use Cases: use_cases.md
-  - Intelligent Evals: intelligent_evals.md
+  - 'Intelligent Evals': intelligent_evals.md
   - Extending: extending.md
   - Development:
-      - Contributing Guide: dev.md
-      - Documentation Guide: documentation_guide.md
+    - 'Contributing Guide': dev.md
+    - 'Documentation Guide': documentation_guide.md
+  - 'Use Cases': use_cases.md
+  - 'FSD': FSD_v1.md
   - API Reference:
       - Orchestrator: 'pydantic_ai_orchestrator.application.orchestrator'
-      - Settings: 'pydantic_ai_orchestrator.infra.settings'
+      - PipelineRunner: 'pydantic_ai_orchestrator.application.pipeline_runner'
+      - Self-Improvement: 'pydantic_ai_orchestrator.application.self_improvement'
+      - Models: 'pydantic_ai_orchestrator.domain.models'
+      - DSL: 'pydantic_ai_orchestrator.domain.pipeline_dsl'
       - Agents: 'pydantic_ai_orchestrator.infra.agents'
+      - Settings: 'pydantic_ai_orchestrator.infra.settings'
       - Scoring: 'pydantic_ai_orchestrator.domain.scoring'
+
 plugins:
   - search
   - mkdocstrings:

--- a/pydantic_ai_orchestrator/application/eval_adapter.py
+++ b/pydantic_ai_orchestrator/application/eval_adapter.py
@@ -1,6 +1,6 @@
 """Utilities for integrating PipelineRunner with pydantic-evals."""
 
-from typing import Any, Callable, Awaitable
+from typing import Any
 
 from .pipeline_runner import PipelineRunner
 from ..domain.models import PipelineResult

--- a/pydantic_ai_orchestrator/application/orchestrator.py
+++ b/pydantic_ai_orchestrator/application/orchestrator.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Any, Optional
 
 from ..domain.agent_protocol import AgentProtocol
-from ..domain.pipeline_dsl import Pipeline, Step
+from ..domain.pipeline_dsl import Step
 from ..domain.models import Candidate, PipelineResult, Task
 from .pipeline_runner import PipelineRunner
 

--- a/pydantic_ai_orchestrator/plugins/sql_validator.py
+++ b/pydantic_ai_orchestrator/plugins/sql_validator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from sqlvalidator import parse
 
-from ..domain.plugins import ValidationPlugin, PluginOutcome
+from ..domain.plugins import PluginOutcome
 
 
 class SQLSyntaxValidator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires      = ["hatchling"]        # any backend works; change if you prefer another
+requires      = ["hatchling"]
 build-backend = "hatchling.build"
 
 # --------------------------------------------------------------------------- #
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # --------------------------------------------------------------------------- #
 [project]
 name            = "pydantic_ai_orchestrator"
-version         = "0.1.0"
+version         = "0.2.0" # Version bumped for new features
 description     = "Production-ready orchestration for Pydantic-AI agents"
 readme          = "README.md"
 requires-python = ">=3.11,<4.0"
@@ -39,9 +39,10 @@ dependencies = [
   "rich>=13.7",
   "logfire>=0.3",
   "sqlvalidator>=0.0.8",
+  "pydantic-evals>=0.0.47", # Added for Intelligent Evals
 ]
 
-# Optional dependency groups (install with: `pip install .[dev]`, `poetry install --with dev`, etc.)
+# Optional dependency groups (install with: `pip install .[dev]`, etc.)
 [project.optional-dependencies]
 dev = [
   "ruff",
@@ -55,7 +56,11 @@ dev = [
   "rich",
   "pytest-benchmark",
 ]
-docs = ["mkdocs", "mkdocstrings[python]"]
+docs = [
+    "mkdocs",
+    "mkdocs-material", # Added for a professional theme
+    "mkdocstrings[python]",
+]
 opentelemetry = ["opentelemetry-sdk>=1.26"]
 bench = ["numpy"]
 
@@ -65,8 +70,9 @@ orch = "pydantic_ai_orchestrator.cli.main:app"
 
 # Project links (PEP 621)
 [project.urls]
-Homepage   = "https://github.com/yourorg/pydantic-ai-orchestrator"
-Repository = "https://github.com/yourorg/pydantic-ai-orchestrator"
+Homepage   = "https://github.com/aandresalvarez/rloop"
+Repository = "https://github.com/aandresalvarez/rloop"
+Documentation = "https://aandresalvarez.github.io/rloop/" # Added link to your docs
 
 # --------------------------------------------------------------------------- #
 # Tool-specific configuration
@@ -82,4 +88,5 @@ line-length = 100
 asyncio_mode = "auto"
 markers = [
   "e2e: marks tests as end-to-end (requires network access or VCR cassettes)",
+  "benchmark: marks tests as benchmarks (requires pytest-benchmark)",
 ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -177,7 +177,6 @@ def test_cli_solve_configuration_error(monkeypatch):
 
 
 def test_cli_explain(tmp_path):
-    from pydantic_ai_orchestrator.domain import Step
 
     file = tmp_path / "pipe.py"
     file.write_text(


### PR DESCRIPTION
## Summary
- update `pyproject.toml` with new dependencies and metadata
- configure Material theme in `mkdocs.yml`
- add `deploy-docs` workflow for publishing docs to GitHub Pages
- fix ruff lint errors

## Testing
- `pip install -e ".[docs]"`
- `mkdocs build`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce939bfc4832cbce0c41b87bcd72b