### PR TITLE
Drop StepFactory usage

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -64,7 +64,7 @@ custom_pipeline = (
         solution_agent,
         tools=[tool1, tool2]       # Optional tools
     )
-    >> Step.validate(              # Validation step
+    >> Step.validate_step(              # Validation step
         validator_agent,
         plugins=[plugin1]          # Optional validation plugins
     )
@@ -84,7 +84,7 @@ runner_with_ctx = Flujo(
 # Advanced constructs
 looping_step = Step.loop_until(
     name="refinement_loop",
-    loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
+loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
     exit_condition_callable=lambda out, ctx: "done" in out.lower(),
 )
 
@@ -94,7 +94,7 @@ router = Step.branch_on(
     condition_callable=lambda out, ctx: "code" if "function" in out else "text",
     branches={
         "code": Pipeline.from_step(Step.solution(solution_agent)),
-        "text": Pipeline.from_step(Step.validate(validator_agent)),
+        "text": Pipeline.from_step(Step.validate_step(validator_agent)),
     },
 )
 ```

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -25,7 +25,7 @@ from flujo.infra.agents import (
 pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
-    >> Step.validate(validator_agent)
+    >> Step.validate_step(validator_agent)
 )
 
 # Run it
@@ -41,7 +41,7 @@ The `>>` operator chains steps together:
 # Create reusable steps
 review_step = Step.review(review_agent)
 solution_step = Step.solution(solution_agent)
-validate_step = Step.validate(validator_agent)
+validate_step = Step.validate_step(validator_agent)
 
 # Compose them in different ways
 pipeline1 = review_step >> solution_step >> validate_step
@@ -113,7 +113,7 @@ Validation steps verify the solution:
 
 ```python
 # Basic validation
-validate_step = Step.validate(validator_agent)
+validate_step = Step.validate_step(validator_agent)
 
 # With custom scoring
 from flujo import weighted_score
@@ -123,7 +123,7 @@ weights = {
     "readability": 0.4
 }
 
-validate_step = Step.validate(
+validate_step = Step.validate_step(
     validator_agent,
     scorer=lambda c: weighted_score(c, weights)
 )
@@ -131,7 +131,7 @@ validate_step = Step.validate(
 # With plugins
 from flujo.plugins import SQLSyntaxValidator
 
-validate_step = Step.validate(
+validate_step = Step.validate_step(
     validator_agent,
     plugins=[SQLSyntaxValidator()]
 )
@@ -153,7 +153,7 @@ pipeline = (
         Step.solution(solution_agent),
         Step.solution(alternative_agent)
     )
-    >> Step.validate(validator_agent)
+    >> Step.validate_step(validator_agent)
 )
 ```
 
@@ -169,7 +169,7 @@ loop_step = Step.loop_until(
     exit_condition_callable=lambda out, ctx: "done" in out,
 )
 
-pipeline = Step.review(review_agent) >> loop_step >> Step.validate(validator_agent)
+pipeline = Step.review(review_agent) >> loop_step >> Step.validate_step(validator_agent)
 ```
 
 ## Typed Pipeline Context
@@ -231,7 +231,7 @@ branch_step = Step.branch_on(
     },
 )
 
-pipeline = Step.solution(solution_agent) >> branch_step >> Step.validate(validator_agent)
+pipeline = Step.solution(solution_agent) >> branch_step >> Step.validate_step(validator_agent)
 ```
 
 ### Custom Step Factories
@@ -249,7 +249,7 @@ def create_code_step(agent, **config):
 pipeline = (
     Step.review(review_agent)
     >> create_code_step(solution_agent)
-    >> Step.validate(validator_agent)
+    >> Step.validate_step(validator_agent)
 )
 ```
 
@@ -286,7 +286,7 @@ pipeline = (
         Step.solution(backup_agent),
         on_error=True
     )
-    >> Step.validate(validator_agent)
+    >> Step.validate_step(validator_agent)
 )
 ```
 
@@ -331,7 +331,7 @@ from flujo.plugins import (
 pipeline = (
     Step.review(review_agent)  # Define requirements
     >> Step.solution(code_agent)  # Generate code
-    >> Step.validate(
+    >> Step.validate_step(
         validator_agent,
         plugins=[
             SQLSyntaxValidator(),
@@ -355,7 +355,7 @@ pipeline = (
         Step.solution(writer_agent),  # Main writer
         Step.solution(editor_agent)   # Alternative version
     )
-    >> Step.validate(
+    >> Step.validate_step(
         validator_agent,
         scorer=lambda c: weighted_score(c, {
             "grammar": 0.3,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -161,7 +161,7 @@ from flujo import (
 custom_pipeline = (
     Step.review(review_agent)
     >> Step.solution(solution_agent)
-    >> Step.validate(validator_agent)
+    >> Step.validate_step(validator_agent)
 )
 
 runner = Flujo(custom_pipeline)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -134,7 +134,7 @@ validator_agent_for_extraction = make_agent_async("openai:gpt-4o", VALIDATE_PROM
 data_extraction_pipeline = (
     Step.review(review_agent_for_extraction, name="PlanExtraction")
     >> Step.solution(extraction_agent, name="ExtractContactInfo")
-    >> Step.validate(validator_agent_for_extraction, name="ValidateCard")
+    >> Step.validate_step(validator_agent_for_extraction, name="ValidateCard")
 )
 
 pipeline_runner = Flujo(data_extraction_pipeline)
@@ -267,7 +267,7 @@ from flujo.plugins.sql_validator import SQLSyntaxValidator
 from flujo.testing.utils import StubAgent
 
 sql_step = Step.solution(StubAgent(["SELECT FROM"]))
-check_step = Step.validate(StubAgent([None]), plugins=[SQLSyntaxValidator()])
+check_step = Step.validate_step(StubAgent([None]), plugins=[SQLSyntaxValidator()])
 runner = Flujo(sql_step >> check_step)
 result = runner.run("SELECT FROM")
 print(result.step_history[-1].feedback)

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -21,13 +21,6 @@ StepInT = TypeVar("StepInT")
 StepOutT = TypeVar("StepOutT")
 NewOutT = TypeVar("NewOutT")
 
-SF_InT = TypeVar("SF_InT")
-SF_OutT = TypeVar("SF_OutT")
-ReviewOutT = TypeVar("ReviewOutT")
-SolInT = TypeVar("SolInT")
-SolOutT = TypeVar("SolOutT")
-ValInT = TypeVar("ValInT")
-ValOutT = TypeVar("ValOutT")
 
 # BranchKey type alias for ConditionalStep
 BranchKey = Any
@@ -162,38 +155,6 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             branch_output_mapper=branch_output_mapper,
             **config_kwargs,
         )
-
-
-class StepFactory:
-    @staticmethod
-    def create(
-        name: str,
-        agent: AsyncAgentProtocol[SF_InT, SF_OutT],
-        **config: Any,
-    ) -> Step[SF_InT, SF_OutT]:
-        """Create a fully configured :class:`Step`."""
-        return Step[SF_InT, SF_OutT](name, agent, **config)
-
-    @classmethod
-    def review(
-        cls, agent: AsyncAgentProtocol[Any, ReviewOutT], **config: Any
-    ) -> Step[Any, ReviewOutT]:
-        """Construct a review step using the provided agent."""
-        return cls.create("review", agent, **config)
-
-    @classmethod
-    def solution(
-        cls, agent: AsyncAgentProtocol[SolInT, SolOutT], **config: Any
-    ) -> Step[SolInT, SolOutT]:
-        """Construct a solution step using the provided agent."""
-        return cls.create("solution", agent, **config)
-
-    @classmethod
-    def validate(
-        cls, agent: AsyncAgentProtocol[ValInT, ValOutT], **config: Any
-    ) -> Step[ValInT, ValOutT]:
-        """Construct a validation step using the provided agent."""
-        return cls.create("validate", agent, **config)
 
 
 class LoopStep(Step[Any, Any]):
@@ -349,7 +310,6 @@ __all__ = [
     "Step",
     "Pipeline",
     "StepConfig",
-    "StepFactory",
     "LoopStep",
     "ConditionalStep",
     "BranchKey",

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -39,9 +39,15 @@ class Default:
     ) -> None:
         _ = reflection_agent, max_iters, k_variants, reflection_limit
 
-        step_review = Step.review(self._wrap_review_agent(review_agent), max_retries=3)
-        step_solution = Step.solution(self._wrap_solution_agent(solution_agent), max_retries=3)
-        step_validate = Step.validate_step(self._wrap_validator_agent(validator_agent), max_retries=3)
+        step_review = Step.review(
+            self._wrap_review_agent(review_agent), max_retries=3
+        )
+        step_solution = Step.solution(
+            self._wrap_solution_agent(solution_agent), max_retries=3
+        )
+        step_validate = Step.validate_step(
+            self._wrap_validator_agent(validator_agent), max_retries=3
+        )
 
         pipeline = step_review >> step_solution >> step_validate
         self.flujo_engine = Flujo(pipeline, context_model=Default.Context)

--- a/tests/integration/test_pipeline_runner.py
+++ b/tests/integration/test_pipeline_runner.py
@@ -60,14 +60,15 @@ async def test_conditional_redirection() -> None:
     assert fixit.call_count == 1
 
 
-async def test_on_failure_called() -> None:
+async def test_on_failure_called_with_fluent_api() -> None:
     agent = StubAgent(["out"])
     plugin = DummyPlugin([PluginOutcome(success=False)])
     handler = Mock()
-    step = Step("s", agent, max_retries=1, plugins=[plugin])
-    step.on_failure(handler)
+
+    step = Step("s", agent, max_retries=1, plugins=[plugin]).on_failure(handler)
     runner = Flujo(step)
     await runner.run_async("prompt")
+
     handler.assert_called_once()
 
 

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -1,5 +1,6 @@
 from flujo.domain import Step, Pipeline
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
+from flujo.domain.plugins import ValidationPlugin
 
 
 def test_step_chaining_operator() -> None:
@@ -56,3 +57,54 @@ def test_dsl_with_agent_and_step() -> None:
     assert pipeline.steps[0].agent is step.agent
     assert pipeline.steps[1].name == "validate"
     assert pipeline.steps[1].agent is agent
+
+
+def test_step_class_methods_create_correct_steps() -> None:
+    agent = MagicMock()
+
+    review_step = Step.review(agent)
+    assert isinstance(review_step, Step)
+    assert review_step.name == "review"
+    assert review_step.agent is agent
+
+    solution_step = Step.solution(agent, max_retries=5)
+    assert solution_step.name == "solution"
+    assert solution_step.config.max_retries == 5
+
+    validate_step = Step.validate_step(agent)
+    assert validate_step.name == "validate"
+
+
+def test_step_fluent_builder_methods() -> None:
+    agent = MagicMock()
+    plugin1 = MagicMock(spec=ValidationPlugin)
+    plugin2 = MagicMock(spec=ValidationPlugin)
+    handler1 = Mock()
+    handler2 = Mock()
+
+    step = (
+        Step("test_step", agent)
+        .add_plugin(plugin1)
+        .add_plugin(plugin2, priority=10)
+        .on_failure(handler1)
+        .on_failure(handler2)
+    )
+
+    assert isinstance(step, Step)
+    assert len(step.plugins) == 2
+    assert step.plugins[0] == (plugin1, 0)
+    assert step.plugins[1] == (plugin2, 10)
+    assert len(step.failure_handlers) == 2
+    assert step.failure_handlers == [handler1, handler2]
+
+
+def test_step_init_handles_mixed_plugin_formats() -> None:
+    agent = MagicMock()
+    plugin1 = MagicMock(spec=ValidationPlugin)
+    plugin2 = MagicMock(spec=ValidationPlugin)
+
+    step = Step("test_init", agent, plugins=[plugin1, (plugin2, 5)])
+
+    assert len(step.plugins) == 2
+    assert step.plugins[0] == (plugin1, 0)
+    assert step.plugins[1] == (plugin2, 5)


### PR DESCRIPTION
## Summary
- remove `StepFactory` and revert to class methods on `Step`
- update default recipe to use `Step` helpers
- fix docs for fluent step configuration without `StepFactory`
- adjust tests to check `Step` class methods

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850a900af6c832cb92f56d262de34ee