### PR TITLE
Implement typed pipeline generics

### DIFF
--- a/pydantic_ai_orchestrator/application/orchestrator.py
+++ b/pydantic_ai_orchestrator/application/orchestrator.py
@@ -16,10 +16,10 @@ class Orchestrator:
 
     def __init__(
         self,
-        review_agent: AsyncAgentProtocol[Any],
-        solution_agent: AsyncAgentProtocol[Any],
-        validator_agent: AsyncAgentProtocol[Any],
-        reflection_agent: AsyncAgentProtocol[Any] | None = None,
+        review_agent: AsyncAgentProtocol[Any, Any],
+        solution_agent: AsyncAgentProtocol[Any, Any],
+        validator_agent: AsyncAgentProtocol[Any, Any],
+        reflection_agent: AsyncAgentProtocol[Any, Any] | None = None,
         max_iters: Optional[int] = None,
         k_variants: Optional[int] = None,
         reflection_limit: Optional[int] = None,

--- a/pydantic_ai_orchestrator/cli/main.py
+++ b/pydantic_ai_orchestrator/cli/main.py
@@ -41,7 +41,8 @@ import runpy
 # Type definitions for CLI
 WeightsType = List[Dict[str, Union[str, float]]]
 MetadataType = Dict[str, Any]
-ScorerType = Literal["ratio", "weighted", "reward"]
+
+ScorerChoices = ["ratio", "weighted", "reward"]
 
 app: typer.Typer = typer.Typer(rich_markup_mode="markdown")
 
@@ -58,7 +59,10 @@ def solve(
     ] = None,
     reflection: Annotated[Optional[bool], typer.Option(help="Enable/disable reflection agent.")] = None,
     scorer: Annotated[
-        Optional[ScorerType], typer.Option(help="Scoring strategy: 'ratio', 'weighted', or 'reward'.")
+        Optional[str],
+        typer.Option(
+            help="Scoring strategy: 'ratio', 'weighted', or 'reward'.",
+        ),
     ] = None,
     weights_path: Annotated[Optional[str], typer.Option(help="Path to weights file (JSON or YAML)")] = None,
     solution_model: Annotated[Optional[str], typer.Option(help="Model for the Solution agent.")] = None,
@@ -131,10 +135,18 @@ def solve(
         val_model: str = validator_model or settings.default_validator_model
         ref_model: str = reflection_model or settings.default_reflection_model
 
-        review: AsyncAgentProtocol[Checklist] = cast(AsyncAgentProtocol[Checklist], make_agent_async(rev_model, REVIEW_SYS, Checklist))
-        solution: AsyncAgentProtocol[str] = cast(AsyncAgentProtocol[str], make_agent_async(sol_model, SOLUTION_SYS, str))
-        validator: AsyncAgentProtocol[Checklist] = cast(AsyncAgentProtocol[Checklist], make_agent_async(val_model, VALIDATE_SYS, Checklist))
-        reflection_agent: AsyncAgentProtocol[str] = cast(AsyncAgentProtocol[str], get_reflection_agent(ref_model))
+        review: AsyncAgentProtocol[Any, Checklist] = cast(
+            AsyncAgentProtocol[Any, Checklist], make_agent_async(rev_model, REVIEW_SYS, Checklist)
+        )
+        solution: AsyncAgentProtocol[Any, str] = cast(
+            AsyncAgentProtocol[Any, str], make_agent_async(sol_model, SOLUTION_SYS, str)
+        )
+        validator: AsyncAgentProtocol[Any, Checklist] = cast(
+            AsyncAgentProtocol[Any, Checklist], make_agent_async(val_model, VALIDATE_SYS, Checklist)
+        )
+        reflection_agent: AsyncAgentProtocol[Any, str] = cast(
+            AsyncAgentProtocol[Any, str], get_reflection_agent(ref_model)
+        )
 
         orch: Orchestrator = Orchestrator(
             review,

--- a/pydantic_ai_orchestrator/domain/agent_protocol.py
+++ b/pydantic_ai_orchestrator/domain/agent_protocol.py
@@ -3,22 +3,33 @@
 from __future__ import annotations
 
 from typing import Protocol, TypeVar, Any, Optional, runtime_checkable
-from ..infra.agents import AsyncAgentProtocol, T_co
+
+AgentInT = TypeVar("AgentInT", contravariant=True)
+AgentOutT = TypeVar("AgentOutT", covariant=True)
+
+
+@runtime_checkable
+class AsyncAgentProtocol(Protocol[AgentInT, AgentOutT]):
+    async def run(self, data: AgentInT, **kwargs: Any) -> AgentOutT:
+        ...
+
+    async def run_async(self, data: AgentInT, **kwargs: Any) -> AgentOutT:
+        return await self.run(data, **kwargs)
 
 T_Input = TypeVar("T_Input", contravariant=True)
 
 
 @runtime_checkable
-class AgentProtocol(AsyncAgentProtocol[T_co], Protocol[T_Input, T_co]):
+class AgentProtocol(AsyncAgentProtocol[T_Input, AgentOutT], Protocol[T_Input, AgentOutT]):
     """Essential interface for all agent types used by the Orchestrator."""
 
-    async def run(self, input_data: Optional[T_Input] = None, **kwargs: Any) -> T_co:
+    async def run(self, input_data: Optional[T_Input] = None, **kwargs: Any) -> AgentOutT:
         """Asynchronously run the agent with the given input and return a result."""
         ...
 
-    async def run_async(self, input_data: Optional[T_Input] = None, **kwargs: Any) -> T_co:
+    async def run_async(self, input_data: Optional[T_Input] = None, **kwargs: Any) -> AgentOutT:
         """Alias for run() to maintain compatibility with AsyncAgentProtocol."""
         return await self.run(input_data, **kwargs)
 
 # Explicit exports
-__all__ = ['AgentProtocol', 'T_Input']
+__all__ = ['AgentProtocol', 'AsyncAgentProtocol', 'T_Input', 'AgentInT', 'AgentOutT']

--- a/pydantic_ai_orchestrator/domain/plugins.py
+++ b/pydantic_ai_orchestrator/domain/plugins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable, Any
 from pydantic import BaseModel
-from ..infra.agents import AsyncAgentProtocol
+from .agent_protocol import AsyncAgentProtocol
 
 
 class PluginOutcome(BaseModel):
@@ -12,7 +12,7 @@ class PluginOutcome(BaseModel):
 
     success: bool
     feedback: str | None = None
-    redirect_to: AsyncAgentProtocol[Any] | None = None
+    redirect_to: Any | None = None
     new_solution: Any | None = None
 
 


### PR DESCRIPTION
## Summary
- define typed `AsyncAgentProtocol` and `AgentProtocol`
- refactor `Step` and `Pipeline` to use generics safely
- update `PipelineRunner` for generic input/output
- adjust agents and plugins for new protocol
- fix CLI scorer option for Python 3.12 compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d30d785b8832cb8212c7755f7e658