### PR TITLE
Fix pydantic-ai compatibility

### DIFF
--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -10,6 +10,7 @@ from typing import (
     Generic,
 )
 from pydantic_ai import Agent
+from pydantic import BaseModel
 import os
 from flujo.infra.settings import settings
 from flujo.domain.models import Checklist
@@ -220,6 +221,18 @@ class AsyncAgentWrapper(
                 kwargs["generation_kwargs"] = {}
             kwargs["generation_kwargs"]["temperature"] = temp
 
+        # Compatibility shim: pydantic-ai expects serializable dicts for its
+        # internal function-calling message generation, not Pydantic model
+        # instances. We automatically serialize any BaseModel inputs here to
+        # ensure compatibility.
+        processed_args = [
+            arg.model_dump() if isinstance(arg, BaseModel) else arg for arg in args
+        ]
+        processed_kwargs = {
+            key: value.model_dump() if isinstance(value, BaseModel) else value
+            for key, value in kwargs.items()
+        }
+
         retryer = AsyncRetrying(
             reraise=False,
             stop=stop_after_attempt(self._max_retries),
@@ -230,7 +243,7 @@ class AsyncAgentWrapper(
             async for attempt in retryer:
                 with attempt:
                     raw_agent_response = await asyncio.wait_for(
-                        self._agent.run(*args, **kwargs),
+                        self._agent.run(*processed_args, **processed_kwargs),
                         timeout=self._timeout_seconds,
                     )
                     logfire.info(

--- a/tests/integration/test_pydantic_ai_compatibility.py
+++ b/tests/integration/test_pydantic_ai_compatibility.py
@@ -1,0 +1,50 @@
+import pytest
+from pydantic import BaseModel
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step
+from flujo.domain.models import Checklist, ChecklistItem
+from flujo.testing.utils import StubAgent
+from flujo.infra.agents import AsyncAgentWrapper
+
+class TypeCheckingAgent:
+    async def run(self, data):
+        assert isinstance(data, dict)
+        return "ok"
+
+
+class KwargCheckingAgent:
+    async def run(self, data, *, pipeline_context):
+        assert isinstance(pipeline_context, dict)
+        return pipeline_context.get("foo")
+
+@pytest.mark.asyncio
+async def test_pydantic_models_are_serialized_for_agents():
+    first = Step("produce", StubAgent([Checklist(items=[ChecklistItem(description="a")])]))
+    second = Step("consume", AsyncAgentWrapper(TypeCheckingAgent()))
+    pipeline = first >> second
+    runner = Flujo(pipeline)
+
+    result = await runner.run_async(None)
+
+    assert result.step_history[-1].output == "ok"
+
+
+class SimpleContext(BaseModel):
+    foo: str
+
+
+@pytest.mark.asyncio
+async def test_pipeline_context_serialized_for_agent_kwargs():
+    first = Step("produce", StubAgent(["x"]))
+    second = Step("consume", AsyncAgentWrapper(KwargCheckingAgent()))
+    pipeline = first >> second
+    runner = Flujo(
+        pipeline,
+        context_model=SimpleContext,
+        initial_context_data={"foo": "bar"},
+    )
+
+    result = await runner.run_async(None)
+
+    assert result.step_history[-1].output == "bar"


### PR DESCRIPTION
## Summary
- ensure that pydantic model inputs are serialized before being sent to pydantic-ai agents
- add unit tests for the wrapper serialization behavior
- add integration test covering pydantic model compatibility
- handle BaseModel inputs passed via kwargs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68508675cfe0832c9b93e4ca0693921f