### PR TITLE
Improve docs, add advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,10 @@ provides utilities to manage multi-agent pipelines with minimal setup.
 
 ## Features
 
-- 🤖 **AI Agent Management**: Create and manage AI agents with different roles and capabilities
-- 🔄 **Pipeline DSL**: Build complex AI workflows using a simple domain-specific language
-- 🛠️ **Tool Integration**: Extend agent capabilities with custom tools
-- 📊 **Quality Control**: Built-in validation and scoring mechanisms
-- 📈 **Telemetry**: Monitor performance and usage with built-in metrics
-- 🔒 **Type Safety**: Leverage Pydantic for runtime type checking and validation
-- 🚀 **Async Support**: Built-in support for asynchronous operations
-- 📚 **Extensive Documentation**: Comprehensive guides and examples
+- 📦 **Pydantic Native** – agents, tools, and pipeline context are all defined with Pydantic models for reliable type safety.
+- 🔁 **Opinionated & Flexible** – the `Orchestrator` gives you a ready‑made workflow while the DSL lets you build any pipeline.
+- 🏗️ **Production Ready** – retries, telemetry, and quality controls help you ship reliable systems.
+- 🧠 **Intelligent Evals** – automated scoring and self‑improvement powered by LLMs.
 
 ## Quick Start
 
@@ -129,12 +125,17 @@ if len(pipeline_result.step_history) > 1 and pipeline_result.step_history[1].suc
 
 Check out the [examples directory](examples/) for more usage examples:
 
-- [Basic Usage](examples/basic.py): Simple orchestrator usage
-- [Pipeline Example](examples/pipeline.py): Custom pipeline creation
-- [Tool Integration](examples/tools.py): Using tools with agents
-- [Async Operations](examples/async.py): Asynchronous workflows
-- [Quality Control](examples/quality.py): Validation and scoring
-- [Telemetry](examples/telemetry.py): Monitoring and metrics
+| Script | What it shows |
+| ------ | ------------- |
+| [**00_quickstart.py**](examples/00_quickstart.py) | Minimal, single-task run (ratio scorer). |
+| [**01_weighted_scoring.py**](examples/01_weighted_scoring.py) | Passing custom checklist weights. |
+| [**02_custom_agents.py**](examples/02_custom_agents.py) | Mixing models or replacing the solution agent. |
+| [**03_reward_scorer.py**](examples/03_reward_scorer.py) | Using the reward-model scorer. |
+| [**04_batch_processing.py**](examples/04_batch_processing.py) | Running many prompts from a CSV and exporting results. |
+| [**05_pipeline_sql.py**](examples/05_pipeline_sql.py) | DSL pipeline with SQL validation plugin. |
+| [**06_typed_context.py**](examples/06_typed_context.py) | Sharing state across steps using TypedPipelineContext. |
+| [**07_loop_step.py**](examples/07_loop_step.py) | Iterative refinement with LoopStep. |
+| [**08_branch_step.py**](examples/08_branch_step.py) | Conditional routing with ConditionalStep. |
 
 ## Requirements
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -110,6 +110,7 @@ operations, the agents used at each stage, and the integration of plugins.
 `PipelineRunner` can also maintain a shared, typed context object for each run.
 Steps declare a `pipeline_context` parameter to access or modify this object. See
 [Typed Pipeline Context](pipeline_context.md) for full documentation.
