### PR TITLE
Rename PipelineRunner to Flujo, introduce Default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ provides utilities to manage multi-agent pipelines with minimal setup.
 ## Features
 
 - 📦 **Pydantic Native** – agents, tools, and pipeline context are all defined with Pydantic models for reliable type safety.
-- 🔁 **Opinionated & Flexible** – the `Orchestrator` gives you a ready‑made workflow while the DSL lets you build any pipeline.
+- 🔁 **Opinionated & Flexible** – the `Default` recipe gives you a ready‑made workflow while the DSL lets you build any pipeline.
 - 🏗️ **Production Ready** – retries, telemetry, and quality controls help you ship reliable systems.
 - 🧠 **Intelligent Evals** – automated scoring and self‑improvement powered by LLMs.
 
@@ -23,8 +23,9 @@ pip install flujo
 ### Basic Usage
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task,
+    Task,
     review_agent, solution_agent, validator_agent,
     init_telemetry,
 )
@@ -34,7 +35,7 @@ init_telemetry()
 
 # Assemble an orchestrator with the library-provided agents. The class
 # runs a fixed pipeline: Review -> Solution -> Validate.
-flujo = Orchestrator(
+flujo = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -62,21 +63,21 @@ else:
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 
 # Build a custom pipeline using the Step DSL. This mirrors the internal
-# workflow used by :class:`Orchestrator` but is fully configurable.
+# workflow used by :class:`Default` but is fully configurable.
 custom_pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
     >> Step.validate(validator_agent)
 )
 
-pipeline_runner = PipelineRunner(custom_pipeline)
+pipeline_runner = Flujo(custom_pipeline)
 
-# Run synchronously; PipelineRunner returns a PipelineResult.
+# Run synchronously; Flujo returns a PipelineResult.
 pipeline_result = pipeline_runner.run(
     "Generate a REST API using FastAPI for a to-do list application."
 )

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -4,17 +4,17 @@ This guide provides detailed documentation for all public interfaces in `flujo`.
 
 ## Core Components
 
-### Orchestrator
+### Default Recipe
 
-The `Orchestrator` class is a high-level facade for running a **standard, fixed
+`flujo.recipes.Default` is a high-level facade for running a **standard, fixed
 multi-agent pipeline**: Review -> Solution -> Validate -> Reflection. It uses the agents you
 provide for these roles. For custom pipelines with different logic, see
-`PipelineRunner` and the `Step` DSL.
+`Flujo` and the `Step` DSL.
 
 ```python
-from flujo import Orchestrator
+from flujo.recipes import Default
 
-orchestrator = Orchestrator(
+orchestrator = Default(
     review_agent: AsyncAgentProtocol[Any, Checklist],
     solution_agent: AsyncAgentProtocol[Any, str],
     validator_agent: AsyncAgentProtocol[Any, Checklist],
@@ -35,14 +35,14 @@ result = orchestrator.run_sync(Task(prompt="Generate a poem"))
 candidate = await orchestrator.run_async(Task(prompt="Generate a poem"))
 ```
 
-### Pipeline DSL & `PipelineRunner`
+### Pipeline DSL & `Flujo`
 
 The Pipeline DSL lets you create flexible, custom workflows and execute them
-with `PipelineRunner`.
+with `Flujo`.
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 from pydantic import BaseModel
@@ -63,9 +63,9 @@ custom_pipeline = (
     )
 )
 
-runner = PipelineRunner(custom_pipeline)
+runner = Flujo(custom_pipeline)
 # With a shared typed context
