### PR TITLE
Update docs for orchestrator workflow

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -4,18 +4,26 @@ This guide explains the fundamental concepts that power `pydantic-ai-orchestrato
 
 ## The Orchestrator
 
-The **Orchestrator** is the central component that manages the entire AI workflow. Think of it as a project manager that:
-
-- Coordinates multiple AI agents
-- Manages the flow of information
-- Handles retries and quality control
-- Returns the best result
+The **`Orchestrator` class** is a central component that manages a **standard,
+pre-defined AI workflow**. Think of it as a project manager for a specific team
+structure: a Review Agent, a Solution Agent, and a Validator Agent (optionally
+followed by a Reflection Agent). It handles the flow of information between
+these fixed roles, manages retries based on their internal configuration, and
+aims to return the best `Candidate` solution from this standard process.
+For building custom workflows with different steps or logic, you would use the
+`Pipeline` DSL and `PipelineRunner`.
 
 ```python
-from pydantic_ai_orchestrator import Orchestrator
+from pydantic_ai_orchestrator import (
+    Orchestrator, review_agent, solution_agent, validator_agent
+)
 
-# Create an orchestrator with a team of agents
-orch = Orchestrator(review_agent, solution_agent, validator_agent)
+# Assemble the orchestrator with default agents
+orch = Orchestrator(
+    review_agent=review_agent,
+    solution_agent=solution_agent,
+    validator_agent=validator_agent,
+)
 ```
 
 ## Agents
@@ -94,10 +102,15 @@ if result:  # result is a Candidate
 
 ## The Pipeline DSL
 
-The Pipeline Domain-Specific Language (DSL) lets you create custom workflows using `Step` objects:
+The **Pipeline Domain-Specific Language (DSL)**, using `Step` objects and
+executed by `PipelineRunner`, is the primary way to create **flexible and custom
+multi-agent workflows**. This gives you full control over the sequence of
+operations, the agents used at each stage, and the integration of plugins.
 
 ```python
-from pydantic_ai_orchestrator import Step, PipelineRunner
+from pydantic_ai_orchestrator import (
+    Step, PipelineRunner, review_agent, solution_agent, validator_agent
+)
 
 # Define a pipeline
 pipeline = (
@@ -108,7 +121,9 @@ pipeline = (
 
 # Run it
 runner = PipelineRunner(pipeline)
-result = runner.run("Your prompt here")
+pipeline_result = runner.run("Your prompt here")
+for step_res in pipeline_result.step_history:
+    print(step_res.name, step_res.success)
 ```
 
 ### Step Types

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,20 +23,26 @@ pip install pydantic-ai-orchestrator[bench]
 ```python
 from pydantic_ai_orchestrator import (
     Orchestrator, Task, init_telemetry,
-    review_agent, solution_agent, validator_agent
+    review_agent, solution_agent, validator_agent,
 )
 
 # Initialize telemetry (optional)
 init_telemetry()
 
 # Create an orchestrator with default agents
-orch = Orchestrator(review_agent, solution_agent, validator_agent)
+orch = Orchestrator(
+    review_agent=review_agent,
+    solution_agent=solution_agent,
+    validator_agent=validator_agent,
+)
 result = orch.run_sync(Task(prompt="Write a poem."))
 print(result)
 ```
 
-The default orchestrator does not include a reflection step.
-Use the `Step` API to build a custom pipeline if you need strategic reflection.
+The default `Orchestrator` runs a fixed Review -> Solution -> Validate pipeline.
+It does not include a reflection step by default, but you can pass a
+`reflection_agent` to enable one. For fully custom workflows or more complex
+reflection logic, use the `Step` API with `PipelineRunner`.
 
 Call `init_telemetry()` once at startup to configure logging and tracing for your application.
 


### PR DESCRIPTION
## Summary
- clarify package location in README and modernize basic usage example
- add improved pipeline example in README
- update quickstart with correct orchestrator API
- document orchestrator constructor in API reference and describe PipelineRunner
- tweak concepts tutorial and usage docs to match the current API

## Testing
- `make test-fast`

------
https://chatgpt.com/codex/tasks/task_e_684da5e33300832ca820c19c19b03a9d