### PR TITLE
Implement prefixless settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ TELEMETRY_EXPORT_ENABLED=false
 # OTLP_ENDPOINT=https://otlp.example.com
 
 # Default models for orchestrator agents
-ORCH_DEFAULT_SOLUTION_MODEL=openai:gpt-4o
-ORCH_DEFAULT_REVIEW_MODEL=openai:gpt-4o
-ORCH_DEFAULT_VALIDATOR_MODEL=openai:gpt-4o
-ORCH_DEFAULT_REFLECTION_MODEL=openai:gpt-4o
+DEFAULT_SOLUTION_MODEL=openai:gpt-4o
+DEFAULT_REVIEW_MODEL=openai:gpt-4o
+DEFAULT_VALIDATOR_MODEL=openai:gpt-4o
+DEFAULT_REFLECTION_MODEL=openai:gpt-4o

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -318,7 +318,7 @@ print(f"Default solution model: {settings.default_solution_model}")
 print(f"Reflection enabled: {settings.reflection_enabled}")
 
 # Environment variables (in .env file):
-# ORCH_DEFAULT_SOLUTION_MODEL=openai:gpt-4o
+# DEFAULT_SOLUTION_MODEL=openai:gpt-4o
 # REFLECTION_ENABLED=true
 # AGENT_TIMEOUT=60
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,10 +78,10 @@ pip install -e ".[dev]"
    TELEMETRY_EXPORT_ENABLED=false
    
    # Optional: Model overrides
