### PR TITLE
Add typed pipeline context docs

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -45,6 +45,10 @@ from pydantic_ai_orchestrator import (
     Step, PipelineRunner, Task,
     review_agent, solution_agent, validator_agent,
 )
+from pydantic import BaseModel
+
+class MyContext(BaseModel):
+    counter: int = 0
 
 # Create a pipeline
 custom_pipeline = (
@@ -60,6 +64,13 @@ custom_pipeline = (
 )
 
 runner = PipelineRunner(custom_pipeline)
+# With a shared typed context
+runner_with_ctx = PipelineRunner(
+    custom_pipeline,
+    context_model=MyContext,
+    initial_context_data={"counter": 0},
+)
+# See `pipeline_context.md` for details on using shared context.
 ```
 
 #### Methods
@@ -78,6 +89,9 @@ structure = custom_pipeline.structure()
 
 # Access runner config
 config = runner.get_config()
+
+# Access final pipeline context
+final_ctx = pipeline_result.final_pipeline_context
 ```
 
 ### Agents

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -107,6 +107,10 @@ executed by `PipelineRunner`, is the primary way to create **flexible and custom
 multi-agent workflows**. This gives you full control over the sequence of
 operations, the agents used at each stage, and the integration of plugins.
 
+`PipelineRunner` can also maintain a shared, typed context object for each run.
+Steps declare a `pipeline_context` parameter to access or modify this object. See
+[Typed Pipeline Context](pipeline_context.md) for full documentation.
+
 ```python
 from pydantic_ai_orchestrator import (
     Step, PipelineRunner, review_agent, solution_agent, validator_agent

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -1,0 +1,82 @@
+# Typed Pipeline Context
+
+`PipelineRunner` can maintain a mutable Pydantic model instance that is shared across every step during a single run. This feature is sometimes called the *pipeline scratchpad* or *shared context*.
+
+## Why use a context?
+
+- Accumulate metrics or intermediate results across steps.
+- Provide configuration or runtime parameters to non‑adjacent steps.
+- Keep your data flow explicit and type safe.
+
+## Defining a context model
+
+```python
+from pydantic import BaseModel
+
+class MyContext(BaseModel):
+    user_query: str
+    counter: int = 0
+```
+
+## Initializing the runner
+
+```python
+runner = PipelineRunner(
+    pipeline,
+    context_model=MyContext,
+    initial_context_data={"user_query": "hello"},
+)
+```
+
+The initial data is validated against the Pydantic model. If validation fails a `PipelineContextInitializationError` is raised and the run is aborted.
+
+## Accessing the context in steps
+
+Any step agent or plugin that wants access should declare a keyword-only argument named `pipeline_context`. It is recommended to type-hint this parameter with your context model.
+
+```python
+class CountingAgent(AsyncAgentProtocol[str, str]):
+    async def run(
+        self,
+        data: str,
+        *,
+        pipeline_context: Optional[MyContext] = None,
+        **kwargs: Any,
+    ) -> str:
+        if pipeline_context:
+            pipeline_context.counter += 1
+        return data
+```
+
+Plugins follow the same convention:
+
+```python
+class MyPlugin(ValidationPlugin):
+    async def validate(
+        self,
+        payload: dict[str, Any],
+        *,
+        pipeline_context: Optional[MyContext] = None,
+    ) -> PluginOutcome:
+        ...
+```
+
+If a component does not accept this parameter and also does not use `**kwargs`, a `TypeError` is raised when a context is provided.
+The runner surfaces a helpful message explaining that the component should declare
+`pipeline_context` (e.g. `async def run(..., *, pipeline_context=None)`) or
+accept `**kwargs`.
+
+## Lifecycle
+
+A fresh context instance is created for every call to `run()` or `run_async()`. Mutations by one step are visible to all subsequent steps in that run. Separate runs do not share state unless you explicitly pass previous context data as `initial_context_data`.
+
+## Retrieving the final state
+
+After execution, `PipelineResult.final_pipeline_context` holds the mutated context instance:
+
+```python
+result = runner.run("hi")
+print(result.final_pipeline_context.counter)
+```
+
+For a complete example, see the [Typed Pipeline Context section](pipeline_dsl.md#typed-pipeline-context) of the Pipeline DSL guide.

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -157,6 +157,33 @@ pipeline = (
 )
 ```
 
+## Typed Pipeline Context
+
+`PipelineRunner` can share a mutable Pydantic model instance across all steps in
+a single run. Pass a context model when creating the runner and declare
+`pipeline_context` in your step functions or agents. See
+[Typed Pipeline Context](pipeline_context.md) for a full explanation.
+
+```python
+from pydantic import BaseModel
+
+class MyContext(BaseModel):
+    counter: int = 0
+
+async def increment(data: str, *, pipeline_context: MyContext | None = None) -> str:
+    if pipeline_context:
+        pipeline_context.counter += 1
+    return data
+
+pipeline = Step("inc", increment) >> Step("read", increment)
+runner = PipelineRunner(pipeline, context_model=MyContext)
+result = runner.run("hi")
+print(result.final_pipeline_context.counter)  # 2
+```
+
+Each `run()` call gets a fresh context instance. Access the final state via
+`PipelineResult.final_pipeline_context`.
+
 ### Conditional Steps
 
 Add conditional logic to your pipeline:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -273,4 +273,27 @@ result = runner.run("SELECT FROM")
 print(result.step_history[-1].feedback)
 ```
 
+### Using a Shared Typed Context
+
+`PipelineRunner` can share a Pydantic model instance across steps. This lets you
+accumulate data or pass configuration during a run. See
+[Typed Pipeline Context](pipeline_context.md) for more details.
+
+```python
+from pydantic import BaseModel
+
+class Stats(BaseModel):
+    calls: int = 0
+
+async def record(data: str, *, pipeline_context: Stats | None = None) -> str:
+    if pipeline_context:
+        pipeline_context.calls += 1
+    return data
+
+pipeline = Step("first", record) >> Step("second", record)
+runner = PipelineRunner(pipeline, context_model=Stats)
+final = runner.run("hi")
+print(final.final_pipeline_context.calls)  # 2
+```
+
 You're now ready to build powerful and intelligent AI applications. Happy orchestrating

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - API Reference:
     - Overview: api_reference.md
     - Pipeline DSL: pipeline_dsl.md
+    - Typed Pipeline Context: pipeline_context.md
     - Scoring: scoring.md
     - Tools: tools.md
     - Telemetry: telemetry.md

--- a/pydantic_ai_orchestrator/application/pipeline_runner.py
+++ b/pydantic_ai_orchestrator/application/pipeline_runner.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Generic, TypeVar
+from typing import Any, Dict, Generic, Optional, Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
 
 
 from ..infra.telemetry import logfire
-from ..exceptions import OrchestratorError
+from ..exceptions import (
+    OrchestratorError,
+    PipelineContextInitializationError,
+)
 from ..domain.pipeline_dsl import Pipeline, Step
 from ..domain.plugins import PluginOutcome
 from ..domain.models import PipelineResult, StepResult
@@ -23,12 +28,24 @@ RunnerOutT = TypeVar("RunnerOutT")
 class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
     """Execute a pipeline sequentially."""
 
-    def __init__(self, pipeline: Pipeline[RunnerInT, RunnerOutT] | Step[RunnerInT, RunnerOutT]):
+    def __init__(
+        self,
+        pipeline: Pipeline[RunnerInT, RunnerOutT] | Step[RunnerInT, RunnerOutT],
+        context_model: Optional[Type[BaseModel]] = None,
+        initial_context_data: Optional[Dict[str, Any]] = None,
+    ) -> None:
         if isinstance(pipeline, Step):
             pipeline = Pipeline.from_step(pipeline)
-        self.pipeline = pipeline
+        self.pipeline: Pipeline[RunnerInT, RunnerOutT] = pipeline
+        self.context_model = context_model
+        self.initial_context_data: Dict[str, Any] = initial_context_data or {}
 
-    async def _run_step(self, step: Step[Any, Any], data: Any) -> StepResult:
+    async def _run_step(
+        self,
+        step: Step[Any, Any],
+        data: Any,
+        pipeline_context: Optional[BaseModel],
+    ) -> StepResult:
         visited: set[Any] = set()
         result = StepResult(name=step.name)
         original_agent = step.agent
@@ -41,7 +58,20 @@ class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
                 raise OrchestratorError(f"Step {step.name} has no agent")
 
             start = time.monotonic()
-            output = await current_agent.run(data)
+            call_kwargs: dict[str, Any] = {}
+            if pipeline_context is not None:
+                call_kwargs["pipeline_context"] = pipeline_context
+            try:
+                output = await current_agent.run(data, **call_kwargs)
+            except TypeError as e:
+                if "pipeline_context" in str(e) and pipeline_context is not None:
+                    err_msg = (
+                        f"Agent '{current_agent.__class__.__name__}' in step '{step.name}' does not accept "
+                        "'pipeline_context' keyword argument. Define it or use **kwargs."
+                    )
+                    logfire.error(err_msg)
+                    raise TypeError(err_msg) from e
+                raise
             result.latency_s += time.monotonic() - start
             last_output = output
 
@@ -54,11 +84,20 @@ class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
             for plugin, _ in sorted_plugins:
                 try:
                     plugin_result: PluginOutcome = await asyncio.wait_for(
-                        plugin.validate({"input": data, "output": output}),
+                        plugin.validate({"input": data, "output": output}, **call_kwargs),
                         timeout=step.config.timeout_s,
                     )
                 except asyncio.TimeoutError as e:
                     raise TimeoutError(f"Plugin timeout in step {step.name}") from e
+                except TypeError as e:
+                    if "pipeline_context" in str(e) and pipeline_context is not None:
+                        err_msg = (
+                            f"Plugin '{plugin.__class__.__name__}' in step '{step.name}' does not accept "
+                            "'pipeline_context' keyword argument. Define it or use **kwargs."
+                        )
+                        logfire.error(err_msg)
+                        raise TypeError(err_msg) from e
+                    raise
 
                 if not plugin_result.success:
                     success = False
@@ -110,19 +149,52 @@ class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
         return result
 
     async def run_async(self, initial_input: RunnerInT) -> PipelineResult:
+        current_pipeline_context_instance: Optional[BaseModel] = None
+        if self.context_model is not None:
+            try:
+                current_pipeline_context_instance = self.context_model(
+                    **self.initial_context_data
+                )
+            except ValidationError as e:
+                logfire.error(
+                    f"Pipeline context initialization failed for model {self.context_model.__name__}: {e}"
+                )
+                raise PipelineContextInitializationError(
+                    f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data. Validation errors:\n{e}"
+                ) from e
+
         data = initial_input
-        result = PipelineResult()
+        pipeline_result_obj = PipelineResult()
         try:
             for step in self.pipeline.steps:
-                with logfire.span(step.name):
-                    step_result = await self._run_step(step, data)
-                result.step_history.append(step_result)
-                result.total_cost_usd += step_result.cost_usd
+                with logfire.span(f"Step: {step.name}", pipeline_step_name=step.name):
+                    if current_pipeline_context_instance is not None:
+                        logfire.debug(
+                            f"Context before step {step.name}: {current_pipeline_context_instance.model_dump_json(exclude_none=True)}"
+                        )
+                    step_result = await self._run_step(
+                        step, data, pipeline_context=current_pipeline_context_instance
+                    )
+                    if current_pipeline_context_instance is not None:
+                        logfire.debug(
+                            f"Context after step {step.name}: {current_pipeline_context_instance.model_dump_json(exclude_none=True)}"
+                        )
+                pipeline_result_obj.step_history.append(step_result)
+                pipeline_result_obj.total_cost_usd += step_result.cost_usd
+                if not step_result.success:
+                    logfire.warn(
+                        f"Step '{step.name}' failed. Halting pipeline execution."
+                    )
+                    break
                 data = step_result.output
         except asyncio.CancelledError:
             logfire.info("Pipeline cancelled")
-            return result
-        return result
+            return pipeline_result_obj
+
+        if current_pipeline_context_instance is not None:
+            pipeline_result_obj.final_pipeline_context = current_pipeline_context_instance
+
+        return pipeline_result_obj
 
     def run(self, initial_input: RunnerInT) -> PipelineResult:
         return asyncio.run(self.run_async(initial_input))

--- a/pydantic_ai_orchestrator/domain/models.py
+++ b/pydantic_ai_orchestrator/domain/models.py
@@ -65,6 +65,14 @@ class PipelineResult(BaseModel):
 
     step_history: List[StepResult] = Field(default_factory=list)
     total_cost_usd: float = 0.0
+    final_pipeline_context: Optional[BaseModel] = Field(
+        default=None,
+        description=(
+            "The final state of the typed pipeline context, if configured and used."
+        ),
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
 
 
 class ImprovementSuggestion(BaseModel):

--- a/pydantic_ai_orchestrator/exceptions.py
+++ b/pydantic_ai_orchestrator/exceptions.py
@@ -42,3 +42,9 @@ class InfiniteRedirectError(OrchestratorError):
     """Raised when a redirect loop is detected in pipeline execution."""
 
     pass
+
+
+class PipelineContextInitializationError(OrchestratorError):
+    """Raised when a typed pipeline context fails to initialize."""
+
+    pass

--- a/tests/integration/test_pipeline_runner_with_context.py
+++ b/tests/integration/test_pipeline_runner_with_context.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.testing.utils import StubAgent
+
+
+class Ctx(BaseModel):
+    count: int = 0
+
+
+class AddOneAgent:
+    async def run(self, data: int, *, pipeline_context: Ctx | None = None) -> int:
+        if pipeline_context:
+            pipeline_context.count += 1
+        return data + 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runner_shared_context_flow() -> None:
+    step1 = Step("a", AddOneAgent())
+    step2 = Step("b", AddOneAgent())
+    runner = PipelineRunner(step1 >> step2, context_model=Ctx, initial_context_data={"count": 0})
+    result = await runner.run_async(1)
+    assert result.final_pipeline_context.count == 2
+    assert result.step_history[-1].output == 3
+
+
+@pytest.mark.asyncio
+async def test_existing_agents_without_context() -> None:
+    agent = StubAgent(["ok"])
+    step = Step("s", agent)
+    runner = PipelineRunner(step)
+    result = await runner.run_async("hi")
+    assert result.step_history[0].output == "ok"

--- a/tests/unit/test_pipeline_context.py
+++ b/tests/unit/test_pipeline_context.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.domain import Step
+from pydantic_ai_orchestrator.exceptions import PipelineContextInitializationError
+from pydantic_ai_orchestrator.domain.plugins import PluginOutcome
+
+
+class Ctx(BaseModel):
+    num: int = 0
+
+
+class CaptureAgent:
+    def __init__(self):
+        self.seen = None
+
+    async def run(self, data: str, *, pipeline_context: Ctx | None = None) -> str:
+        self.seen = pipeline_context
+        return data
+
+
+class IncAgent:
+    async def run(self, data: str, *, pipeline_context: Ctx | None = None) -> str:
+        assert pipeline_context is not None
+        pipeline_context.num += 1
+        return data
+
+
+class ReadAgent:
+    async def run(self, data: str, *, pipeline_context: Ctx | None = None) -> int:
+        assert pipeline_context is not None
+        return pipeline_context.num
+
+
+class ContextPlugin:
+    def __init__(self):
+        self.ctx = None
+
+    async def validate(self, data: dict, *, pipeline_context: Ctx | None = None) -> PluginOutcome:
+        self.ctx = pipeline_context
+        return PluginOutcome(success=True)
+
+
+class StrictPlugin:
+    async def validate(self, data: dict) -> PluginOutcome:
+        return PluginOutcome(success=True)
+
+
+class KwargsPlugin:
+    def __init__(self):
+        self.kwargs = None
+
+    async def validate(self, data: dict, **kwargs) -> PluginOutcome:
+        self.kwargs = kwargs
+        return PluginOutcome(success=True)
+
+
+@pytest.mark.asyncio
+async def test_context_initialization_and_access() -> None:
+    agent = CaptureAgent()
+    step = Step("s", agent)
+    runner = PipelineRunner(step, context_model=Ctx, initial_context_data={"num": 1})
+    result = await runner.run_async("in")
+    assert isinstance(agent.seen, Ctx)
+    assert result.final_pipeline_context.num == 1
+
+
+@pytest.mark.asyncio
+async def test_context_initialization_failure() -> None:
+    runner = PipelineRunner(Step("s", CaptureAgent()), context_model=Ctx, initial_context_data={"num": "bad"})
+    with pytest.raises(PipelineContextInitializationError):
+        await runner.run_async("in")
+
+
+@pytest.mark.asyncio
+async def test_context_mutation_between_steps() -> None:
+    pipeline = Step("inc", IncAgent()) >> Step("read", ReadAgent())
+    runner = PipelineRunner(pipeline, context_model=Ctx)
+    result = await runner.run_async("x")
+    assert result.step_history[-1].output == 1
+    assert result.final_pipeline_context.num == 1
+
+
+@pytest.mark.asyncio
+async def test_context_isolated_per_run() -> None:
+    step = Step("inc", IncAgent())
+    runner = PipelineRunner(step, context_model=Ctx)
+    r1 = await runner.run_async("a")
+    r2 = await runner.run_async("b")
+    assert r1.final_pipeline_context.num == 1
+    assert r2.final_pipeline_context.num == 1
+
+
+@pytest.mark.asyncio
+async def test_plugin_receives_context_and_strict_plugin_errors() -> None:
+    ctx_plugin = ContextPlugin()
+    kwargs_plugin = KwargsPlugin()
+    strict_plugin = StrictPlugin()
+    step = Step("s", CaptureAgent(), plugins=[(ctx_plugin, 0), (kwargs_plugin, 0), (strict_plugin, 0)])
+    runner = PipelineRunner(step, context_model=Ctx)
+    with pytest.raises(TypeError):
+        await runner.run_async("in")
+    # Context plugin ran before the TypeError
+    assert isinstance(ctx_plugin.ctx, Ctx)
+    assert kwargs_plugin.kwargs.get("pipeline_context") == ctx_plugin.ctx


### PR DESCRIPTION
## Summary
- add dedicated page about typed pipeline context and document lifecycle
- link new page throughout docs and navigation
- surface clear errors when agents or plugins lack a `pipeline_context` kwarg
- log pipeline context before and after each step for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684de3788e28832c8c52889250a48474