### PR TITLE
Rename PipelineRunner to Flujo, introduce Default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ provides utilities to manage multi-agent pipelines with minimal setup.
 ## Features
 
 - 📦 **Pydantic Native** – agents, tools, and pipeline context are all defined with Pydantic models for reliable type safety.
-- 🔁 **Opinionated & Flexible** – the `Orchestrator` gives you a ready‑made workflow while the DSL lets you build any pipeline.
+- 🔁 **Opinionated & Flexible** – the `Default` recipe gives you a ready‑made workflow while the DSL lets you build any pipeline.
 - 🏗️ **Production Ready** – retries, telemetry, and quality controls help you ship reliable systems.
 - 🧠 **Intelligent Evals** – automated scoring and self‑improvement powered by LLMs.
 
@@ -23,8 +23,9 @@ pip install flujo
 ### Basic Usage
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task,
+    Task,
     review_agent, solution_agent, validator_agent,
     init_telemetry,
 )
@@ -34,7 +35,7 @@ init_telemetry()
 
 # Assemble an orchestrator with the library-provided agents. The class
 # runs a fixed pipeline: Review -> Solution -> Validate.
-flujo = Orchestrator(
+flujo = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -62,21 +63,21 @@ else:
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 
 # Build a custom pipeline using the Step DSL. This mirrors the internal
-# workflow used by :class:`Orchestrator` but is fully configurable.
+# workflow used by :class:`Default` but is fully configurable.
 custom_pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
     >> Step.validate(validator_agent)
 )
 
-pipeline_runner = PipelineRunner(custom_pipeline)
+pipeline_runner = Flujo(custom_pipeline)
 
-# Run synchronously; PipelineRunner returns a PipelineResult.
+# Run synchronously; Flujo returns a PipelineResult.
 pipeline_result = pipeline_runner.run(
     "Generate a REST API using FastAPI for a to-do list application."
 )

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -4,17 +4,17 @@ This guide provides detailed documentation for all public interfaces in `flujo`.
 
 ## Core Components
 
-### Orchestrator
+### Default Recipe
 
-The `Orchestrator` class is a high-level facade for running a **standard, fixed
+`flujo.recipes.Default` is a high-level facade for running a **standard, fixed
 multi-agent pipeline**: Review -> Solution -> Validate -> Reflection. It uses the agents you
 provide for these roles. For custom pipelines with different logic, see
-`PipelineRunner` and the `Step` DSL.
+`Flujo` and the `Step` DSL.
 
 ```python
-from flujo import Orchestrator
+from flujo.recipes import Default
 
-orchestrator = Orchestrator(
+orchestrator = Default(
     review_agent: AsyncAgentProtocol[Any, Checklist],
     solution_agent: AsyncAgentProtocol[Any, str],
     validator_agent: AsyncAgentProtocol[Any, Checklist],
@@ -35,14 +35,14 @@ result = orchestrator.run_sync(Task(prompt="Generate a poem"))
 candidate = await orchestrator.run_async(Task(prompt="Generate a poem"))
 ```
 
-### Pipeline DSL & `PipelineRunner`
+### Pipeline DSL & `Flujo`
 
 The Pipeline DSL lets you create flexible, custom workflows and execute them
-with `PipelineRunner`.
+with `Flujo`.
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 from pydantic import BaseModel
@@ -63,9 +63,9 @@ custom_pipeline = (
     )
 )
 
-runner = PipelineRunner(custom_pipeline)
+runner = Flujo(custom_pipeline)
 # With a shared typed context