-   ORCH_DEFAULT_SOLUTION_MODEL=openai:gpt-4o
-   ORCH_DEFAULT_REVIEW_MODEL=openai:gpt-4o
-   ORCH_DEFAULT_VALIDATOR_MODEL=openai:gpt-4o
-   ORCH_DEFAULT_REFLECTION_MODEL=openai:gpt-4o
+   DEFAULT_SOLUTION_MODEL=openai:gpt-4o
+   DEFAULT_REVIEW_MODEL=openai:gpt-4o
+   DEFAULT_VALIDATOR_MODEL=openai:gpt-4o
+   DEFAULT_REFLECTION_MODEL=openai:gpt-4o
    ```
 
 ## Verifying Installation

--- a/docs/intelligent_evals.md
+++ b/docs/intelligent_evals.md
@@ -86,7 +86,7 @@ file.
 ## Configuring the Self-Improvement Agent
 
 The model used by the self-improvement agent can be changed via the
-`orch_default_self_improvement_model` setting or overridden at the CLI using
+`default_self_improvement_model` setting or overridden at the CLI using
 `flujo improve --improvement-model MODEL_NAME`.
 ### Interpreting Suggestion Types
 The `suggestion_type` field indicates how you might act on the advice:

--- a/tests/integration/test_settings_validation.py
+++ b/tests/integration/test_settings_validation.py
@@ -7,9 +7,9 @@ def test_invalid_env_vars(monkeypatch):
 
     for k in list(os.environ.keys()):
         if k in {
-            "orch_openai_api_key",
-            "orch_google_api_key",
-            "orch_anthropic_api_key",
+            "ORCH_OPENAI_API_KEY",
+            "ORCH_GOOGLE_API_KEY",
+            "ORCH_ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
         }:
             monkeypatch.delenv(k, raising=False)

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -4,9 +4,6 @@ import asyncio
 from unittest.mock import AsyncMock, patch, MagicMock
 from pydantic import SecretStr
 
-# Ensure environment variable exists before agents are imported
-os.environ.setdefault("orch_openai_api_key", "test-key")
-
 from flujo.infra.agents import (
     AsyncAgentWrapper,
     NoOpReflectionAgent,
@@ -169,10 +166,10 @@ async def test_async_agent_wrapper_agent_failed_string_only() -> None:
 
 
 def test_make_agent_async_injects_key(monkeypatch) -> None:
-    monkeypatch.setenv("orch_openai_api_key", "test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     from flujo.infra import settings as settings_mod
 
-    settings_mod.settings.openai_api_key = SecretStr("test-key")
+    monkeypatch.setattr(settings_mod.settings, "openai_api_key", SecretStr("test-key"))
     from flujo.infra.agents import make_agent_async
 
     wrapper = make_agent_async("openai:gpt-4o", "sys", str)
@@ -180,7 +177,7 @@ def test_make_agent_async_injects_key(monkeypatch) -> None:
 
 
 def test_make_agent_async_missing_key(monkeypatch) -> None:
-    monkeypatch.delenv("orch_anthropic_api_key", raising=False)
+    monkeypatch.delenv("ORCH_ANTHROPIC_API_KEY", raising=False)
     from flujo.infra import settings as settings_mod
 
     settings_mod.settings.anthropic_api_key = None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,8 +2,7 @@ import os
 import asyncio
 from typing import Any
 
-# Ensure API key exists before importing the CLI
-os.environ.setdefault("orch_openai_api_key", "test-key")
+# Tests require an API key; a fixture sets it for each test
 
 from flujo.cli.main import app
 from typer.testing import CliRunner
@@ -12,6 +11,19 @@ import pytest
 import json
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch) -> None:
+    """Ensure OPENAI_API_KEY is present for CLI commands."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    import importlib
+    import flujo.infra.settings as settings_mod
+    importlib.reload(settings_mod)
+    import flujo.infra.agents as agents_mod
+    importlib.reload(agents_mod)
+    import flujo.cli.main as cli_main
+    cli_main.settings = settings_mod.settings
 
 
 @pytest.fixture
@@ -87,7 +99,7 @@ def test_cli_bench_command(monkeypatch) -> None:
 
 
 def test_cli_show_config_masks_secrets(monkeypatch) -> None:
-    monkeypatch.setenv("orch_openai_api_key", "sk-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
     # This requires re-importing settings or running CLI in a subprocess
     # For simplicity, we'll just check the output format.
     result = runner.invoke(app, ["show-config"])

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -55,7 +55,7 @@ def test_reward_scorer_init(monkeypatch) -> None:
     from flujo.domain.scoring import RewardScorer, RewardModelUnavailable
     import flujo.infra.settings as settings_mod
 
-    monkeypatch.setenv("ORCH_REWARD_ENABLED", "true")
+    monkeypatch.setenv("REWARD_ENABLED", "true")
     # --- Test Success Case ---
     enabled_settings = Settings(
         reward_enabled=True,
@@ -79,10 +79,12 @@ def test_reward_scorer_init(monkeypatch) -> None:
         agent_timeout=60,
     )
     monkeypatch.setattr(settings_mod, "settings", enabled_settings)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     RewardScorer()  # Should not raise
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     # --- Test Failure Case (Missing Key) ---
-    monkeypatch.delenv("orch_openai_api_key", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ORCH_OPENAI_API_KEY", raising=False)
     disabled_settings = Settings(
         reward_enabled=True,
@@ -116,7 +118,7 @@ async def test_reward_scorer_returns_float(monkeypatch) -> None:
     from unittest.mock import AsyncMock
     import flujo.infra.settings as settings_mod
 
-    monkeypatch.setenv("ORCH_REWARD_ENABLED", "true")
+    monkeypatch.setenv("REWARD_ENABLED", "true")
     test_settings = Settings(
         reward_enabled=True,
         openai_api_key=SecretStr("sk-test"),
@@ -139,11 +141,13 @@ async def test_reward_scorer_returns_float(monkeypatch) -> None:
         agent_timeout=60,
     )
     monkeypatch.setattr(settings_mod, "settings", test_settings)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     scorer = RewardScorer()
     scorer.agent.run = AsyncMock(return_value=SimpleNamespace(output=0.77))
     result = await scorer.score("x")
     assert result == 0.77
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
 def test_reward_scorer_disabled(monkeypatch) -> None:
@@ -172,6 +176,7 @@ def test_reward_scorer_disabled(monkeypatch) -> None:
         agent_timeout=60,
     )
     monkeypatch.setattr(settings_mod, "settings", test_settings)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     with pytest.raises(FeatureDisabled):
         RewardScorer()
@@ -214,7 +219,7 @@ async def test_reward_scorer_score_no_output(monkeypatch) -> None:
     from unittest.mock import AsyncMock
     import flujo.infra.settings as settings_mod
 
-    monkeypatch.setenv("ORCH_REWARD_ENABLED", "true")
+    monkeypatch.setenv("REWARD_ENABLED", "true")
     test_settings = Settings(
         reward_enabled=True,
         openai_api_key=SecretStr("sk-test"),
@@ -237,11 +242,13 @@ async def test_reward_scorer_score_no_output(monkeypatch) -> None:
         agent_timeout=60,
     )
     monkeypatch.setattr(settings_mod, "settings", test_settings)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     scorer = RewardScorer()
     scorer.agent.run = AsyncMock(side_effect=Exception("LLM failed"))
     result = await scorer.score("x")
     assert result == 0.0
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
 def test_ratio_score_all_passed() -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -4,8 +4,10 @@ import os
 
 
 def test_env_var_precedence(monkeypatch) -> None:
-    monkeypatch.setenv("orch_openai_api_key", "sk-test")
-    monkeypatch.setenv("orch_reflection_enabled", "false")
+    # Legacy API key name should still be honored
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ORCH_OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("REFLECTION_ENABLED", "false")
     s = Settings()
     assert s.openai_api_key.get_secret_value() == "sk-test"
     assert s.reflection_enabled is False
@@ -19,8 +21,16 @@ def test_defaults(monkeypatch) -> None:
     assert s.logfire_api_key is None
 
 
+def test_logfire_legacy_alias(monkeypatch) -> None:
+    monkeypatch.delenv("LOGFIRE_API_KEY", raising=False)
+    monkeypatch.setenv("ORCH_LOGFIRE_API_KEY", "legacy")
+    s = Settings()
+    assert s.logfire_api_key.get_secret_value() == "legacy"
+    assert "orch_logfire" not in s.provider_api_keys
+
+
 def test_missing_api_key_allowed(monkeypatch) -> None:
-    monkeypatch.delenv("orch_openai_api_key", raising=False)
+    monkeypatch.delenv("ORCH_OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     import importlib
     import flujo.infra.settings as settings_mod
@@ -30,10 +40,10 @@ def test_missing_api_key_allowed(monkeypatch) -> None:
     assert isinstance(s, Settings)
 
 
-def test_settings_initialization() -> None:
+def test_settings_initialization(monkeypatch) -> None:
     # Unset env var so constructor value is used
-    os.environ.pop("orch_openai_api_key", None)
-    os.environ.pop("ORCH_OPENAI_API_KEY", None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ORCH_OPENAI_API_KEY", raising=False)
     settings = Settings(
         openai_api_key=SecretStr("test"),
         google_api_key=SecretStr("test"),


### PR DESCRIPTION
## Summary
- drop `orch_` prefix from settings model
- add compatibility aliases for API keys
- update documentation and examples
- adjust tests for new env vars
- fix env var aliases and dynamic key loader
- add test for logfire legacy var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504aff1b08832c9a7e4a52b0a998f7