### PR TITLE
Add ConditionalStep for pipeline branching

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -76,6 +76,15 @@ looping_step = Step.loop_until(
     loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
     exit_condition_callable=lambda out, ctx: "done" in out,
 )
+# Conditional branching
+router = Step.branch_on(
+    name="router",
+    condition_callable=lambda out, ctx: out,
+    branches={
+        "a": Pipeline.from_step(Step("a", solution_agent)),
+        "b": Pipeline.from_step(Step("b", validator_agent)),
+    },
+)
 # See `pipeline_context.md` for details on using shared context.
 ```
 

--- a/docs/pipeline_branching.md
+++ b/docs/pipeline_branching.md
@@ -1,0 +1,53 @@
+# ConditionalStep: Branching Pipelines
+
+`ConditionalStep` lets you choose between multiple sub-pipelines at runtime. A callable decides which branch to execute based on the previous output or the shared pipeline context.
+
+## Parameters
+
+- **`name`** – Step name.
+- **`condition_callable`** – Function accepting `(previous_step_output, pipeline_context)` and returning a key.
+- **`branches`** – Dictionary mapping keys to `Pipeline` objects.
+- **`default_branch_pipeline`** – Optional pipeline used when no key matches.
+- **`branch_input_mapper`** – Optional function mapping the `ConditionalStep` input to the branch input.
+- **`branch_output_mapper`** – Optional function mapping the branch output to the `ConditionalStep` output.
+
+All callables receive the shared typed pipeline context if provided.
+
+## Success and Failure
+
+The `ConditionalStep` succeeds when the selected branch completes successfully. If no branch matches and no default is provided, the step fails. Failures inside the chosen branch propagate to the `ConditionalStep`.
+
+`StepResult.metadata_['executed_branch_key']` stores the branch key that was executed.
+
+## Example
+
+```python
+from pydantic_ai_orchestrator.domain import Step, Pipeline
+
+async def classify(x: str) -> str:
+    return "numbers" if x.isdigit() else "text"
+
+async def process_numbers(data: str) -> str:
+    return str(int(data) * 2)
+
+async def process_text(data: str) -> str:
+    return data.upper()
+
+branches = {
+    "numbers": Pipeline.from_step(Step("num", process_numbers)),
+    "text": Pipeline.from_step(Step("txt", process_text)),
+}
+
+branch_step = Step.branch_on(
+    name="router",
+    condition_callable=lambda out, ctx: out,
+    branches=branches,
+)
+
+pipeline = Step("classify", classify) >> branch_step
+```
+
+Running the pipeline will execute either the `process_numbers` or `process_text` branch based on the classification result.
+
+See [pipeline_dsl.md](pipeline_dsl.md) for an overview of the DSL.
+

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -199,24 +199,24 @@ print(result.final_pipeline_context.counter)  # 2
 Each `run()` call gets a fresh context instance. Access the final state via
 `PipelineResult.final_pipeline_context`.
 
-### Conditional Steps
+### Conditional Branching
 
-Add conditional logic to your pipeline:
+Use `Step.branch_on()` to route to different sub-pipelines at runtime. See [ConditionalStep](pipeline_branching.md) for full details.
 
 ```python
-from pydantic_ai_orchestrator import conditional
+def choose_branch(out, ctx):
+    return "a" if "important" in out else "b"
 