-runner_with_ctx = PipelineRunner(
+runner_with_ctx = Flujo(
     custom_pipeline,
     context_model=MyContext,
     initial_context_data={"counter": 0},
@@ -223,7 +223,7 @@ from flujo import run_pipeline_async, evaluate_and_improve
 # Run pipeline evaluation
 result = await run_pipeline_async(
     inputs: str,                   # Input prompt
-    runner: PipelineRunner,        # Pipeline runner
+    runner: Flujo,                 # Pipeline runner
     **kwargs                       # Additional arguments
 )
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,24 +2,23 @@
 
 This guide explains the fundamental concepts that power `flujo`. Understanding these concepts will help you build more effective AI workflows.
 
-## The Orchestrator
+## The Default Recipe
 
-The **`Orchestrator` class** is a central component that manages a **standard,
+The **`Default` recipe** is a high-level helper that manages a **standard,
 pre-defined AI workflow**. Think of it as a project manager for a specific team
 structure: a Review Agent, a Solution Agent, a Validator Agent, and optionally a
-Reflection Agent. It handles the flow of information between
-these fixed roles, manages retries based on their internal configuration, and
-aims to return the best `Candidate` solution from this standard process.
-For building custom workflows with different steps or logic, you would use the
-`Pipeline` DSL and `PipelineRunner`.
+Reflection Agent. It handles the flow of information between these fixed roles,
+manages retries based on their internal configuration, and returns the best
+`Candidate` from this standard process. For building custom workflows with
+different steps or logic, you would use the `Pipeline` DSL and the `Flujo`
+engine.
 
 ```python
-from flujo import (
-    Orchestrator, review_agent, solution_agent, validator_agent, reflection_agent
-)
+from flujo.recipes import Default
+from flujo import review_agent, solution_agent, validator_agent, reflection_agent
 
-# Assemble the orchestrator with default agents
-flujo = Orchestrator(
+# Assemble the default recipe with the built-in agents
+recipe = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -109,19 +108,19 @@ if result:  # result is a Candidate
 ## The Pipeline DSL
 
 The **Pipeline Domain-Specific Language (DSL)**, using `Step` objects and
-executed by `PipelineRunner`, is the primary way to create **flexible and custom
+executed by `Flujo`, is the primary way to create **flexible and custom
 multi-agent workflows**. This gives you full control over the sequence of
 operations, the agents used at each stage, and the integration of plugins.
 
-`PipelineRunner` can also maintain a shared, typed context object for each run.
+`Flujo` can also maintain a shared, typed context object for each run.
 Steps declare a `pipeline_context` parameter to access or modify this object. See
 [Typed Pipeline Context](pipeline_context.md) for full documentation.
 
-The built-in [**Orchestrator**](#the-orchestrator) uses this DSL under the hood. When you need different logic, you can use the same tools directly. The DSL also supports advanced constructs like [**LoopStep**](pipeline_looping.md) for iteration and [**ConditionalStep**](pipeline_branching.md) for branching workflows.
+The built-in [**Default recipe**](#the-default-recipe) uses this DSL under the hood. When you need different logic, you can use the same tools directly through the `Flujo` engine. The DSL also supports advanced constructs like [**LoopStep**](pipeline_looping.md) for iteration and [**ConditionalStep**](pipeline_branching.md) for branching workflows.
 
 ```python
 from flujo import (
-    Step, PipelineRunner, review_agent, solution_agent, validator_agent
+    Step, Flujo, review_agent, solution_agent, validator_agent
 )
 
 # Define a pipeline
@@ -132,7 +131,7 @@ pipeline = (
 )
 
 # Run it
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 pipeline_result = runner.run("Your prompt here")
 for step_res in pipeline_result.step_history:
     print(f"Step: {step_res.name}, Success: {step_res.success}")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,10 +58,11 @@ You can also configure the orchestrator programmatically:
 ### Basic Configuration
 
 ```python
-from flujo import Orchestrator, Task
+from flujo.recipes import Default
+from flujo import Task
 
-# Create an orchestrator with custom settings
-orch = Orchestrator(
+# Create the default recipe with custom settings
+orch = Default(
     review_agent,
     solution_agent,
     validator_agent,
@@ -125,7 +126,7 @@ agent = make_agent_async(
 ### Step Configuration
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 
 # Configure individual steps
 pipeline = (
@@ -143,7 +144,7 @@ pipeline = (
 
 ```python
 # Configure the pipeline runner
-runner = PipelineRunner(
+runner = Flujo(
     pipeline,
     max_parallel=2,  # Maximum parallel executions
     timeout=60,      # Overall timeout

--- a/docs/documentation_guide.md
+++ b/docs/documentation_guide.md
@@ -136,7 +136,7 @@ This automated process ensures that our documentation is always a perfect reflec
         - Contributing Guide: dev.md
         - Documentation Guide: documentation_guide.md # <-- Add this line
       - API Reference:
-          - Orchestrator: 'flujo.application.orchestrator'
+          - Default: 'flujo.recipes.default'
           # ... other API refs
     ```
 

--- a/docs/documentation_status.md
+++ b/docs/documentation_status.md
@@ -46,7 +46,7 @@ The documentation has been systematically reviewed and updated to reflect the cu
 - ✅ **UPDATED**: Added CLI-based verification steps
 
 #### `docs/api_reference.md` - API Documentation
-- ✅ **UPDATED**: Fixed Orchestrator workflow description (now includes Reflection step)
+- ✅ **UPDATED**: Fixed Default recipe workflow description (now includes Reflection step)
 - ✅ **UPDATED**: Corrected agent type annotations and signatures
 - ✅ **UPDATED**: Updated Pipeline DSL examples with actual API
 - ✅ **UPDATED**: Removed non-existent methods and classes
@@ -95,7 +95,7 @@ All documented CLI commands verified in `flujo/cli/main.py`:
 | `add-eval-case` | ✅ Verified | Add evaluation cases |
 
 ### ✅ Core API Components Verified
-- **Orchestrator Class**: ✅ Confirmed with correct signature including reflection agent
+- **Default Recipe Class**: ✅ Confirmed with correct signature including reflection agent
 - **Pipeline DSL**: ✅ All documented step types and constructs verified
 - **Data Models**: ✅ Task, Candidate, Checklist, ChecklistItem all confirmed
 - **Agents**: ✅ All four default agents confirmed (review, solution, validator, reflection)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -14,7 +14,7 @@ The simplified orchestrator no longer performs reflection automatically. To
 incorporate strategic feedback, build a custom pipeline using `Step`:
 
 ```python
-from flujo import Step, PipelineRunner, review_agent, solution_agent, validator_agent, get_reflection_agent
+from flujo import Step, Flujo, review_agent, solution_agent, validator_agent, get_reflection_agent
 
 reflection_agent = get_reflection_agent(model="anthropic:claude-3-haiku")
 
@@ -25,7 +25,7 @@ pipeline = (
     >> Step.validate(reflection_agent)
 )
 
-result = PipelineRunner(pipeline).run("Write a poem")
+result = Flujo(pipeline).run("Write a poem")
 ```
 
 ### Creating Custom Step Factories with Pre-configured Plugins

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ The `flujo` is a powerful Python library that provides a structured approach to 
 ## Features
 
 - **🔧 Pydantic Native** – Everything from agents to pipeline context is defined with Pydantic models for reliable type safety
-- **🎯 Opinionated & Flexible** – Start with the built-in `Orchestrator` for common patterns or compose custom flows using the Pipeline DSL
+- **🎯 Opinionated & Flexible** – Start with the built-in `Default` recipe for common patterns or compose custom flows using the Pipeline DSL
 - **🚀 Production Ready** – Built-in retries, telemetry, scoring, and quality controls help you deploy reliable systems
 - **🧠 Intelligent Evals** – Automated evaluation and self-improvement powered by LLMs
 - **⚡ High Performance** – Async-first design with efficient concurrent execution
@@ -26,8 +26,9 @@ pip install flujo
 ### Basic Usage
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task,
+    Task,
     review_agent, solution_agent, validator_agent, reflection_agent,
     init_telemetry,
 )
@@ -35,8 +36,8 @@ from flujo import (
 # Initialize telemetry (optional)
 init_telemetry()
 
-# Create orchestrator with default agents
-flujo = Orchestrator(
+# Create the default recipe with built-in agents
+orch = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -70,7 +71,7 @@ flujo improve pipeline.py dataset.py
 
 ## Core Concepts
 
-- **Orchestrator**: High-level coordinator for standard multi-agent workflows
+- **Default recipe**: High-level coordinator for standard multi-agent workflows
 - **Pipeline DSL**: Flexible system for building custom agent workflows
 - **Agents**: Specialized AI models with specific roles (review, solution, validation, reflection)
 - **Tasks**: Input specifications with prompts and metadata
@@ -82,7 +83,7 @@ flujo improve pipeline.py dataset.py
 
 The library follows a clean architecture with clear separation of concerns:
 
-- **Application Layer**: Orchestrator, PipelineRunner, and high-level coordination
+- **Application Layer**: Default recipe, Flujo engine, and high-level coordination
 - **Domain Layer**: Core models, pipeline DSL, and business logic
 - **Infrastructure Layer**: Agents, settings, telemetry, and external integrations
 - **CLI Layer**: Command-line interface for common operations

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,7 +106,8 @@ import flujo
 print(f"Version: {flujo.__version__}")
 
 # Test basic import
-from flujo import Orchestrator, Task
+from flujo.recipes import Default
+from flujo import Task
 print("✅ Installation successful!")
 ```
 

--- a/docs/intelligent_evals.md
+++ b/docs/intelligent_evals.md
@@ -7,13 +7,13 @@ This guide explains how to run automated evaluations and use the self-improvemen
 ```python
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.application.self_improvement import evaluate_and_improve, SelfImprovementAgent
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo import Flujo
 from flujo.domain import Step
 from pydantic_evals import Dataset, Case
 from flujo.infra.agents import self_improvement_agent
 
 pipeline = Step.solution(lambda x: x)
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 dataset = Dataset(cases=[Case(inputs="hi", expected_output="hi")])
 agent = SelfImprovementAgent(self_improvement_agent)
 report = await evaluate_and_improve(

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -1,6 +1,6 @@
 # Typed Pipeline Context
 
-`PipelineRunner` can maintain a mutable Pydantic model instance that is shared across every step during a single run. This feature is sometimes called the *pipeline scratchpad* or *shared context*.
+`Flujo` can maintain a mutable Pydantic model instance that is shared across every step during a single run. This feature is sometimes called the *pipeline scratchpad* or *shared context*.
 
 ## Why use a context?
 
@@ -21,7 +21,7 @@ class MyContext(BaseModel):
 ## Initializing the runner
 
 ```python
-runner = PipelineRunner(
+runner = Flujo(
     pipeline,
     context_model=MyContext,
     initial_context_data={"user_query": "hello"},

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -16,7 +16,7 @@ The Pipeline DSL lets you:
 ### Creating a Pipeline
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 from flujo.infra.agents import (
     review_agent, solution_agent, validator_agent
 )
@@ -29,7 +29,7 @@ pipeline = (
 )
 
 # Run it
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 result = runner.run("Write a function to sort a list")
 ```
 
@@ -174,7 +174,7 @@ pipeline = Step.review(review_agent) >> loop_step >> Step.validate(validator_age
 
 ## Typed Pipeline Context
 
-`PipelineRunner` can share a mutable Pydantic model instance across all steps in
+a `Flujo` runner can share a mutable Pydantic model instance across all steps in
 a single run. Pass a context model when creating the runner and declare
 `pipeline_context` in your step functions or agents. See
 [Typed Pipeline Context](pipeline_context.md) for a full explanation.
@@ -191,7 +191,7 @@ async def increment(data: str, *, pipeline_context: MyContext | None = None) -> 
     return data
 
 pipeline = Step("inc", increment) >> Step("read", increment)
-runner = PipelineRunner(pipeline, context_model=MyContext)
+runner = Flujo(pipeline, context_model=MyContext)
 result = runner.run("hi")
 print(result.final_pipeline_context.counter)  # 2
 ```
@@ -252,7 +252,7 @@ step = Step.solution(
 )
 
 # Configure retries at the pipeline level
-runner = PipelineRunner(
+runner = Flujo(
     pipeline,
     max_retries=3,
     retry_on_error=True
@@ -306,7 +306,7 @@ pipeline = (
 ### Code Generation Pipeline
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 from flujo.plugins import (
     SQLSyntaxValidator,
     CodeStyleValidator
@@ -326,7 +326,7 @@ pipeline = (
 )
 
 # Run it
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 result = runner.run("Write a SQL query to find active users")
 ```
 
@@ -351,7 +351,7 @@ pipeline = (
 )
 
 # Run it
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 result = runner.run("Write a blog post about AI")
 ```
 

--- a/docs/pipeline_looping.md
+++ b/docs/pipeline_looping.md
@@ -50,7 +50,7 @@ loop_step = Step.loop_until(
 
 ```python
 pipeline = Step.solution(agent_a) >> loop_step
-runner = PipelineRunner(pipeline, context_model=Ctx)
+runner = Flujo(pipeline, context_model=Ctx)
 result = runner.run(0)
 print(result.step_history[-1].output)
 print(result.final_pipeline_context.counter)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,8 +29,9 @@ OPENAI_API_KEY=your_key_here
 Create a new file `hello_orchestrator.py`:
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task,
+    Task,
     review_agent, solution_agent, validator_agent, reflection_agent,
     init_telemetry,
 )
@@ -39,7 +40,7 @@ init_telemetry()
 
 # Assemble the orchestrator with the default agents. It runs a fixed
 # Review -> Solution -> Validate -> Reflection workflow.
-flujo = Orchestrator(
+flujo = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -61,9 +62,9 @@ if best_candidate:
             print(f"{status} {item.description}")
 ```
 
-The `Orchestrator` class provides a quick way to run this standard
+The `Default` recipe provides a quick way to run this standard
 multi-agent workflow. For custom pipelines and advanced control, you'll
-use the `PipelineRunner` and `Step` DSL described later.
+use the `Flujo` engine and `Step` DSL described later.
 
 ## 4. Run Your First Orchestration
 
@@ -122,7 +123,7 @@ custom_agent = make_agent_async(
 )
 
 # Use it in your orchestrator
-flujo = Orchestrator(
+flujo = Default(
     review_agent=custom_agent, 
     solution_agent=solution_agent, 
     validator_agent=validator_agent,
@@ -152,18 +153,18 @@ code_agent = make_agent_async(
 
 ```python
 from flujo import (
-    Step, PipelineRunner, Task,
+    Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
 
-# Define a custom pipeline (similar to the Orchestrator workflow)
+# Define a custom pipeline (similar to the Default workflow)
 custom_pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
     >> Step.validate(validator_agent)
 )
 
-runner = PipelineRunner(custom_pipeline)
+runner = Flujo(custom_pipeline)
 
 # The input to `run()` is the prompt for the first step.
 pipeline_result = runner.run("Write a function to sort a list")

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -134,7 +134,7 @@ pipeline = (
 )
 
 # Configure the runner with custom scoring
-runner = PipelineRunner(
+runner = Flujo(
     pipeline,
     scorer=lambda c: weighted_score(c, {
         "review_score": 0.3,
@@ -239,7 +239,7 @@ pipeline = (
 ### Code Generation Scoring
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 from flujo.plugins import (
     SQLSyntaxValidator,
     CodeStyleValidator

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -48,7 +48,7 @@ agent = make_agent_async(
 ### Using Tools in a Pipeline
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 
 # Create a pipeline with tools
 pipeline = (
@@ -61,7 +61,7 @@ pipeline = (
 )
 
 # Run it
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 result = runner.run("What's the weather in Paris?")
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,9 +109,9 @@ This guide helps you resolve common issues when using `flujo`.
 
 2. Verify model configuration:
    ```python
-   from flujo import Orchestrator
-   
-   orchestrator = Orchestrator(
+   from flujo.recipes import Default
+
+   orchestrator = Default(
        model="openai:gpt-4",
        temperature=0.7
    )
@@ -136,7 +136,7 @@ This guide helps you resolve common issues when using `flujo`.
 
 2. Check step configuration:
    ```python
-   from flujo import Step, PipelineRunner
+   from flujo import Step, Flujo
    
    pipeline = (
        Step.review(review_agent)
@@ -209,7 +209,7 @@ This guide helps you resolve common issues when using `flujo`.
 
 3. Optimize configuration:
    ```python
-   orchestrator = Orchestrator(
+   orchestrator = Default(
        model="openai:gpt-4",
        max_tokens=1000,  # Limit token usage
        timeout=30,       # Set reasonable timeout

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,16 +25,17 @@ pip install flujo[bench]
 ## API
 
 ```python
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator, Task, init_telemetry,
+    Flujo, Task, init_telemetry,
     review_agent, solution_agent, validator_agent,
 )
 
 # Initialize telemetry (optional)
 init_telemetry()
 
-# Create an orchestrator with default agents
-orch = Orchestrator(
+# Create the default recipe with built-in agents
+orch = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
@@ -43,26 +44,26 @@ result = orch.run_sync(Task(prompt="Write a poem."))
 print(result)
 ```
 
-The default `Orchestrator` runs a fixed Review -> Solution -> Validate pipeline.
-It does not include a reflection step by default, but you can pass a
+The `Default` recipe runs a fixed Review → Solution → Validate pipeline. It does
+not include a reflection step by default, but you can pass a
 `reflection_agent` to enable one. For fully custom workflows or more complex
-reflection logic, use the `Step` API with `PipelineRunner`.
+reflection logic, use the `Step` API with the `Flujo` engine.
 
 Call `init_telemetry()` once at startup to configure logging and tracing for your application.
 
 ### Pipeline DSL
 
-You can define custom workflows using the `Step` class and execute them with `PipelineRunner`:
+You can define custom workflows using the `Step` class and execute them with `Flujo`:
 
 ```python
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 from flujo.plugins.sql_validator import SQLSyntaxValidator
 from flujo.testing.utils import StubAgent
 
 solution_step = Step.solution(StubAgent(["SELECT FROM"]))
 validate_step = Step.validate(StubAgent([None]), plugins=[SQLSyntaxValidator()])
 pipeline = solution_step >> validate_step
-result = PipelineRunner(pipeline).run("SELECT FROM")
+result = Flujo(pipeline).run("SELECT FROM")
 ```
 
 ## Environment Variables
@@ -92,4 +93,4 @@ Functions like `ratio_score` and `weighted_score` are available for custom workf
 The default orchestrator always returns a score of `1.0`.
 
 ## Reflection
-Add a reflection step by composing your own pipeline with `Step` and running it with `PipelineRunner`.
+Add a reflection step by composing your own pipeline with `Step` and running it with `Flujo`.

--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -6,8 +6,8 @@ Run with:
     OPENAI_API_KEY=sk-... python 00_quickstart.py
 """
 
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator,
     Task,
     review_agent,
     solution_agent,
@@ -15,8 +15,8 @@ from flujo import (
     reflection_agent,
 )
 
-# 1️⃣  Create a default orchestrator (uses GPT-4o for all agents)
-orch = Orchestrator(review_agent, solution_agent, validator_agent, reflection_agent)
+# 1️⃣  Create a default recipe (uses GPT-4o for all agents)
+orch = Default(review_agent, solution_agent, validator_agent, reflection_agent)
 
 # 2️⃣  Wrap your prompt in a Task (metadata optional)
 task = Task(prompt="Write a short motivational haiku about debugging.")

--- a/examples/01_weighted_scoring.py
+++ b/examples/01_weighted_scoring.py
@@ -4,8 +4,8 @@
 Demonstrates **weighted** checklist scoring.  Two items, different weights.
 """
 
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator,
     Task,
     make_agent_async,
     solution_agent,
@@ -49,8 +49,8 @@ task = Task(
     metadata={"weights": weights},
 )
 
-# Create orchestrator with the required agents
-orch = Orchestrator(review_agent, solution_agent, validator_agent, reflection_agent)
+# Create the default recipe with the required agents
+orch = Default(review_agent, solution_agent, validator_agent, reflection_agent)
 
 best = orch.run_sync(task)
 

--- a/examples/02_custom_agents.py
+++ b/examples/02_custom_agents.py
@@ -6,8 +6,8 @@ to save tokens.
 """
 
 from pydantic_ai import Agent
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator,
     Task,
     review_agent,
     validator_agent,
@@ -21,7 +21,7 @@ solution_agent = Agent(
     output_type=str,
 )
 
-orch = Orchestrator(
+orch = Default(
     review_agent=review_agent,  # keep the "review" step on GPT-4o
     solution_agent=solution_agent,  # cheaper generation
     validator_agent=validator_agent,

--- a/examples/03_reward_scorer.py
+++ b/examples/03_reward_scorer.py
@@ -5,8 +5,8 @@ Enable the experimental reward-model scorer (extra LLM judge).
 """
 
 import os
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator,
     Task,
     review_agent,
     solution_agent,
@@ -20,7 +20,7 @@ os.environ["REWARD_ENABLED"] = "true"
 settings.scorer = "reward"
 
 # Create orchestrator with the required agents
-orch = Orchestrator(review_agent, solution_agent, validator_agent, reflection_agent)
+orch = Default(review_agent, solution_agent, validator_agent, reflection_agent)
 
 best = orch.run_sync(Task(prompt="Summarise the Zen of Python in two sentences."))
 print("Reward-model score:", best.score)

--- a/examples/04_batch_processing.py
+++ b/examples/04_batch_processing.py
@@ -11,8 +11,8 @@ CSV schema:
 import csv
 import pathlib
 import time
+from flujo.recipes import Default
 from flujo import (
-    Orchestrator,
     Task,
     review_agent,
     solution_agent,
@@ -24,7 +24,7 @@ INPUT = pathlib.Path("prompts.csv")
 OUTPUT = pathlib.Path("results.csv")
 
 # Create orchestrator with the required agents
-orch = Orchestrator(review_agent, solution_agent, validator_agent, reflection_agent)
+orch = Default(review_agent, solution_agent, validator_agent, reflection_agent)
 
 with INPUT.open() as f_in, OUTPUT.open("w", newline="") as f_out:
     reader = csv.DictReader(f_in)

--- a/examples/05_pipeline_sql.py
+++ b/examples/05_pipeline_sql.py
@@ -4,7 +4,7 @@
 Demonstrates the Pipeline DSL and SQL validator plugin.
 """
 
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 from flujo.plugins.sql_validator import SQLSyntaxValidator
 from flujo.testing.utils import StubAgent
 
@@ -17,7 +17,7 @@ solution_step = Step.solution(solution)
 validation_step = Step.validate(validator, plugins=[SQLSyntaxValidator()])
 
 pipeline = solution_step >> validation_step
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 
 result = runner.run("SELECT FROM")
 for step_result in result.step_history:

--- a/examples/06_typed_context.py
+++ b/examples/06_typed_context.py
@@ -5,7 +5,7 @@ Demonstrates sharing state across steps with Typed Pipeline Context.
 """
 
 from pydantic import BaseModel
-from flujo import Step, PipelineRunner
+from flujo import Step, Flujo
 
 
 class Ctx(BaseModel):
@@ -19,7 +19,7 @@ async def increment(data: str, *, pipeline_context: Ctx | None = None) -> str:
 
 
 pipeline = Step("first", increment) >> Step("second", increment)
-runner = PipelineRunner(pipeline, context_model=Ctx)
+runner = Flujo(pipeline, context_model=Ctx)
 
 result = runner.run("hello")
 print("Final output:", result.step_history[-1].output)

--- a/examples/07_loop_step.py
+++ b/examples/07_loop_step.py
@@ -4,7 +4,7 @@
 Demonstrates using LoopStep for iterative refinement.
 """
 
-from flujo import Step, Pipeline, PipelineRunner
+from flujo import Step, Pipeline, Flujo
 
 
 async def add_exclamation(data: str) -> str:
@@ -20,7 +20,7 @@ loop_step = Step.loop_until(
     max_loops=5,
 )
 
-runner = PipelineRunner(loop_step)
+runner = Flujo(loop_step)
 result = runner.run("hi")
 print("Final output:", result.step_history[-1].output)
 

--- a/examples/08_branch_step.py
+++ b/examples/08_branch_step.py
@@ -4,7 +4,7 @@
 Demonstrates ConditionalStep for routing to different pipelines.
 """
 
-from flujo import Step, Pipeline, PipelineRunner
+from flujo import Step, Pipeline, Flujo
 
 
 def classify(text: str) -> str:
@@ -21,7 +21,7 @@ branch_step = Step.branch_on(
 )
 
 pipeline = Step("classify", classify) >> branch_step
-runner = PipelineRunner(pipeline)
+runner = Flujo(pipeline)
 
 result = runner.run("hello!")
 print("Final output:", result.step_history[-1].output)

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -8,7 +8,8 @@ try:
     __version__ = version("flujo")
 except Exception:
     __version__ = "0.0.0"
-from .application.orchestrator import Orchestrator
+from .application.flujo_engine import Flujo
+from .recipes import Default
 from .infra.settings import settings
 from .infra.telemetry import init_telemetry
 
@@ -20,7 +21,6 @@ from .domain import (
     PluginOutcome,
     ValidationPlugin,
 )
-from .application.pipeline_runner import PipelineRunner
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult
@@ -39,7 +39,8 @@ from .infra.agents import (
 from .exceptions import OrchestratorError, ConfigurationError, SettingsError
 
 __all__ = [
-    "Orchestrator",
+    "Flujo",
+    "Default",
     "Task",
     "Candidate",
     "Checklist",
@@ -49,7 +50,6 @@ __all__ = [
     "StepConfig",
     "PluginOutcome",
     "ValidationPlugin",
-    "PipelineRunner",
     "run_pipeline_async",
     "evaluate_and_improve",
     "SelfImprovementAgent",

--- a/flujo/application/eval_adapter.py
+++ b/flujo/application/eval_adapter.py
@@ -1,15 +1,15 @@
-"""Utilities for integrating PipelineRunner with pydantic-evals."""
+"""Utilities for integrating :class:`Flujo` with pydantic-evals."""
 
 from typing import Any
 
-from .pipeline_runner import PipelineRunner
+from .flujo_engine import Flujo
 from ..domain.models import PipelineResult
 
 
-async def run_pipeline_async(inputs: Any, *, runner: PipelineRunner[Any, Any]) -> PipelineResult:
-    """Adapter to run a PipelineRunner as a pydantic-evals task."""
+async def run_pipeline_async(inputs: Any, *, runner: Flujo[Any, Any]) -> PipelineResult:
+    """Adapter to run a :class:`Flujo` engine as a pydantic-evals task."""
     return await runner.run_async(inputs)
 
 
 # Example usage:
-# runner: PipelineRunner[Any, Any] = PipelineRunner(your_pipeline_or_step)
+# runner: Flujo[Any, Any] = Flujo(your_pipeline_or_step)

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -31,7 +31,7 @@ RunnerInT = TypeVar("RunnerInT")
 RunnerOutT = TypeVar("RunnerOutT")
 
 
-class PipelineRunner(Generic[RunnerInT, RunnerOutT]):
+class Flujo(Generic[RunnerInT, RunnerOutT]):
     """Execute a pipeline sequentially."""
 
     def __init__(

--- a/flujo/cli/main.py
+++ b/flujo/cli/main.py
@@ -18,7 +18,7 @@ from flujo.infra.agents import (
     VALIDATE_SYS,
     get_reflection_agent,
 )
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.application.self_improvement import (
     evaluate_and_improve,
@@ -26,7 +26,7 @@ from flujo.application.self_improvement import (
     ImprovementReport,
 )
 from flujo.domain.models import ImprovementSuggestion
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.infra.settings import settings
 from flujo.exceptions import ConfigurationError, SettingsError
 from flujo.infra.telemetry import init_telemetry, logfire
@@ -160,7 +160,7 @@ def solve(
             AsyncAgentProtocol[Any, str], get_reflection_agent(ref_model)
         )
 
-        orch: Orchestrator = Orchestrator(
+        orch: Default = Default(
             review,
             solution,
             validator,
@@ -240,7 +240,7 @@ def bench(prompt: str, rounds: int = 10) -> None:
         validator_agent = make_agent_async(
             settings.default_validator_model, VALIDATE_SYS, Checklist
         )
-        orch: Orchestrator = Orchestrator(
+        orch: Default = Default(
             review_agent, solution_agent, validator_agent, get_reflection_agent()
         )
         times: List[float] = []
@@ -385,7 +385,7 @@ def improve(
         typer.echo("[red]Invalid pipeline or dataset file", err=True)
         raise typer.Exit(1)
 
-    runner: PipelineRunner = PipelineRunner(pipeline)
+    runner: Flujo = Flujo(pipeline)
     task_fn = functools.partial(run_pipeline_async, runner=runner)
     _agent = make_self_improvement_agent(model=improvement_agent_model)
     agent: SelfImprovementAgent = SelfImprovementAgent(_agent)

--- a/flujo/recipes/__init__.py
+++ b/flujo/recipes/__init__.py
@@ -1,0 +1,3 @@
+from .default import Default
+
+__all__ = ["Default"]

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -1,4 +1,4 @@
-"""Backward-compatible facade over :class:`PipelineRunner`."""
+"""Opinionated default workflow built on top of :class:`Flujo`."""
 
 from __future__ import annotations
 
@@ -7,13 +7,14 @@ from typing import Any, Optional, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for typing only
     from ..infra.agents import AsyncAgentProtocol
+
 from ..domain.pipeline_dsl import Step
 from ..domain.models import Candidate, PipelineResult, Task
-from .pipeline_runner import PipelineRunner
+from ..application.flujo_engine import Flujo
 
 
-class Orchestrator:
-    """Simple wrapper around :class:`PipelineRunner`."""
+class Default:
+    """Pre-configured workflow using the :class:`Flujo` engine."""
 
     def __init__(
         self,
@@ -32,10 +33,10 @@ class Orchestrator:
             >> Step.solution(cast(Any, solution_agent), max_retries=3)
             >> Step.validate_step(cast(Any, validator_agent), max_retries=3)
         )
-        self.runner = PipelineRunner(pipeline)
+        self.flujo_engine = Flujo(pipeline)
 
     async def run_async(self, task: Task) -> Candidate | None:
-        result: PipelineResult = await self.runner.run_async(task.prompt)
+        result: PipelineResult = await self.flujo_engine.run_async(task.prompt)
         if len(result.step_history) < 2:
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # --------------------------------------------------------------------------- #
 [project]
 name            = "flujo"
-version         = "0.2.0" # Version bumped for new features
+version         = "0.3.0" # Version bumped for breaking changes
 description     = "Production-ready orchestration for AI agents, built with Pydantic."
 readme          = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/tests/benchmarks/test_engine_overhead.py
+++ b/tests/benchmarks/test_engine_overhead.py
@@ -1,6 +1,6 @@
 import pytest
 from flujo.domain import Step
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.testing.utils import StubAgent
 
 pytest.importorskip("pytest_benchmark")
@@ -11,7 +11,7 @@ def test_pipeline_runner_overhead(benchmark):
     """Measures the execution time of the runner minus agent time."""
     agent = StubAgent(["output"])
     pipeline = Step("s1", agent) >> Step("s2", agent) >> Step("s3", agent) >> Step("s4", agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
 
     @benchmark
     def run_pipeline():

--- a/tests/e2e/test_e2e_pipelines.py
+++ b/tests/e2e/test_e2e_pipelines.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flujo.domain import Step
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.plugins.sql_validator import SQLSyntaxValidator
 from flujo.testing.utils import StubAgent
 
@@ -13,7 +13,7 @@ async def test_sql_pipeline_with_real_validator():
     solution_step = Step.solution(sql_agent)
     validation_step = Step.validate_step(validator_agent).add_plugin(SQLSyntaxValidator())
     pipeline = solution_step >> validation_step
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     result = await runner.run_async("prompt")
     assert result.step_history[-1].success is False
     assert result.step_history[-1].feedback

--- a/tests/e2e/test_golden_transcript.py
+++ b/tests/e2e/test_golden_transcript.py
@@ -5,7 +5,7 @@ try:
 except Exception:  # pragma: no cover - skip if dependency missing
     vcr = None
     pytest.skip("vcrpy not installed", allow_module_level=True)
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.infra.agents import (
     review_agent,
@@ -34,7 +34,7 @@ def test_golden_transcript():
     Runs a simple end-to-end test against the real OpenAI API (or a recording)
     to ensure the entire orchestration flow produces a valid, scored candidate.
     """
-    orch = Orchestrator(
+    orch = Default(
         review_agent,
         solution_agent,
         validator_agent,

--- a/tests/integration/test_backward_compatibility.py
+++ b/tests/integration/test_backward_compatibility.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.testing.utils import StubAgent
 from flujo.domain.models import Task, Checklist
 
@@ -8,6 +8,6 @@ async def test_orchestrator_init_backward_compatible():
     solution = StubAgent(["sol"])
     validator = StubAgent([Checklist(items=[])])
     reflection = StubAgent([None])
-    orch = Orchestrator(review, solution, validator, reflection)
+    orch = Default(review, solution, validator, reflection)
     result = await orch.run_async(Task(prompt="hi"))
     assert result is None or hasattr(result, "score")

--- a/tests/integration/test_evals_adapter.py
+++ b/tests/integration/test_evals_adapter.py
@@ -1,6 +1,6 @@
 import pytest
 from flujo.application.eval_adapter import run_pipeline_async
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
 from flujo.domain.models import PipelineResult
 from flujo.testing.utils import StubAgent
@@ -11,7 +11,7 @@ from pydantic_evals import Dataset, Case
 async def test_adapter_returns_pipeline_result():
     agent = StubAgent(["ok"])
     pipeline = Step.solution(agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="hi", expected_output="ok")])
 
     report = await dataset.evaluate(lambda x: run_pipeline_async(x, runner=runner))

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.testing.utils import StubAgent
 
@@ -7,7 +7,7 @@ async def test_orchestrator_runs_pipeline():
     review = StubAgent(["checklist"])
     solve = StubAgent(["solution"])
     validate = StubAgent(["validated"])
-    orch = Orchestrator(review, solve, validate, None)
+    orch = Default(review, solve, validate, None)
 
     result = await orch.run_async(Task(prompt="do"))
 

--- a/tests/integration/test_orchestrator_sync.py
+++ b/tests/integration/test_orchestrator_sync.py
@@ -1,4 +1,4 @@
-from flujo.application.orchestrator import Orchestrator
+from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
 from flujo.testing.utils import StubAgent
 
@@ -7,7 +7,7 @@ def test_orchestrator_run_sync():
     review = StubAgent(["c"])
     solve = StubAgent(["s"])
     validate = StubAgent(["v"])
-    orch = Orchestrator(review, solve, validate, None)
+    orch = Default(review, solve, validate, None)
 
     result = orch.run_sync(Task(prompt="x"))
 

--- a/tests/integration/test_pipeline_runner_with_context.py
+++ b/tests/integration/test_pipeline_runner_with_context.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
 from flujo.testing.utils import StubAgent
 
@@ -21,7 +21,7 @@ class AddOneAgent:
 async def test_pipeline_runner_shared_context_flow() -> None:
     step1 = Step("a", AddOneAgent())
     step2 = Step("b", AddOneAgent())
-    runner = PipelineRunner(step1 >> step2, context_model=Ctx, initial_context_data={"count": 0})
+    runner = Flujo(step1 >> step2, context_model=Ctx, initial_context_data={"count": 0})
     result = await runner.run_async(1)
     assert result.final_pipeline_context.count == 2
     assert result.step_history[-1].output == 3
@@ -31,6 +31,6 @@ async def test_pipeline_runner_shared_context_flow() -> None:
 async def test_existing_agents_without_context() -> None:
     agent = StubAgent(["ok"])
     step = Step("s", agent)
-    runner = PipelineRunner(step)
+    runner = Flujo(step)
     result = await runner.run_async("hi")
     assert result.step_history[0].output == "ok"

--- a/tests/integration/test_self_improvement.py
+++ b/tests/integration/test_self_improvement.py
@@ -4,7 +4,7 @@ from flujo.application.self_improvement import (
     evaluate_and_improve,
     SelfImprovementAgent,
 )
-from flujo.application.pipeline_runner import PipelineRunner
+from flujo.application.flujo_engine import Flujo
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.domain import Step
 from flujo.testing.utils import StubAgent
@@ -33,7 +33,7 @@ class DummyAgent:
 async def test_e2e_self_improvement_with_mocked_llm_suggestions():
     agent = StubAgent(["ok"])
     pipeline = Step.solution(agent)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="hi", expected_output="wrong")])
     report = await evaluate_and_improve(
         lambda x: run_pipeline_async(x, runner=runner),
@@ -48,7 +48,7 @@ async def test_e2e_self_improvement_with_mocked_llm_suggestions():
 async def test_build_context_for_self_improvement_agent():
     from flujo.application.self_improvement import _build_context
     pr = Step.solution(StubAgent(["ok"]))
-    runner = PipelineRunner(pr)
+    runner = Flujo(pr)
     dataset = Dataset(cases=[Case(name="c1", inputs="i", expected_output="o")])
     report = await dataset.evaluate(lambda x: run_pipeline_async(x, runner=runner))
     context = _build_context(report.cases, None)
@@ -67,7 +67,7 @@ async def test_self_improvement_context_includes_config_and_prompts(monkeypatch)
     agent = StubAgent(["ok"])
     agent.system_prompt = "Test prompt"
     pipeline = Step.solution(agent, max_retries=5, timeout_s=30)
-    runner = PipelineRunner(pipeline)
+    runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="i", expected_output="o")])
 
     await evaluate_and_improve(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,9 +16,9 @@ runner = CliRunner()
 
 @pytest.fixture
 def mock_orchestrator() -> None:
-    """Fixture to mock the Orchestrator and its methods."""
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        mock_instance = MockOrchestrator.return_value
+    """Fixture to mock the Default and its methods."""
+    with patch("flujo.cli.main.Default") as MockDefault:
+        mock_instance = MockDefault.return_value
 
         class DummyCandidate:
             def model_dump(self):
@@ -36,7 +36,7 @@ def test_cli_solve_happy_path(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -55,7 +55,7 @@ def test_cli_solve_custom_models(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -75,7 +75,7 @@ def test_cli_bench_command(monkeypatch) -> None:
     def dummy_run_sync(self, task):
         return DummyCandidate()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", dummy_run_sync)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", dummy_run_sync)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -120,7 +120,7 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
     mock_agent = AsyncMock()
     mock_agent.run.return_value = "mocked agent output"
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
+    with patch("flujo.cli.main.Default") as MockDefault:
         # Create a mock instance with a proper run_sync method
         mock_instance = MagicMock()
         async def mock_run_async(task: Task) -> DummyCandidate:
@@ -130,7 +130,7 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
             return DummyCandidate()
         mock_instance.run_async = mock_run_async
         mock_instance.run_sync = MagicMock(side_effect=lambda task: asyncio.run(mock_run_async(task)))
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
 
         # Patch make_agent_async to return our mock agent
         monkeypatch.setattr(
@@ -166,8 +166,8 @@ def test_cli_solve_with_weights(monkeypatch) -> None:
 
             assert result.exit_code == 0, f"CLI command failed. Output: {result.stdout}, Error: {result.stderr}"
 
-            # Verify Orchestrator was called with correct arguments
-            MockOrchestrator.assert_called_once()
+            # Verify Default was called with correct arguments
+            MockDefault.assert_called_once()
             mock_instance.run_sync.assert_called_once()
             
             # Verify the task passed to run_sync
@@ -218,7 +218,7 @@ def test_cli_solve_keyboard_interrupt(monkeypatch) -> None:
     def raise_keyboard(*args, **kwargs):
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", raise_keyboard)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", raise_keyboard)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -232,7 +232,7 @@ def test_cli_bench_keyboard_interrupt(monkeypatch) -> None:
     def raise_keyboard(*args, **kwargs):
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr("flujo.cli.main.Orchestrator.run_sync", raise_keyboard)
+    monkeypatch.setattr("flujo.cli.main.Default.run_sync", raise_keyboard)
     monkeypatch.setattr(
         "flujo.cli.main.make_agent_async", lambda *a, **k: object()
     )
@@ -382,10 +382,10 @@ def test_cli_run() -> None:
         def model_dump(self):
             return {"solution": "test solution", "score": 1.0}
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
+    with patch("flujo.cli.main.Default") as MockDefault:
         mock_instance = MagicMock()
         mock_instance.run_sync.return_value = DummyCandidate()
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
 
         result = runner.invoke(app, ["solve", "test prompt"])
         assert result.exit_code == 0
@@ -410,13 +410,13 @@ def test_cli_run_with_args() -> None:
     dummy_settings.scorer = "ratio"
     dummy_settings.reflection_limit = 1
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator, \
+    with patch("flujo.cli.main.Default") as MockDefault, \
          patch("flujo.cli.main.make_agent_async") as mock_make_agent, \
          patch("flujo.cli.main.get_reflection_agent") as mock_get_reflection_agent, \
          patch("flujo.cli.main.settings", dummy_settings):
         mock_instance = MagicMock()
         mock_instance.run_sync.return_value = DummyCandidate()
-        MockOrchestrator.return_value = mock_instance
+        MockDefault.return_value = mock_instance
         mock_make_agent.return_value = MagicMock()
         mock_get_reflection_agent.return_value = MagicMock()
 
@@ -472,8 +472,8 @@ def test_cli_run_with_invalid_retries() -> None:
     from unittest.mock import patch
     from flujo.exceptions import ConfigurationError
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        MockOrchestrator.side_effect = ConfigurationError("Invalid retry settings")
+    with patch("flujo.cli.main.Default") as MockDefault:
+        MockDefault.side_effect = ConfigurationError("Invalid retry settings")
         result = runner.invoke(app, ["solve", "test prompt", "--max-iters", "100"])
         assert result.exit_code == 2
         assert "Configuration Error" in result.stderr
@@ -496,8 +496,8 @@ def test_cli_run_with_invalid_agent_timeout() -> None:
     from unittest.mock import patch
     from flujo.exceptions import ConfigurationError
 
-    with patch("flujo.cli.main.Orchestrator") as MockOrchestrator:
-        MockOrchestrator.side_effect = ConfigurationError("Invalid agent timeout")
+    with patch("flujo.cli.main.Default") as MockDefault:
+        MockDefault.side_effect = ConfigurationError("Invalid agent timeout")
         result = runner.invoke(app, ["solve", "test prompt"])
         assert result.exit_code == 2
         assert "Configuration Error" in result.stderr


### PR DESCRIPTION
## Summary
- rename PipelineRunner engine to Flujo
- move Orchestrator to recipes.Default
- update CLI and tests for new names
- update docs and README
- bump version to 0.3.0
- update remaining docs and examples to use new names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f0fce04ac832c93e6867563a82fd9