### PR TITLE
Add benchmark harness integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
 
+  benchmark:
+    name: Run Benchmark Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -e ".[dev,bench]"
+      - name: Run benchmark and save results
+        run: pytest --benchmark-json=benchmark_results.json tests/benchmarks
+
 # Codecov badge (add to README.md or docs/index.md):
 # ![codecov](https://codecov.io/gh/yourorg/flujo/branch/main/graph/badge.svg)
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -108,6 +108,8 @@ make test-e2e                     # or poetry-test-e2e / uv-test-e2e
 # Benchmark Tests
 make test-bench                   # or poetry-test-bench / uv-test-bench
 ```
+Run the benchmark suite to measure the framework's internal overhead and catch
+performance regressions introduced by new code.
 
 > **Note:** Async tests are handled automatically by **pytest-asyncio**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
   "hypothesis",
   "vcrpy",
   "rich",
-  "pytest-benchmark",
   "build",     # Added for package building
   "twine",     # Added for package uploading
 ]
@@ -69,7 +68,10 @@ docs = [
     "mkdocstrings[python]",
 ]
 opentelemetry = ["opentelemetry-sdk>=1.26"]
-bench = ["numpy"]
+bench = [
+    "numpy",
+    "pytest-benchmark>=4.0.0",
+]
 
 # CLI entry point (install adds `flujo` command to PATH)
 [project.scripts]


### PR DESCRIPTION
## Summary
- expose benchmark extras with pytest-benchmark
- run benchmark suite in CI
- document how to run benchmarks

## Testing
- `make test-bench`

------
https://chatgpt.com/codex/tasks/task_e_685067479238832c949e279a0661dba5