-def needs_review(result):
-    return result.score < 0.8
-
-pipeline = (
-    Step.solution(solution_agent)
-    >> conditional(
-        needs_review,
-        Step.review(review_agent)
-    )
-    >> Step.validate(validator_agent)
+branch_step = Step.branch_on(
+    name="router",
+    condition_callable=choose_branch,
+    branches={
+        "a": Pipeline.from_step(Step("a_step", agent_a)),
+        "b": Pipeline.from_step(Step("b_step", agent_b)),
+    },
 )
+
+pipeline = Step.solution(solution_agent) >> branch_step >> Step.validate(validator_agent)
 ```
 
 ### Custom Step Factories

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -321,4 +321,28 @@ result = runner.run("hi")
 print(result.step_history[-1].output)  # 'hi!!!'
 ```
 
+### Conditional Branching with `ConditionalStep`
+
+Sometimes a pipeline should take different actions depending on earlier results. `ConditionalStep` lets you define that logic declaratively.
+
+```python
+def choose(out, ctx):
+    return "positive" if "!" in out else "neutral"
+
+branches = {
+    "positive": Pipeline.from_step(Step("yay", lambda x: x + " 😊")),
+    "neutral": Pipeline.from_step(Step("meh", lambda x: x)),
+}
+
+branch = Step.branch_on(
+    name="sentiment_router",
+    condition_callable=choose,
+    branches=branches,
+)
+
+pipeline = Step("start", fixer) >> branch
+runner = PipelineRunner(pipeline)
+print(runner.run("ok").step_history[-1].output)
+```
+
 You're now ready to build powerful and intelligent AI applications. Happy orchestrating

--- a/pydantic_ai_orchestrator/domain/__init__.py
+++ b/pydantic_ai_orchestrator/domain/__init__.py
@@ -1,6 +1,6 @@
 """Domain layer package."""
 
-from .pipeline_dsl import Step, Pipeline, StepConfig, LoopStep
+from .pipeline_dsl import Step, Pipeline, StepConfig, LoopStep, ConditionalStep, BranchKey
 from .plugins import PluginOutcome, ValidationPlugin
 
 __all__ = [
@@ -8,6 +8,8 @@ __all__ = [
     "Pipeline",
     "StepConfig",
     "LoopStep",
+    "ConditionalStep",
+    "BranchKey",
     "PluginOutcome",
     "ValidationPlugin",
 ]

--- a/pydantic_ai_orchestrator/domain/models.py
+++ b/pydantic_ai_orchestrator/domain/models.py
@@ -58,6 +58,10 @@ class StepResult(BaseModel):
     token_counts: int = 0
     cost_usd: float = 0.0
     feedback: str | None = None
+    metadata_: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional metadata about the step execution.",
+    )
 
 
 class PipelineResult(BaseModel):
@@ -67,9 +71,7 @@ class PipelineResult(BaseModel):
     total_cost_usd: float = 0.0
     final_pipeline_context: Optional[BaseModel] = Field(
         default=None,
-        description=(
-            "The final state of the typed pipeline context, if configured and used."
-        ),
+        description=("The final state of the typed pipeline context, if configured and used."),
     )
 
     model_config = {"arbitrary_types_allowed": True}

--- a/tests/integration/test_conditional_step_execution.py
+++ b/tests/integration/test_conditional_step_execution.py
@@ -1,0 +1,162 @@
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai_orchestrator.domain import Step, Pipeline, ConditionalStep
+from pydantic_ai_orchestrator.application.pipeline_runner import PipelineRunner
+from pydantic_ai_orchestrator.testing.utils import StubAgent, DummyPlugin
+from pydantic_ai_orchestrator.domain.plugins import PluginOutcome
+
+
+class EchoAgent:
+    async def run(self, data, **kwargs):
+        return data
+
+
+@pytest.mark.asyncio
+async def test_branch_a_executes() -> None:
+    classify = Step("classify", StubAgent(["a"]))
+    branches = {
+        "a": Pipeline.from_step(Step("a", StubAgent(["A"]))),
+        "b": Pipeline.from_step(Step("b", StubAgent(["B"]))),
+    }
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: out,
+        branches=branches,
+    )
+    runner = PipelineRunner(classify >> branch_step)
+    result = await runner.run_async("in")
+    step_result = result.step_history[-1]
+    assert step_result.success is True
+    assert step_result.output == "A"
+    assert step_result.metadata_["executed_branch_key"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_branch_b_executes() -> None:
+    classify = Step("classify", StubAgent(["b"]))
+    branches = {
+        "a": Pipeline.from_step(Step("a", StubAgent(["A"]))),
+        "b": Pipeline.from_step(Step("b", StubAgent(["B"]))),
+    }
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: out,
+        branches=branches,
+    )
+    runner = PipelineRunner(classify >> branch_step)
+    result = await runner.run_async("in")
+    assert result.step_history[-1].output == "B"
+    assert result.step_history[-1].metadata_["executed_branch_key"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_default_branch_used() -> None:
+    classify = Step("classify", StubAgent(["x"]))
+    branches = {
+        "a": Pipeline.from_step(Step("a", StubAgent(["A"]))),
+    }
+    default = Pipeline.from_step(Step("def", StubAgent(["DEF"])))
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: out,
+        branches=branches,
+        default_branch_pipeline=default,
+    )
+    runner = PipelineRunner(classify >> branch_step)
+    result = await runner.run_async("in")
+    assert result.step_history[-1].output == "DEF"
+    assert result.step_history[-1].metadata_["executed_branch_key"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_no_match_no_default_fails() -> None:
+    classify = Step("classify", StubAgent(["x"]))
+    branches = {"a": Pipeline.from_step(Step("a", StubAgent(["A"])))}
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: out,
+        branches=branches,
+    )
+    runner = PipelineRunner(classify >> branch_step)
+    result = await runner.run_async("in")
+    step_result = result.step_history[-1]
+    assert step_result.success is False
+    assert "no default" in step_result.feedback.lower()
+
+
+class FlagCtx(BaseModel):
+    flag: str = "a"
+
+
+@pytest.mark.asyncio
+async def test_condition_uses_context() -> None:
+    classify = Step("classify", StubAgent(["ignored"]))
+    branches = {
+        "a": Pipeline.from_step(Step("a", StubAgent(["A"]))),
+        "b": Pipeline.from_step(Step("b", StubAgent(["B"]))),
+    }
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: ctx.flag if ctx else "a",
+        branches=branches,
+    )
+    runner = PipelineRunner(
+        classify >> branch_step, context_model=FlagCtx, initial_context_data={"flag": "b"}
+    )
+    result = await runner.run_async("in")
+    assert result.step_history[-1].output == "B"
+    assert result.step_history[-1].metadata_["executed_branch_key"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_mappers_applied() -> None:
+    branches = {
+        "x": Pipeline.from_step(Step("inc", EchoAgent())),
+    }
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: "x",
+        branches=branches,
+        branch_input_mapper=lambda inp, ctx: inp + 1,
+        branch_output_mapper=lambda out, key, ctx: out * 10,
+    )
+    runner = PipelineRunner(branch_step)
+    result = await runner.run_async(1)
+    assert result.step_history[-1].output == 20
+
+
+@pytest.mark.asyncio
+async def test_failure_in_branch_propagates() -> None:
+    fail_plugin = DummyPlugin([PluginOutcome(success=False, feedback="bad")])
+    bad_step = Step("bad", StubAgent(["oops"]), plugins=[fail_plugin])
+    branches = {"a": Pipeline.from_step(bad_step)}
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda out, ctx: "a",
+        branches=branches,
+    )
+    runner = PipelineRunner(branch_step)
+    result = await runner.run_async("in")
+    step_result = result.step_history[-1]
+    assert step_result.success is False
+    assert "bad" in step_result.feedback
+
+
+@pytest.mark.asyncio
+async def test_condition_exception_fails_step() -> None:
+    branches = {"a": Pipeline.from_step(Step("a", StubAgent(["A"])))}
+
+    def condition(_: str, __: FlagCtx | None) -> str:
+        raise RuntimeError("boom")
+
+    branch_step = Step.branch_on(
+        name="branch",
+        condition_callable=condition,
+        branches=branches,
+    )
+    runner = PipelineRunner(branch_step)
+    result = await runner.run_async("in")
+    step_result = result.step_history[-1]
+    assert step_result.success is False
+    assert "boom" in step_result.feedback

--- a/tests/unit/test_conditional_step.py
+++ b/tests/unit/test_conditional_step.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic_ai_orchestrator.domain import Step, Pipeline, ConditionalStep
+
+
+def test_conditional_step_init_validation() -> None:
+    with pytest.raises(ValueError):
+        ConditionalStep(
+            name="cond",
+            condition_callable=lambda *_: "a",
+            branches={},
+        )
+
+
+def test_step_factory_branch_on() -> None:
+    branches = {"a": Pipeline.from_step(Step("a"))}
+    step = Step.branch_on(
+        name="branch",
+        condition_callable=lambda *_: "a",
+        branches=branches,
+    )
+    assert isinstance(step, ConditionalStep)
+    assert "a" in step.branches


### PR DESCRIPTION
## Summary
- implement ConditionalStep class and branch_on factory
- enable PipelineRunner to execute ConditionalStep
- extend StepResult with optional metadata_
- document conditional branching
- add tutorial example and API reference updates
- test ConditionalStep at unit and integration level

## Testing
- `pytest -m "not e2e and not benchmark"`

------
https://chatgpt.com/codex/tasks/task_e_684def406c04832c9cf601b2825be080