-runner_with_ctx = PipelineRunner(
+runner_with_ctx = Flujo(
     custom_pipeline,
     context_model=MyContext,
     initial_context_data={"counter": 0},
@@ -223,7 +223,7 @@ from flujo import run_pipeline_async, evaluate_and_improve
 # Run pipeline evaluation
 result = await run_pipeline_async(
     inputs: str,                   # Input prompt
-    runner: PipelineRunner,        # Pipeline runner
+    runner: Flujo,                 # Pipeline runner
     **kwargs                       # Additional arguments
 )
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,8 +29,9 @@ OPENAI_API_KEY=your_key_here
 Create a new file `hello_orchestrator.py`:
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task,
+    Task,
     review_agent, solution_agent, validator_agent, reflection_agent,
     init_telemetry,
 )
@@ -39,7 +40,7 @@ init_telemetry()
 
 # Assemble the orchestrator with the default agents. It runs a fixed
 # Review -> Solution -> Validate -> Reflection workflow.
-flujo = Orchestrator(
+flujo = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -61,9 +62,9 @@ if best_candidate:
             print(f"{status} {item.description}")
 ```
 
-The `Orchestrator` class provides a quick way to run this standard
+The `Default` recipe provides a quick way to run this standard
 multi-agent workflow. For custom pipelines and advanced control, you'll
-use the `PipelineRunner` and `Step` DSL described later.
+use the `Flujo` engine and `Step` DSL described later.
 
 ## 4. Run Your First Orchestration
 
@@ -122,7 +123,7 @@ custom_agent = make_agent_async(
 )
 
 # Use it in your orchestrator
-flujo = Orchestrator(
+flujo = Default(
     review_agent=custom_agent, 
     solution_agent=solution_agent, 
     validator_agent=validator_agent,
@@ -152,18 +153,18 @@ code_agent = make_agent_async(
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 
-# Define a custom pipeline (similar to the Orchestrator workflow)
+# Define a custom pipeline (similar to the Default workflow)
 custom_pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
     >> Step.validate(validator_agent)
 )
 
-runner = PipelineRunner(custom_pipeline)
+runner = Flujo(custom_pipeline)
 
 # The input to `run()` is the prompt for the first step.
 pipeline_result = runner.run("Write a function to sort a list")

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -8,7 +8,8 @@ try:
     __version__ = version("flujo")
 except Exception:
     __version__ = "0.0.0"
-from .application.orchestrator import Orchestrator
+from .application.flujo_engine import Flujo
+from .recipes import Default
 from .infra.settings import settings
 from .infra.telemetry import init_telemetry
 
@@ -20,7 +21,6 @@ from .domain import (
     PluginOutcome,
     ValidationPlugin,
 )
-from .application.pipeline_runner import PipelineRunner
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult
@@ -39,7 +39,8 @@ from .infra.agents import (
 from .exceptions import OrchestratorError, ConfigurationError, SettingsError
 
 __all__ = [
-    "Orchestrator",
+    "Flujo",
+    "Default",
     "Task",
     "Candidate",
     "Checklist",
@@ -49,7 +50,6 @@ __all__ = [
     "StepConfig",
     "PluginOutcome",
     "ValidationPlugin",
-    "PipelineRunner",
     "run_pipeline_async",
     "evaluate_and_improve",
     "SelfImprovementAgent",

--- a/flujo/application/eval_adapter.py
+++ b/flujo/application/eval_adapter.py
@@ -1,15 +1,15 @@
-"""Utilities for integrating PipelineRunner with pydantic-evals."""
+"""Utilities for integrating :class:`Flujo` with pydantic-evals."""
 
 from typing import Any
 
-from .pipeline_runner import PipelineRunner
+from .flujo_engine import Flujo
 from ..domain.models import PipelineResult
 
 
-async def run_pipeline_async(inputs: Any, *, runner: PipelineRunner[Any, Any]) -> PipelineResult:
-    """Adapter to run a PipelineRunner as a pydantic-evals task."""
+async def run_pipeline_async(inputs: Any, *, runner: Flujo[Any, Any]) -> PipelineResult:
+    """Adapter to run a :class:`Flujo` engine as a pydantic-evals task."""
     return await runner.run_async(inputs)
 
 
 # Example usage:
-# runner: PipelineRunner[Any, Any] = PipelineRunner(your_pipeline_or_step)
+# runner: Flujo[Any, Any] = Flujo(your_pipeline_or_step)

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -31,7 +31,7 @@ RunnerInT = TypeVar("RunnerInT")
 RunnerOutT = TypeVar("RunnerOutT")
 
 
-class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
+class Flujo(Generic[RunnerInT, RunnerOutT]):
     """Execute a pipeline sequentially."""
 
     def __init__(

--- a/flujo/cli/main.py
+++ b/flujo/cli/main.py
@@ -18,7 +18,7 @@ from flujo.infra.agents import (
     VALIDATE_SYS,
     get_reflection_agent,
 )
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.application.self_improvement import (
     evaluate_and_improve,
@@ -26,7 +26,7 @@ from flujo.application.self_improvement import (
     ImprovementReport,
 )
 from flujo.domain.models import ImprovementSuggestion
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.infra.settings import settings
 from flujo.exceptions import ConfigurationError, SettingsError
 from flujo.infra.telemetry import init_telemetry, logfire
@@ -160,7 +160,7 @@ def solve(
             AsyncAgentProtocol[Any, str], get_reflection_agent(ref_model)
         )
 
-        orch: Orchestrator = Orchestrator(
+        orch: Default = Default(
             review,
             solution,
             validator,
@@ -240,7 +240,7 @@ def bench(prompt: str, rounds: int = 10) -> None:
         validator_agent = make_agent_async(
             settings.default_validator_model, VALIDATE_SYS, Checklist
         )
-        orch: Orchestrator = Orchestrator(
+        orch: Default = Default(
             review_agent, solution_agent, validator_agent, get_reflection_agent()
         )
         times: List[float] = []
@@ -385,7 +385,7 @@ def improve(
         typer.echo("[red]Invalid pipeline or dataset file", err=True)
         raise typer.Exit(1)
 
-    runner: PipelineRunner = PipelineRunner(pipeline)
+    runner: Flujo = Flujo(pipeline)
     task_fn = functools.partial(run_pipeline_async, runner=runner)
     _agent = make_self_improvement_agent(model=improvement_agent_model)
     agent: SelfImprovementAgent = SelfImprovementAgent(_agent)

--- a/flujo/recipes/__init__.py
+++ b/flujo/recipes/__init__.py
@@ -1,0 +1,3 @@
+from .default import Default
+
+__all__ = ["Default"]

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -1,4 +1,4 @@
-"""Backward-compatible facade over :class:`PipelineRunner`."""
+"""Opinionated default workflow built on top of :class:`Flujo`."""
 
 from __future__ import annotations
 
@@ -7,13 +7,14 @@ from typing import Any, Optional, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for typing only
     from ..infra.agents import AsyncAgentProtocol
+
 from ..domain.pipeline_dsl import Step
 from ..domain.models import Candidate, PipelineResult, Task
-from .pipeline_runner import PipelineRunner
+from ..application.flujo_engine import Flujo
 
 
-class Orchestrator:
-    """Simple wrapper around :class:`PipelineRunner`."""
+class Default:
+    """Pre-configured workflow using the :class:`Flujo` engine."""
 
     def __init__(
         self,
@@ -32,10 +33,10 @@ class Orchestrator:
             >> Step.solution(cast(Any, solution_agent), max_retries=3)
             >> Step.validate_step(cast(Any, validator_agent), max_retries=3)
         )
-        self.runner = PipelineRunner(pipeline)
+        self.flujo_engine = Flujo(pipeline)
 
     async def run_async(self, task: Task) -> Candidate | None:
-        result: PipelineResult = await self.runner.run_async(task.prompt)
+        result: PipelineResult = await self.flujo_engine.run_async(task.prompt)
         if len(result.step_history) < 2:
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # --------------------------------------------------------------------------- #
 [project]
 name            = "flujo"
-version         = "0.2.0" # Version bumped for new features
+version         = "0.3.0" # Version bumped for breaking changes
 description     = "Production-ready orchestration for AI agents, built with Pydantic."
 readme          = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/tests/benchmarks/test_engine_overhead.py
+++ b/tests/benchmarks/test_engine_overhead.py
@@ -1,6 +1,6 @@
 import pytest
 from flujo.domain import Step
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.testing.utils import StubAgent
 
 pytest.importorskip("pytest_benchmark")
@@ -11,7 +11,7 @@ def test_pipeline_runner_overhead(benchmark):
     """Measures the execution time of the runner minus agent time."""
     agent = StubAgent(["output"])
     pipeline = Step("s1", agent) >> Step("s2", agent) >> Step("s3", agent) >> Step("s4", agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
 
     @benchmark
     def run_pipeline():

--- a/tests/e2e/test_e2e_pipelines.py
+++ b/tests/e2e/test_e2e_pipelines.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flujo.domain import Step
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.plugins.sql_validator import SQLSyntaxValidator
 from flujo.testing.utils import StubAgent
 
@@ -13,7 +13,7 @@ async def test_sql_pipeline_with_real_validator():
     solution_step = Step.solution(sql_agent)
     validation_step = Step.validate_step(validator_agent).add_plugin(SQLSyntaxValidator())
     pipeline = solution_step >> validation_step
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     result = await runner.run_async("prompt")
     assert result.step_history[-1].success is False
     assert result.step_history[-1].feedback

--- a/tests/e2e/test_golden_transcript.py
+++ b/tests/e2e/test_golden_transcript.py
@@ -5,7 +5,7 @@ try:
 except Exception:  # pragma: no cover - skip if dependency missing
     vcr = None
     pytest.skip("vcrpy not installed", allow_module_level=True)
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.infra.agents import (
     review_agent,
@@ -34,7 +34,7 @@ def test_golden_transcript():
     Runs a simple end-to-end test against the real OpenAI API (or a recording)
     to ensure the entire orchestration flow produces a valid, scored candidate.
     """
-    orch = Orchestrator(
+    orch = Default(
         review_agent,
         solution_agent,
         validator_agent,

--- a/tests/integration/test_backward_compatibility.py
+++ b/tests/integration/test_backward_compatibility.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.testing.utils import StubAgent
 from flujo.domain.models import Task, Checklist
 
@@ -8,6 +8,6 @@ async def test_orchestrator_init_backward_compatible():
     solution = StubAgent(["sol"])
     validator = StubAgent([Checklist(items=[])])
     reflection = StubAgent([None])
-    orch = Orchestrator(review, solution, validator, reflection)
+    orch = Default(review, solution, validator, reflection)
     result = await orch.run_async(Task(prompt="hi"))
     assert result is None or hasattr(result, "score")

--- a/tests/integration/test_evals_adapter.py
+++ b/tests/integration/test_evals_adapter.py
@@ -1,6 +1,6 @@
 import pytest
 from flujo.application.eval_adapter import run_pipeline_async
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
 from flujo.domain.models import PipelineResult
 from flujo.testing.utils import StubAgent
@@ -11,7 +11,7 @@ from pydantic_evals import Dataset, Case
 async def test_adapter_returns_pipeline_result():
     agent = StubAgent(["ok"])
     pipeline = Step.solution(agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="hi", expected_output="ok")])
 
     report = await dataset.evaluate(lambda x: run_pipeline_async(x, runner=runner))

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.testing.utils import StubAgent
 
@@ -7,7 +7,7 @@ async def test_orchestrator_runs_pipeline():
     review = StubAgent(["checklist"])
     solve = StubAgent(["solution"])
     validate = StubAgent(["validated"])
-    orch = Orchestrator(review, solve, validate, None)
+    orch = Default(review, solve, validate, None)
 
     result = await orch.run_async(Task(prompt="do"))
 

--- a/tests/integration/test_orchestrator_sync.py
+++ b/tests/integration/test_orchestrator_sync.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.testing.utils import StubAgent
 
@@ -7,7 +7,7 @@ def test_orchestrator_run_sync():
     review = StubAgent(["c"])
     solve = StubAgent(["s"])
     validate = StubAgent(["v"])
-    orch = Orchestrator(review, solve, validate, None)
+    orch = Default(review, solve, validate, None)
 
     result = orch.run_sync(Task(prompt="x"))
 

--- a/tests/integration/test_pipeline_runner_with_context.py
+++ b/tests/integration/test_pipeline_runner_with_context.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
 from flujo.testing.utils import StubAgent
 
@@ -21,7 +21,7 @@ class AddOneAgent:
 async def test_pipeline_runner_shared_context_flow() -> None:
     step1 = Step("a", AddOneAgent())
     step2 = Step("b", AddOneAgent())
-    runner = PipelineRunner(step1 >> step2, context_model=Ctx, initial_context_data={"count": 0})
+    runner = Flujo(step1 >> step2, context_model=Ctx, initial_context_data={"count": 0})
     result = await runner.run_async(1)
     assert result.final_pipeline_context.count == 2
     assert result.step_history[-1].output == 3
@@ -31,6 +31,6 @@ async def test_pipeline_runner_shared_context_flow() -> None:
 async def test_existing_agents_without_context() -> None:
     agent = StubAgent(["ok"])
     step = Step("s", agent)
-    runner = PipelineRunner(step)
+    runner = Flujo(step)
     result = await runner.run_async("hi")
     assert result.step_history[0].output == "ok"

--- a/tests/integration/test_self_improvement.py
+++ b/tests/integration/test_self_improvement.py
@@ -4,7 +4,7 @@ from flujo.application.self_improvement import (
     evaluate_and_improve,
     SelfImprovementAgent,
 )
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.domain import Step
 from flujo.testing.utils import StubAgent
@@ -33,7 +33,7 @@ class DummyAgent:
 async def test_e2e_self_improvement_with_mocked_llm_suggestions():
     agent = StubAgent(["ok"])
     pipeline = Step.solution(agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="hi", expected_output="wrong")])
     report = await evaluate_and_improve(
         lambda x: run_pipeline_async(x, runner=runner),
@@ -48,7 +48,7 @@ async def test_e2e_self_improvement_with_mocked_llm_suggestions():
 async def test_build_context_for_self_improvement_agent():
     from flujo.application.self_improvement import _build_context
     pr = Step.solution(StubAgent(["ok"]))
-    runner = PipelineRunner(pr)
+    runner = Flujo(pr)
     dataset = Dataset(cases=[Case(name="c1", inputs="i", expected_output="o")])
     report = await dataset.evaluate(lambda x: run_pipeline_async(x, runner=runner))
     context = _build_context(report.cases, None)
@@ -67,7 +67,7 @@ async def test_self_improvement_context_includes_config_and_prompts(monkeypatch)
     agent = StubAgent(["ok"])
     agent.system_prompt = "Test prompt"
     pipeline = Step.solution(agent, max_retries=5, timeout_s=30)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="i", expected_output="o")])
 
     await evaluate_and_improve(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,9 +16,9 @@ runner = CliRunner()
 
 @pytest.fixture
 def mock_orchestrator() -> None:
-    """Fixture to mock the Orchestrator and its methods."""
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        mock_instance = MockOrchestrator.return_value
+    """Fixture to mock the Default and its methods."""
+    with patch("flujo.cli.main.Default") as MockDefault:
+        mock_instance = MockDefault.return_value
 
         class DummyCandidate:
             def model_dump(self):
@@ -36,7 +36,7 @@ def test_cli_solve_happy_path(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -55,7 +55,7 @@ def test_cli_solve_custom_models(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -75,7 +75,7 @@ def test_cli_bench_command(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -120,7 +120,7 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
     mock_agent = AsyncMock()
     mock_agent.run.return_value = "mocked agent output"
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
+    with patch("flujo.cli.main.Default") as MockDefault:
         # Create a mock instance with a proper run_sync method
         mock_instance = MagicMock()
         async def mock_run_async(task: Task) -> DummyCandidate:
@@ -130,7 +130,7 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
             return DummyCandidate()
         mock_instance.run_async = mock_run_async
         mock_instance.run_sync = MagicMock(side_effect=lambda task: asyncio.run(mock_run_async(task)))
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
 
         # Patch make_agent_async to return our mock agent
         monkeypatch.setattr(
@@ -166,8 +166,8 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
 
             assert result.exit_code == 0, f"CLI command failed. Output: {result.stdout}, Error: {result.stderr}"
 
-            # Verify Orchestrator was called with correct arguments
-            MockOrchestrator.assert_called_once()
+            # Verify Default was called with correct arguments
+            MockDefault.assert_called_once()
             mock_instance.run_sync.assert_called_once()
             
             # Verify the task passed to run_sync
@@ -218,7 +218,7 @@ def test_cli_solve_keyboard_interrupt(monkeypatch) -> None:
     def raise_keyboard(*args, **kwargs):
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", raise_keyboard)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", raise_keyboard)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -232,7 +232,7 @@ def test_cli_bench_keyboard_interrupt(monkeypatch) -> None:
     def raise_keyboard(*args, **kwargs):
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", raise_keyboard)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", raise_keyboard)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -382,10 +382,10 @@ def test_cli_run() -> None:
         def model_dump(self):
             return {"solution": "test solution", "score": 1.0}
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
+    with patch("flujo.cli.main.Default") as MockDefault:
         mock_instance = MagicMock()
         mock_instance.run_sync.return_value = DummyCandidate()
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
 
         result = runner.invoke(app, ["solve", "test prompt"])
         assert result.exit_code == 0
@@ -410,13 +410,13 @@ def test_cli_run_with_args() -> None:
     dummy_settings.scorer = "ratio"
     dummy_settings.reflection_limit = 1
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator, \
+    with patch("flujo.cli.main.Default") as MockDefault, \
          patch("flujo.cli.main.make_agent_async") as mock_make_agent, \
          patch("flujo.cli.main.get_reflection_agent") as mock_get_reflection_agent, \
          patch("flujo.cli.main.settings", dummy_settings):
         mock_instance = MagicMock()
         mock_instance.run_sync.return_value = DummyCandidate()
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
         mock_make_agent.return_value = MagicMock()
         mock_get_reflection_agent.return_value = MagicMock()
 
@@ -472,8 +472,8 @@ def test_cli_run_with_invalid_retries() -> None:
     from unittest.mock import patch
     from flujo.exceptions import ConfigurationError
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        MockOrchestrator.side_effect = ConfigurationError("Invalid retry settings")
+    with patch("flujo.cli.main.Default") as MockDefault:
+        MockDefault.side_effect = ConfigurationError("Invalid retry settings")
         result = runner.invoke(app, ["solve", "test prompt", "--max-iters", "100"])
         assert result.exit_code == 2
         assert "Configuration Error" in result.stderr
@@ -496,8 +496,8 @@ def test_cli_run_with_invalid_agent_timeout() -> None:
     from unittest.mock import patch
     from flujo.exceptions import ConfigurationError
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        MockOrchestrator.side_effect = ConfigurationError("Invalid agent timeout")
+    with patch("flujo.cli.main.Default") as MockDefault:
+        MockDefault.side_effect = ConfigurationError("Invalid agent timeout")
         result = runner.invoke(app, ["solve", "test prompt"])
         assert result.exit_code == 2
         assert "Configuration Error" in result.stderr


### PR DESCRIPTION
## Summary
- rename PipelineRunner engine to Flujo
- move Orchestrator to recipes.Default
- update CLI and tests for new names
- update docs and README
- bump version to 0.3.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0fce04ac832c93e6867563a82fd9