### PR TITLE
Fix pydantic-ai compatibility

### DIFF
--- a/tests/integration/test_pydantic_ai_compatibility.py
+++ b/tests/integration/test_pydantic_ai_compatibility.py
@@ -1,0 +1,23 @@
+import pytest
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step
+from flujo.domain.models import Checklist, ChecklistItem
+from flujo.testing.utils import StubAgent
+from flujo.infra.agents import AsyncAgentWrapper
+
+class TypeCheckingAgent:
+    async def run(self, data):
+        assert isinstance(data, dict)
+        return "ok"
+
+@pytest.mark.asyncio
+async def test_pydantic_models_are_serialized_for_agents():
+    first = Step("produce", StubAgent([Checklist(items=[ChecklistItem(description="a")])]))
+    second = Step("consume", AsyncAgentWrapper(TypeCheckingAgent()))
+    pipeline = first >> second
+    runner = Flujo(pipeline)
+
+    result = await runner.run_async(None)
+
+    assert result.step_history[-1].output == "ok"

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -10,6 +10,7 @@ from flujo.infra.agents import (
     get_reflection_agent,
     LoggingReviewAgent,
 )
+from flujo.domain.models import Checklist, ChecklistItem
 
 from flujo.exceptions import OrchestratorRetryError
 from flujo.infra.settings import settings
@@ -293,3 +294,20 @@ def test_make_self_improvement_agent_uses_override_model(monkeypatch) -> None:
 
     make_self_improvement_agent(model="override_model")
     assert called["model"] == "override_model"
+
+
+@pytest.mark.asyncio
+async def test_async_agent_wrapper_serializes_pydantic_input() -> None:
+    mock_agent = AsyncMock()
+    wrapper = AsyncAgentWrapper(mock_agent)
+    checklist = Checklist(items=[ChecklistItem(description="a")])
+    await wrapper.run_async(checklist)
+    mock_agent.run.assert_called_once_with(checklist.model_dump())
+
+
+@pytest.mark.asyncio
+async def test_async_agent_wrapper_passthrough_non_model() -> None:
+    mock_agent = AsyncMock()
+    wrapper = AsyncAgentWrapper(mock_agent)
+    await wrapper.run_async("hi")
+    mock_agent.run.assert_called_once_with("hi")


### PR DESCRIPTION
## Summary
- ensure that pydantic model inputs are serialized before being sent to pydantic-ai agents
- add unit tests for the wrapper serialization behavior
- add integration test covering pydantic model compatibility

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68508675cfe0832c9b93e4ca0693921f