### PR TITLE
Implement lifecycle hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,9 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+        additional_dependencies:
+          - pydantic
+          - pydantic-settings
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -78,6 +78,7 @@ runner_with_ctx = Flujo(
     initial_context_data={"counter": 0},
     resources=my_resources,
     usage_limits=UsageLimits(total_cost_usd_limit=10.0),
+    hooks=[my_hook],
 )
 
 # Advanced constructs
@@ -245,6 +246,22 @@ limits = UsageLimits(
     total_tokens_limit: Optional[int] = None,
 )
 ```
+
+### Lifecycle Hooks
+
+You can register callbacks to observe or control pipeline execution.
+
+```python
+from flujo import HookCallable, PipelineAbortSignal
+
+async def my_hook(**kwargs):
+    print("event:", kwargs.get("event_name"))
+
+runner = Flujo(pipeline, hooks=[my_hook])
+```
+
+Hooks receive keyword arguments depending on the event. Raise
+`PipelineAbortSignal` from a hook to stop the run gracefully.
 
 ## Self-Improvement & Evaluation
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -343,6 +343,20 @@ runner = Flujo(pipeline, resources=resources)
 Any agent or plugin can declare a keyword-only argument named `resources` to
 receive this object.
 
+## Lifecycle Hooks
+
+Lifecycle hooks let you run custom code before and after key events such as
+`pre_run`, `post_run`, `pre_step`, `post_step`, and `on_step_failure`.
+
+```python
+async def log_hook(**kwargs):
+    print("event", kwargs.get("event_name"))
+
+runner = Flujo(pipeline, hooks=[log_hook])
+```
+
+Raise `PipelineAbortSignal` from a hook to stop execution.
+
 ## Best Practices
 
 1. **Agent Design**

--- a/docs/cookbook/lifecycle_hooks.md
+++ b/docs/cookbook/lifecycle_hooks.md
@@ -1,0 +1,21 @@
+# Lifecycle Hooks
+
+This cookbook demonstrates how to use lifecycle hooks to observe or modify a pipeline run.
+
+```python
+from flujo import Flujo, Step, PipelineAbortSignal
+
+async def logger_hook(**kwargs):
+    print("event:", kwargs.get("event_name"))
+
+async def abort_on_fail(**kwargs):
+    if kwargs.get("event_name") == "on_step_failure":
+        raise PipelineAbortSignal("aborted from cookbook")
+
+pipeline = Step("s1", agent=MagicMock(return_value="ok"))
+runner = Flujo(pipeline, hooks=[logger_hook, abort_on_fail])
+result = runner.run("hello")
+```
+
+Hooks receive keyword arguments specific to the event. Raising `PipelineAbortSignal`
+terminates the run gracefully.

--- a/docs/migration/v0.3.8.md
+++ b/docs/migration/v0.3.8.md
@@ -1,0 +1,5 @@
+# v0.3.8 Migration Guide
+
+This version adds lifecycle hooks. Existing pipelines continue to work without changes.
+You can now pass a list of hook callables to `Flujo` and react to events like
+`pre_run` or `on_step_failure`. See the cookbook page for details.

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -22,6 +22,7 @@ from .domain import (
     ValidationPlugin,
     AppResources,
 )
+from .domain.types import HookCallable
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult, UsageLimits
@@ -42,6 +43,7 @@ from .exceptions import (
     ConfigurationError,
     SettingsError,
     UsageLimitExceededError,
+    PipelineAbortSignal,
 )
 
 __all__ = [
@@ -62,6 +64,8 @@ __all__ = [
     "SelfImprovementAgent",
     "PipelineResult",
     "StepResult",
+    "HookCallable",
+    "PipelineAbortSignal",
     "settings",
     "init_telemetry",
     "review_agent",

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -12,6 +12,7 @@ from ..exceptions import (
     OrchestratorError,
     PipelineContextInitializationError,
     UsageLimitExceededError,
+    PipelineAbortSignal,
 )
 from ..domain.pipeline_dsl import (
     Pipeline,
@@ -23,6 +24,7 @@ from ..domain.pipeline_dsl import (
 from ..domain.plugins import PluginOutcome
 from ..domain.models import PipelineResult, StepResult, UsageLimits
 from ..domain.resources import AppResources
+from ..domain.types import HookCallable
 
 
 class InfiniteRedirectError(OrchestratorError):
@@ -43,6 +45,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         initial_context_data: Optional[Dict[str, Any]] = None,
         resources: Optional[AppResources] = None,
         usage_limits: Optional[UsageLimits] = None,
+        hooks: Optional[list[HookCallable]] = None,
     ) -> None:
         if isinstance(pipeline, Step):
             pipeline = Pipeline.from_step(pipeline)
@@ -51,6 +54,17 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         self.initial_context_data: Dict[str, Any] = initial_context_data or {}
         self.resources = resources
         self.usage_limits = usage_limits
+        self.hooks = hooks or []
+
+    async def _dispatch_hook(self, event_name: str, **kwargs: Any) -> None:
+        for hook in self.hooks:
+            try:
+                await hook(event_name=event_name, **kwargs)
+            except PipelineAbortSignal:
+                raise
+            except Exception as e:  # noqa: BLE001
+                name = getattr(hook, "__name__", str(hook))
+                logfire.error(f"Error in hook '{name}': {e}")
 
     async def _run_step(
         self,
@@ -505,7 +519,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         data: Optional[RunnerInT] = initial_input
         pipeline_result_obj = PipelineResult()
         try:
+            await self._dispatch_hook(
+                "pre_run",
+                initial_input=initial_input,
+                pipeline_context=current_pipeline_context_instance,
+                resources=self.resources,
+            )
             for step in self.pipeline.steps:
+                await self._dispatch_hook(
+                    "pre_step",
+                    step=step,
+                    step_input=data,
+                    pipeline_context=current_pipeline_context_instance,
+                    resources=self.resources,
+                )
                 with logfire.span(step.name) as span:
                     step_result = await self._run_step(
                         step,
@@ -522,7 +549,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     pipeline_result_obj.step_history.append(step_result)
                     pipeline_result_obj.total_cost_usd += step_result.cost_usd
                     self._check_usage_limits(pipeline_result_obj, span)
-                if not step_result.success:
+                if step_result.success:
+                    await self._dispatch_hook(
+                        "post_step",
+                        step_result=step_result,
+                        pipeline_context=current_pipeline_context_instance,
+                        resources=self.resources,
+                    )
+                else:
+                    await self._dispatch_hook(
+                        "on_step_failure",
+                        step_result=step_result,
+                        pipeline_context=current_pipeline_context_instance,
+                        resources=self.resources,
+                    )
                     logfire.warn(
                         f"Step '{step.name}' failed. Halting pipeline execution."
                     )
@@ -532,17 +572,28 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         except asyncio.CancelledError:
             logfire.info("Pipeline cancelled")
             return pipeline_result_obj
+        except PipelineAbortSignal as e:
+            logfire.info(str(e))
         except UsageLimitExceededError as e:
             if current_pipeline_context_instance is not None:
                 pipeline_result_obj.final_pipeline_context = (
                     current_pipeline_context_instance
                 )
             raise e
-
-        if current_pipeline_context_instance is not None:
-            pipeline_result_obj.final_pipeline_context = (
-                current_pipeline_context_instance
-            )
+        finally:
+            if current_pipeline_context_instance is not None:
+                pipeline_result_obj.final_pipeline_context = (
+                    current_pipeline_context_instance
+                )
+            try:
+                await self._dispatch_hook(
+                    "post_run",
+                    pipeline_result=pipeline_result_obj,
+                    pipeline_context=current_pipeline_context_instance,
+                    resources=self.resources,
+                )
+            except PipelineAbortSignal as e:  # pragma: no cover - avoid masking
+                logfire.info(str(e))
 
         return pipeline_result_obj
 

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -1,8 +1,16 @@
 """Domain layer package."""
 
-from .pipeline_dsl import Step, Pipeline, StepConfig, LoopStep, ConditionalStep, BranchKey
+from .pipeline_dsl import (
+    Step,
+    Pipeline,
+    StepConfig,
+    LoopStep,
+    ConditionalStep,
+    BranchKey,
+)
 from .plugins import PluginOutcome, ValidationPlugin
 from .resources import AppResources
+from .types import HookCallable
 
 __all__ = [
     "Step",
@@ -14,4 +22,5 @@ __all__ = [
     "PluginOutcome",
     "ValidationPlugin",
     "AppResources",
+    "HookCallable",
 ]

--- a/flujo/domain/types.py
+++ b/flujo/domain/types.py
@@ -1,0 +1,9 @@
+"""Shared type aliases for the domain layer."""
+
+from typing import Callable, Coroutine, Any
+
+from .models import PipelineResult, StepResult  # noqa: F401
+from .resources import AppResources  # noqa: F401
+
+# A hook is an async callable that receives keyword arguments.
+HookCallable = Callable[..., Coroutine[Any, Any, None]]

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -60,3 +60,10 @@ class UsageLimitExceededError(OrchestratorError):
     def __init__(self, message: str, result: "PipelineResult") -> None:
         super().__init__(message)
         self.result = result
+
+
+class PipelineAbortSignal(Exception):
+    """Special exception hooks can raise to stop a pipeline gracefully."""
+
+    def __init__(self, message: str = "Pipeline aborted by hook.") -> None:
+        super().__init__(message)

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -164,7 +164,7 @@ def make_agent(
 
     # The Agent constructor's type hints are not strict enough for mypy strict mode.
     # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-    agent: Agent[Any, Any] = Agent(  # type: ignore[call-overload]
+    agent: Agent[Any, Any] = Agent(
         model,
         system_prompt=system_prompt,
         output_type=output_type,
@@ -174,7 +174,9 @@ def make_agent(
     return agent
 
 
-class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]):
+class AsyncAgentWrapper(
+    Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]
+):
     """
     Wraps a pydantic_ai.Agent to provide an asynchronous interface
     with retry and timeout capabilities.
@@ -188,7 +190,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         model_name: str | None = None,
     ) -> None:
         if not isinstance(max_retries, int):
-            raise TypeError(f"max_retries must be an integer, got {type(max_retries).__name__}.")
+            raise TypeError(
+                f"max_retries must be an integer, got {type(max_retries).__name__}."
+            )
         if max_retries < 0:
             raise ValueError("max_retries must be a non-negative integer.")
         if timeout is not None:
@@ -203,7 +207,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         self._timeout_seconds: int | None = (
             timeout if timeout is not None else settings.agent_timeout
         )
-        self._model_name: str | None = model_name or getattr(agent, "model", "unknown_model")
+        self._model_name: str | None = model_name or getattr(
+            agent, "model", "unknown_model"
+        )
 
     async def _run_with_retry(self, *args: Any, **kwargs: Any) -> Any:
         temp = kwargs.pop("temperature", None)
@@ -227,11 +233,13 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
                         self._agent.run(*args, **kwargs),
                         timeout=self._timeout_seconds,
                     )
-                    logfire.info(f"Agent '{self._model_name}' raw response: {raw_agent_response}")
+                    logfire.info(
+                        f"Agent '{self._model_name}' raw response: {raw_agent_response}"
+                    )
 
-                    if isinstance(raw_agent_response, str) and raw_agent_response.startswith(
-                        "Agent failed after"
-                    ):
+                    if isinstance(
+                        raw_agent_response, str
+                    ) and raw_agent_response.startswith("Agent failed after"):
                         raise OrchestratorRetryError(raw_agent_response)
 
                     return raw_agent_response
@@ -265,7 +273,9 @@ def make_agent_async(
     Creates a pydantic_ai.Agent and returns an AsyncAgentWrapper exposing .run_async.
     """
     agent = make_agent(model, system_prompt, output_type)
-    return AsyncAgentWrapper(agent, max_retries=max_retries, timeout=timeout, model_name=model)
+    return AsyncAgentWrapper(
+        agent, max_retries=max_retries, timeout=timeout, model_name=model
+    )
 
 
 class NoOpReflectionAgent(AsyncAgentProtocol[Any, str]):
@@ -323,10 +333,14 @@ def get_reflection_agent(
 
 
 # Create a default instance for convenience and API consistency
-reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = get_reflection_agent()
+reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = (
+    get_reflection_agent()
+)
 
 
-def make_self_improvement_agent(model: str | None = None) -> AsyncAgentWrapper[Any, str]:
+def make_self_improvement_agent(
+    model: str | None = None,
+) -> AsyncAgentWrapper[Any, str]:
     """Create the SelfImprovementAgent."""
     model_name = model or settings.default_self_improvement_model
     return make_agent_async(model_name, SELF_IMPROVE_SYS, str)
@@ -349,7 +363,9 @@ class LoggingReviewAgent(AsyncAgentProtocol[Any, Any]):
         return await self._run_inner(self.agent.run, *args, **kwargs)
 
     async def _run_async(self, *args: Any, **kwargs: Any) -> Any:
-        if hasattr(self.agent, "run_async") and callable(getattr(self.agent, "run_async")):
+        if hasattr(self.agent, "run_async") and callable(
+            getattr(self.agent, "run_async")
+        ):
             return await self._run_inner(self.agent.run_async, *args, **kwargs)
         else:
             return await self.run(*args, **kwargs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,10 @@ nav:
   - Cookbook:
     - 'Using Resources': cookbook/using_resources.md
     - 'Cost Control': cookbook/cost_control.md
+    - 'Lifecycle Hooks': cookbook/lifecycle_hooks.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
+    - 'v0.3.8': migration/v0.3.8.md
   - API Reference:
     - Overview: api_reference.md
     - Pipeline DSL: pipeline_dsl.md

--- a/tests/integration/test_pipeline_hooks.py
+++ b/tests/integration/test_pipeline_hooks.py
@@ -1,0 +1,208 @@
+import pytest
+from unittest.mock import MagicMock
+from flujo import (
+    Flujo,
+    Step,
+    Pipeline,
+    AppResources,
+    UsageLimits,
+)
+from flujo.exceptions import PipelineAbortSignal, UsageLimitExceededError
+from flujo.domain.models import PipelineResult
+from pydantic import BaseModel
+from typing import Any, List, Dict, cast
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+from flujo.testing.utils import StubAgent, DummyPlugin
+from flujo.domain.plugins import PluginOutcome
+from tests.integration.test_usage_governor import FixedMetricAgent
+
+
+class HookResources(AppResources):
+    db: MagicMock
+
+
+class HookContext(BaseModel):
+    call_count: int = 0
+
+
+@pytest.fixture  # type: ignore[misc]
+def call_recorder() -> List[Dict[str, Any]]:
+    return []
+
+
+async def generic_recorder_hook(
+    call_recorder: List[Dict[str, Any]], **kwargs: Any
+) -> None:
+    call_recorder.append(
+        {
+            "event": kwargs.get("event_name"),
+            "keys": sorted(kwargs.keys()),
+        }
+    )
+    if kwargs.get("pipeline_context"):
+        kwargs["pipeline_context"].call_count += 1
+
+
+async def aborting_hook(call_recorder: List[Dict[str, Any]], **kwargs: Any) -> None:
+    if kwargs.get("event_name") == "on_step_failure":
+        call_recorder.append({"event": "on_step_failure_and_abort"})
+        raise PipelineAbortSignal("Aborted from hook")
+
+
+async def erroring_hook(**kwargs: Any) -> None:
+    raise ValueError("Hook failed!")
+
+
+async def post_run_abort_hook(**kwargs: Any) -> None:
+    if kwargs.get("event_name") == "post_run":
+        raise PipelineAbortSignal("abort in post_run")
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_all_hooks_are_called_in_correct_order(
+    call_recorder: List[Dict[str, Any]],
+) -> None:
+    pipeline = Step(
+        "s1",
+        agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok1"])),
+    ) >> Step("s2", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok2"])))
+
+    async def recorder(**kwargs: Any) -> None:
+        await generic_recorder_hook(call_recorder, **kwargs)
+
+    runner = Flujo(pipeline, hooks=[recorder])
+    await runner.run_async("start")
+
+    events = [c["event"] for c in call_recorder]
+    assert events == [
+        "pre_run",
+        "pre_step",
+        "post_step",
+        "pre_step",
+        "post_step",
+        "post_run",
+    ]
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_on_step_failure_hook_is_called(
+    call_recorder: List[Dict[str, Any]],
+) -> None:
+    failing_plugin = DummyPlugin([PluginOutcome(success=False)])
+    pipeline = Step(
+        "s1", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"]))
+    ) >> Step(
+        "s2",
+        agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["bad"])),
+        plugins=[failing_plugin],
+    )
+
+    async def recorder(**kwargs: Any) -> None:
+        await generic_recorder_hook(call_recorder, **kwargs)
+
+    runner = Flujo(pipeline, hooks=[recorder])
+    await runner.run_async("start")
+
+    events = [c["event"] for c in call_recorder]
+    assert events == [
+        "pre_run",
+        "pre_step",
+        "post_step",
+        "pre_step",
+        "on_step_failure",
+        "post_run",
+    ]
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_hook_receives_correct_arguments(
+    call_recorder: List[Dict[str, Any]],
+) -> None:
+    pipeline = Step("s1", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+
+    async def recorder(**kwargs: Any) -> None:
+        await generic_recorder_hook(call_recorder, **kwargs)
+
+    runner = Flujo(pipeline, hooks=[recorder])
+    await runner.run_async("start")
+
+    pre_run_call = next(c for c in call_recorder if c["event"] == "pre_run")
+    assert "initial_input" in pre_run_call["keys"]
+
+    post_step_call = next(c for c in call_recorder if c["event"] == "post_step")
+    assert "step_result" in post_step_call["keys"]
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_pipeline_aborts_gracefully_from_hook(
+    call_recorder: List[Dict[str, Any]],
+) -> None:
+    failing_plugin = DummyPlugin([PluginOutcome(success=False)])
+    pipeline = (
+        Step("s1", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+        >> Step(
+            "s2",
+            agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["bad"])),
+            plugins=[failing_plugin],
+        )
+        >> Step("s3", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["unused"])))
+    )
+
+    runner = Flujo(pipeline, hooks=[aborting_hook])
+    result = await runner.run_async("start")
+
+    assert isinstance(result, PipelineResult)
+    assert len(result.step_history) == 2
+    assert result.step_history[0].success is True
+    assert result.step_history[1].success is False
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_faulty_hook_does_not_crash_pipeline(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pipeline = Step("s1", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(pipeline, hooks=[erroring_hook])
+
+    result = await runner.run_async("start")
+
+    assert result.step_history[0].success is True
+    assert "Error in hook" in caplog.text
+    assert "Hook failed!" in caplog.text
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_hooks_receive_context_and_resources(
+    call_recorder: List[Dict[str, Any]],
+) -> None:
+    pipeline = Step("s1", agent=cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    mock_res = HookResources(db=MagicMock())
+
+    async def recorder(**kwargs: Any) -> None:
+        await generic_recorder_hook(call_recorder, **kwargs)
+
+    runner = Flujo(
+        pipeline,
+        context_model=HookContext,
+        initial_context_data={"call_count": 0},
+        resources=mock_res,
+        hooks=[recorder],
+    )
+    result = await runner.run_async("start")
+
+    post_step_call = next(c for c in call_recorder if c["event"] == "post_step")
+    assert "pipeline_context" in post_step_call["keys"]
+    assert "resources" in post_step_call["keys"]
+    assert isinstance(result.final_pipeline_context, HookContext)
+    assert result.final_pipeline_context.call_count > 0
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_post_run_abort_does_not_mask_errors() -> None:
+    """Abort signal in post_run should not hide UsageLimitExceededError."""
+    limits = UsageLimits(total_cost_usd_limit=0.0, total_tokens_limit=None)
+    pipeline = Pipeline.from_step(Step("metric_step", FixedMetricAgent()))
+    runner = Flujo(pipeline, usage_limits=limits, hooks=[post_run_abort_hook])
+
+    with pytest.raises(UsageLimitExceededError):
+        await runner.run_async(0)


### PR DESCRIPTION
## Summary
- add HookCallable type and PipelineAbortSignal
- integrate hooks into `Flujo` engine
- document lifecycle hooks in API and concepts
- add lifecycle hooks cookbook and migration guide
- add tests for hook callbacks
- configure mypy in pre-commit and fix strict typing errors
- fix post_run abort masking other errors

## Testing
- `pre-commit run --files flujo/application/flujo_engine.py tests/integration/test_pipeline_hooks.py`
- `make test-fast`


------
https://chatgpt.com/codex/tasks/task_e_68503cbfb034832c8b013cda3e367ec6