+The built-in [**Orchestrator**](#the-orchestrator) uses this DSL under the hood. When you need different logic, you can use the same tools directly. The DSL also supports advanced constructs like [**LoopStep**](pipeline_looping.md) for iteration and [**ConditionalStep**](pipeline_branching.md) for branching workflows.
 
 ```python
 from pydantic_ai_orchestrator import (

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,10 @@
 Production-ready orchestration for Pydantic-based AI agents.
 
 ## Features
-- Typed settings and secrets
-- Telemetry and observability
-- Pluggable scoring (ratio, weighted, reward-model)
-- CLI and API
-- Extensible agent and reflection system
-- Flexible pipeline DSL and runner
+- **Pydantic Native** – everything from agents to the shared pipeline context is defined with Pydantic models.
+- **Opinionated & Flexible** – start with the built-in `Orchestrator` or compose your own flows using the DSL.
+- **Production Ready** – retries, telemetry and scoring help you deploy reliable systems.
+- **Intelligent Evals** – built-in support for LLM-powered evaluation and self-improvement.
 
 ## Installation
 

--- a/docs/pipeline_branching.md
+++ b/docs/pipeline_branching.md
@@ -49,5 +49,5 @@ pipeline = Step("classify", classify) >> branch_step
 
 Running the pipeline will execute either the `process_numbers` or `process_text` branch based on the classification result.
 
-See [pipeline_dsl.md](pipeline_dsl.md) for an overview of the DSL.
+See [pipeline_dsl.md](pipeline_dsl.md) for an overview of the DSL. A runnable example can be found in [examples/08_branch_step.py](../examples/08_branch_step.py).
 

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -76,4 +76,4 @@ result = runner.run("hi")
 print(result.final_pipeline_context.counter)
 ```
 
-For a complete example, see the [Typed Pipeline Context section](pipeline_dsl.md#typed-pipeline-context) of the Pipeline DSL guide.
+For a complete example, see the [Typed Pipeline Context section](pipeline_dsl.md#typed-pipeline-context) of the Pipeline DSL guide. A runnable demonstration is available in [examples/06_typed_context.py](../examples/06_typed_context.py).

--- a/docs/pipeline_looping.md
+++ b/docs/pipeline_looping.md
@@ -56,4 +56,4 @@ print(result.step_history[-1].output)
 print(result.final_pipeline_context.counter)
 ```
 
-See [pipeline_dsl.md](pipeline_dsl.md) for general DSL usage.
+See [pipeline_dsl.md](pipeline_dsl.md) for general DSL usage. For a complete script demonstrating `LoopStep`, check [examples/07_loop_step.py](../examples/07_loop_step.py).

--- a/examples/06_typed_context.py
+++ b/examples/06_typed_context.py
@@ -1,0 +1,27 @@
+"""
+06_typed_context.py
+-------------------
+Demonstrates sharing state across steps with Typed Pipeline Context.
+"""
+
+from pydantic import BaseModel
+from pydantic_ai_orchestrator import Step, PipelineRunner
+
+
+class Ctx(BaseModel):
+    count: int = 0
+
+
+async def increment(data: str, *, pipeline_context: Ctx | None = None) -> str:
+    if pipeline_context:
+        pipeline_context.count += 1
+    return data + "!"
+
+
+pipeline = Step("first", increment) >> Step("second", increment)
+runner = PipelineRunner(pipeline, context_model=Ctx)
+
+result = runner.run("hello")
+print("Final output:", result.step_history[-1].output)
+print("Final count:", result.final_pipeline_context.count)
+

--- a/examples/07_loop_step.py
+++ b/examples/07_loop_step.py
@@ -1,0 +1,26 @@
+"""
+07_loop_step.py
+---------------
+Demonstrates using LoopStep for iterative refinement.
+"""
+
+from pydantic_ai_orchestrator import Step, Pipeline, PipelineRunner
+
+
+async def add_exclamation(data: str) -> str:
+    return data + "!"
+
+
+body = Pipeline.from_step(Step("add", add_exclamation))
+
+loop_step = Step.loop_until(
+    name="refine",
+    loop_body_pipeline=body,
+    exit_condition_callable=lambda out, ctx: out.endswith("!!!"),
+    max_loops=5,
+)
+
+runner = PipelineRunner(loop_step)
+result = runner.run("hi")
+print("Final output:", result.step_history[-1].output)
+

--- a/examples/08_branch_step.py
+++ b/examples/08_branch_step.py
@@ -1,0 +1,28 @@
+"""
+08_branch_step.py
+-----------------
+Demonstrates ConditionalStep for routing to different pipelines.
+"""
+
+from pydantic_ai_orchestrator import Step, Pipeline, PipelineRunner
+
+
+def classify(text: str) -> str:
+    return "shout" if text.endswith("!") else "normal"
+
+
+shout_pipeline = Pipeline.from_step(Step("shout", lambda x: x.upper()))
+normal_pipeline = Pipeline.from_step(Step("normal", lambda x: x.capitalize()))
+
+branch_step = Step.branch_on(
+    name="router",
+    condition_callable=lambda out, ctx: out,
+    branches={"shout": shout_pipeline, "normal": normal_pipeline},
+)
+
+pipeline = Step("classify", classify) >> branch_step
+runner = PipelineRunner(pipeline)
+
+result = runner.run("hello!")
+print("Final output:", result.step_history[-1].output)
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,9 @@
 | **03_reward_scorer.py** | Using the reward-model scorer. |
 | **04_batch_processing.py** | Running many prompts from a CSV and exporting results. |
 | **05_pipeline_sql.py** | DSL pipeline with SQL validation plugin. |
+| **06_typed_context.py** | Sharing state across steps using TypedPipelineContext. |
+| **07_loop_step.py** | Iterative refinement with LoopStep. |
+| **08_branch_step.py** | Conditional routing with ConditionalStep. |
 
 Each script is standalone – activate your virtualenv, set `OPENAI_API_KEY`, then:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,9 @@ nav:
   - API Reference:
     - Overview: api_reference.md
     - Pipeline DSL: pipeline_dsl.md
-    - LoopStep: pipeline_looping.md
     - Typed Pipeline Context: pipeline_context.md
+    - Looping (LoopStep): pipeline_looping.md
+    - Branching (ConditionalStep): pipeline_branching.md
     - Scoring: scoring.md
     - Tools: tools.md
     - Telemetry: telemetry.md


### PR DESCRIPTION
## Summary
- document that the Orchestrator uses the DSL and link to advanced constructs
- add new example scripts for typed context, LoopStep, and ConditionalStep
- list the new examples in examples README
- expand examples table in main README and link advanced docs

## Testing
- `make pip-test-fast`


------
https://chatgpt.com/codex/tasks/task_e_684df57e6ec4832c9e2872b448292588