### PR TITLE
Implement LoopStep iteration construct

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -70,6 +70,12 @@ runner_with_ctx = PipelineRunner(
     context_model=MyContext,
     initial_context_data={"counter": 0},
 )
+# Looping allows iterative execution of a sub-pipeline
+looping_step = Step.loop_until(
+    name="loop",
+    loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
+    exit_condition_callable=lambda out, ctx: "done" in out,
+)
 # See `pipeline_context.md` for details on using shared context.
 ```
 

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -157,6 +157,21 @@ pipeline = (
 )
 ```
 
+### Looping and Iteration
+
+Repeat a sub-pipeline until a condition is met using `Step.loop_until()`.
+See [LoopStep documentation](pipeline_looping.md) for full details.
+
+```python
+loop_step = Step.loop_until(
+    name="refine",
+    loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
+    exit_condition_callable=lambda out, ctx: "done" in out,
+)
+
+pipeline = Step.review(review_agent) >> loop_step >> Step.validate(validator_agent)
+```
+
 ## Typed Pipeline Context
 
 `PipelineRunner` can share a mutable Pydantic model instance across all steps in

--- a/docs/pipeline_looping.md
+++ b/docs/pipeline_looping.md
@@ -1,0 +1,59 @@
+# LoopStep: Iterative Pipelines
+
+`LoopStep` allows you to run a sub‑pipeline repeatedly until a custom condition is met. This enables iterative refinement, polling style workflows or self‑correction loops.
+
+## Parameters
+
+- **`name`** – Step name.
+- **`loop_body_pipeline`** – A `Pipeline` executed on each iteration.
+- **`exit_condition_callable`** – Callable accepting `(last_body_output, pipeline_context)` and returning `True` to stop looping.
+- **`max_loops`** – Maximum iterations (defaults to `5`). Prevents infinite loops.
+- **`initial_input_to_loop_body_mapper`** – Optional function mapping the `LoopStep` input to the first body input.
+- **`iteration_input_mapper`** – Optional function mapping the previous iteration output to the next iteration input.
+- **`loop_output_mapper`** – Optional function mapping the final successful output of the body to the overall `LoopStep` output.
+
+All mappers receive the shared typed pipeline context when provided.
+
+## Using Typed Pipeline Context
+
+A single context instance is passed into every iteration. The loop body can modify this context and the exit condition can inspect it.
+
+```python
+from pydantic import BaseModel
+from pydantic_ai_orchestrator.domain import Step, Pipeline
+
+class Ctx(BaseModel):
+    counter: int = 0
+
+async def inc(x: int, *, pipeline_context: Ctx | None = None) -> int:
+    if pipeline_context:
+        pipeline_context.counter += 1
+    return x + 1
+
+body = Pipeline.from_step(Step("inc", inc))
+
+loop_step = Step.loop_until(
+    name="increment_until_three",
+    loop_body_pipeline=body,
+    exit_condition_callable=lambda out, ctx: out >= 3,
+    max_loops=5,
+)
+```
+
+## Success and Failure
+
+- `StepResult.attempts` reflects the number of iterations performed.
+- `success` is `True` when the exit condition is met and the final iteration completed successfully.
+- Reaching `max_loops` without meeting the exit condition marks the step as failed.
+
+## Examples
+
+```python
+pipeline = Step.solution(agent_a) >> loop_step
+runner = PipelineRunner(pipeline, context_model=Ctx)
+result = runner.run(0)
+print(result.step_history[-1].output)
+print(result.final_pipeline_context.counter)
+```
+
+See [pipeline_dsl.md](pipeline_dsl.md) for general DSL usage.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -296,4 +296,29 @@ final = runner.run("hi")
 print(final.final_pipeline_context.calls)  # 2
 ```
 
+### Iterative Loops with `LoopStep`
+
+Some workflows require repeating a set of steps until a condition is met. `LoopStep`
+lets you express this directly in the DSL.
+
+```python
+from pydantic_ai_orchestrator import Step, PipelineRunner, Pipeline
+
+async def fixer(data: str) -> str:
+    return data + "!"
+
+body = Pipeline.from_step(Step("fix", fixer))
+
+loop = Step.loop_until(
+    name="add_exclamation",
+    loop_body_pipeline=body,
+    exit_condition_callable=lambda out, ctx: out.endswith("!!!"),
+    max_loops=3,
+)
+
+runner = PipelineRunner(loop)
+result = runner.run("hi")
+print(result.step_history[-1].output)  # 'hi!!!'
+```
+
 You're now ready to build powerful and intelligent AI applications. Happy orchestrating

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - API Reference:
     - Overview: api_reference.md
     - Pipeline DSL: pipeline_dsl.md
+    - LoopStep: pipeline_looping.md
     - Typed Pipeline Context: pipeline_context.md
     - Scoring: scoring.md
     - Tools: tools.md

--- a/pydantic_ai_orchestrator/domain/__init__.py
+++ b/pydantic_ai_orchestrator/domain/__init__.py
@@ -1,12 +1,13 @@
 """Domain layer package."""
 
-from .pipeline_dsl import Step, Pipeline, StepConfig
+from .pipeline_dsl import Step, Pipeline, StepConfig, LoopStep
 from .plugins import PluginOutcome, ValidationPlugin
 
 __all__ = [
     "Step",
     "Pipeline",
     "StepConfig",
+    "LoopStep",
     "PluginOutcome",
     "ValidationPlugin",
 ]

--- a/tests/integration/test_loop_step_execution.py
+++ b/tests/integration/test_loop_step_execution.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.domain import Step, Pipeline, LoopStep
+
+
+class IncrementAgent:
+    async def run(self, data: int, **kwargs) -> int:
+        return data + 1
+
+
+@pytest.mark.asyncio
+async def test_basic_loop_until_condition_met() -> None:
+    body = Pipeline.from_step(Step("inc", IncrementAgent()))
+    loop = Step.loop_until(
+        name="loop",
+        loop_body_pipeline=body,
+        exit_condition_callable=lambda out, ctx: out >= 3,
+        max_loops=5,
+    )
+    runner = PipelineRunner(loop)
+    result = await runner.run_async(0)
+    step_result = result.step_history[-1]
+    assert step_result.success is True
+    assert step_result.attempts == 3
+    assert step_result.output == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_max_loops_reached() -> None:
+    body = Pipeline.from_step(Step("inc", IncrementAgent()))
+    loop = Step.loop_until(
+        name="loop",
+        loop_body_pipeline=body,
+        exit_condition_callable=lambda out, ctx: out > 10,
+        max_loops=2,
+    )
+    runner = PipelineRunner(loop)
+    result = await runner.run_async(0)
+    step_result = result.step_history[-1]
+    assert step_result.success is False
+    assert step_result.attempts == 2
+
+
+class Ctx(BaseModel):
+    counter: int = 0
+
+
+@pytest.mark.asyncio
+async def test_loop_with_context_modification() -> None:
+    class IncRecordAgent:
+        async def run(self, x: int, *, pipeline_context: Ctx | None = None) -> int:
+            if pipeline_context:
+                pipeline_context.counter += 1
+            return x + 1
+
+    body = Pipeline.from_step(Step("inc", IncRecordAgent()))
+    loop = Step.loop_until(
+        name="loop_ctx",
+        loop_body_pipeline=body,
+        exit_condition_callable=lambda out, ctx: ctx and ctx.counter >= 2,
+        max_loops=5,
+    )
+    runner = PipelineRunner(loop, context_model=Ctx)
+    result = await runner.run_async(0)
+    step_result = result.step_history[-1]
+    assert step_result.success is True
+    assert result.final_pipeline_context.counter == 2

--- a/tests/unit/test_loop_step.py
+++ b/tests/unit/test_loop_step.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pydantic_ai_orchestrator.domain import Step, Pipeline, LoopStep
+
+
+def test_loop_step_init_validation() -> None:
+    with pytest.raises(ValueError):
+        LoopStep(
+            name="loop",
+            loop_body_pipeline=Pipeline.from_step(Step("a")),
+            exit_condition_callable=lambda *_: True,
+            max_loops=0,
+        )
+
+
+def test_step_factory_loop_until() -> None:
+    body = Pipeline.from_step(Step("a"))
+    step = Step.loop_until(name="loop", loop_body_pipeline=body, exit_condition_callable=lambda *_: True)
+    assert isinstance(step, LoopStep)
+    assert step.max_loops == 5


### PR DESCRIPTION
## Summary
- add LoopStep class and Step.loop_until factory
- implement loop execution in PipelineRunner
- document LoopStep usage and add to API
- add tutorial section for loops
- include LoopStep docs page and navigation
- test LoopStep creation and execution

## Testing
- `pytest tests/unit/test_loop_step.py tests/integration/test_loop_step_execution.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684deadc0d04832c8020e8eeff2a198d