### PR TITLE
Implement baseline benchmark harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
   "rich",
   "build",     # Added for package building
   "twine",     # Added for package uploading
+  "pytest-benchmark>=4.0.0",
 ]
 docs = [
     "mkdocs",

--- a/tests/benchmarks/test_engine_overhead.py
+++ b/tests/benchmarks/test_engine_overhead.py
@@ -8,7 +8,8 @@ pytest.importorskip("pytest_benchmark")
 
 @pytest.mark.benchmark(group="engine-overhead")
 def test_pipeline_runner_overhead(benchmark):
-    """Measures the execution time of the runner minus agent time."""
+    """Measures the execution time of the Flujo engine's orchestration logic,
+    minimizing agent execution time by using a fast stub."""
     agent = StubAgent(["output"])
     pipeline = Step("s1", agent) >> Step("s2", agent) >> Step("s3", agent) >> Step("s4", agent)
     runner = Flujo(pipeline)


### PR DESCRIPTION
## Summary
- include `pytest-benchmark` in dev extras
- clarify the overhead benchmark test

## Testing
- `make test-bench`
- `make test-fast`


------
https://chatgpt.com/codex/tasks/task_e_6850a4a2ee78832c9abb732111a13f7d