### PR TITLE
Implement base HITL features

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -88,6 +88,12 @@ loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
     exit_condition_callable=lambda out, ctx: "done" in out.lower(),
 )
 
+# Pause for human input
+approval_step = Step.human_in_the_loop(
+    name="approval",
+    message_for_user="Is the draft acceptable?",
+)
+
 # Conditional branching
 router = Step.branch_on(
     name="router",
@@ -232,6 +238,19 @@ pipeline_result = PipelineResult(
     total_cost_usd: float = 0.0,          # Total cost
     final_pipeline_context: Optional[BaseModel] = None,  # Final context
 )
+
+### PipelineContext
+
+Each run gets a `PipelineContext` with:
+
+- `run_id`: unique identifier
+- `initial_prompt`: the first input
+- `scratchpad`: a mutable dictionary for agents
+- `hitl_history`: list of `HumanInteraction` records
+
+### Resuming a Paused Pipeline
+
+Use `Flujo.resume_async(paused_result, human_input)` to continue after a `HumanInTheLoopStep`.
 ```
 
 ### UsageLimits

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -116,6 +116,10 @@ operations, the agents used at each stage, and the integration of plugins.
 Steps declare a `pipeline_context` parameter to access or modify this object. See
 [Typed Pipeline Context](pipeline_context.md) for full documentation.
 
+## The Pipeline Context: Built-in Memory
+
+Every run automatically receives a `PipelineContext` instance. It includes a `run_id`, the initial prompt, a mutable `scratchpad` dictionary and a record of all human interactions (`hitl_history`). This allows agents to share state without additional setup.
+
 The built-in [**Default recipe**](#the-default-recipe) uses this DSL under the hood. When you need different logic, you can use the same tools directly through the `Flujo` engine. The DSL also supports advanced constructs like [**LoopStep**](pipeline_looping.md) for iteration and [**ConditionalStep**](pipeline_branching.md) for branching workflows.
 
 ```python
@@ -185,6 +189,10 @@ router_step = Step.branch_on(
     },
 )
 ```
+
+#### Human-in-the-Loop Steps
+
+Use `Step.human_in_the_loop()` to pause execution and wait for structured human input. The step optionally validates the response with a Pydantic model and all interactions are saved to the `PipelineContext`.
 
 ## Scoring
 

--- a/docs/cookbook/hitl_dynamic_clarification.md
+++ b/docs/cookbook/hitl_dynamic_clarification.md
@@ -1,0 +1,11 @@
+# Cookbook: Dynamic Clarification
+
+Let an earlier step produce the question for the human by omitting `message_for_user`.
+
+```python
+pipeline = Step("ask", StubAgent(["Is this ok?"])) >> Step.human_in_the_loop("clarify")
+runner = Flujo(pipeline)
+result = await runner.run_async("hello")
+# display pause message from context and resume
+result = await runner.resume_async(result, "sure")
+```

--- a/docs/cookbook/hitl_simple_approval.md
+++ b/docs/cookbook/hitl_simple_approval.md
@@ -1,0 +1,14 @@
+# Cookbook: Simple Human Approval
+
+Use a `HumanInTheLoopStep` to pause a pipeline until a person approves the result.
+
+```python
+from flujo import Step, Pipeline, Flujo
+
+pipeline = Step("draft", StubAgent(["draft text"])) >> Step.human_in_the_loop("approve", message_for_user="Approve the draft?")
+runner = Flujo(pipeline)
+result = await runner.run_async("start")
+# show result.final_pipeline_context.scratchpad["pause_message"] to the user
+# then resume
+result = await runner.resume_async(result, "yes")
+```

--- a/docs/cookbook/hitl_stateful_correction_loop.md
+++ b/docs/cookbook/hitl_stateful_correction_loop.md
@@ -1,0 +1,17 @@
+# Cookbook: Stateful Correction Loop
+
+Combine `LoopStep` with human input to allow bounded multi-turn corrections.
+
+```python
+loop_body = Step("draft", StubAgent(["bad", "good"])) >> Step.human_in_the_loop("fix")
+loop = Step.loop_until(
+    name="correction",
+    loop_body_pipeline=Pipeline.from_step(loop_body),
+    exit_condition_callable=lambda out, ctx: out == "ok",
+    max_loops=2,
+)
+runner = Flujo(loop)
+paused = await runner.run_async("start")
+paused = await runner.resume_async(paused, "not ok")
+final = await runner.resume_async(paused, "ok")
+```

--- a/docs/cookbook/hitl_structured_input.md
+++ b/docs/cookbook/hitl_structured_input.md
@@ -1,0 +1,16 @@
+# Cookbook: Structured Human Input
+
+Validate human input against a Pydantic model for robustness.
+
+```python
+class Answer(BaseModel):
+    choice: int
+
+step = Step.human_in_the_loop("pick", input_schema=Answer)
+pipeline = Step("start", StubAgent(["Q"])) >> step
+runner = Flujo(pipeline)
+paused = await runner.run_async("x")
+# paused.final_pipeline_context.scratchpad["pause_message"] has the question
+resumed = await runner.resume_async(paused, {"choice": 1})
+assert isinstance(resumed.step_history[-1].output, Answer)
+```

--- a/examples/09_human_in_the_loop.py
+++ b/examples/09_human_in_the_loop.py
@@ -1,0 +1,21 @@
+"""Demonstrates pausing a pipeline for human input."""
+import asyncio
+from typing import Any
+from flujo import Flujo, Step
+from flujo.testing.utils import StubAgent
+
+
+async def main() -> None:
+    pipeline = Step("draft", StubAgent(["A short draft"])) >> Step.human_in_the_loop(
+        "approval", message_for_user="Approve draft?"
+    )
+    runner = Flujo(pipeline)
+    result = await runner.run_async("start")
+    msg = result.final_pipeline_context.scratchpad.get("pause_message")
+    print(f"Pipeline paused with message: {msg}")
+    resumed = await runner.resume_async(result, "yes")
+    print("Final output:", resumed.step_history[-1].output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -1,7 +1,9 @@
 """Domain models for flujo."""
 
-from typing import Any, List, Optional, Literal
+from typing import Any, List, Optional, Literal, Dict
 from pydantic import BaseModel, Field
+from datetime import datetime
+import uuid
 from enum import Enum
 
 
@@ -16,12 +18,8 @@ class ChecklistItem(BaseModel):
     """A single item in a checklist for evaluating a solution."""
 
     description: str = Field(..., description="The criterion to evaluate.")
-    passed: Optional[bool] = Field(
-        None, description="Whether the solution passes this criterion."
-    )
-    feedback: Optional[str] = Field(
-        None, description="Feedback if the criterion is not met."
-    )
+    passed: Optional[bool] = Field(None, description="Whether the solution passes this criterion.")
+    feedback: Optional[str] = Field(None, description="Feedback if the criterion is not met.")
 
 
 class Checklist(BaseModel):
@@ -76,9 +74,7 @@ class PipelineResult(BaseModel):
     total_cost_usd: float = 0.0
     final_pipeline_context: Optional[BaseModel] = Field(
         default=None,
-        description=(
-            "The final state of the typed pipeline context, if configured and used."
-        ),
+        description=("The final state of the typed pipeline context, if configured and used."),
     )
 
     model_config = {"arbitrary_types_allowed": True}
@@ -157,3 +153,22 @@ class ImprovementReport(BaseModel):
     """Aggregated improvement suggestions returned by the agent."""
 
     suggestions: list[ImprovementSuggestion] = Field(default_factory=list)
+
+
+class HumanInteraction(BaseModel):
+    """Records a single human interaction in a HITL conversation."""
+
+    message_to_human: str
+    human_response: Any
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class PipelineContext(BaseModel):
+    """A built-in context object shared across the pipeline run."""
+
+    run_id: str = Field(default_factory=lambda: f"run_{uuid.uuid4().hex}")
+    initial_prompt: str
+    scratchpad: Dict[str, Any] = Field(default_factory=dict)
+    hitl_history: List[HumanInteraction] = Field(default_factory=list)
+
+    model_config = {"arbitrary_types_allowed": True}

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -11,6 +11,7 @@ from typing import (
     Sequence,
     TypeVar,
     Dict,
+    Type,
 )
 from pydantic import BaseModel, Field, ConfigDict
 from .agent_protocol import AsyncAgentProtocol
@@ -94,6 +95,20 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
         """Construct a validation step using the provided agent."""
         return cls("validate", agent, **config)
 
+    @classmethod
+    def human_in_the_loop(
+        cls,
+        name: str,
+        message_for_user: str | None = None,
+        input_schema: Type[BaseModel] | None = None,
+    ) -> "HumanInTheLoopStep":
+        """Create a step that pauses execution for human input."""
+        return HumanInTheLoopStep(
+            name=name,
+            message_for_user=message_for_user,
+            input_schema=input_schema,
+        )
+
     def add_plugin(self, plugin: ValidationPlugin, priority: int = 0) -> "Step[StepInT, StepOutT]":
         """Add a validation plugin to this step."""
         self.plugins.append((plugin, priority))
@@ -154,6 +169,34 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             branch_input_mapper=branch_input_mapper,
             branch_output_mapper=branch_output_mapper,
             **config_kwargs,
+        )
+
+
+class HumanInTheLoopStep(Step[Any, Any]):
+    """A step that pauses the pipeline for human input."""
+
+    message_for_user: str | None = Field(default=None)
+    input_schema: Type[BaseModel] | None = Field(default=None)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        message_for_user: str | None = None,
+        input_schema: Type[BaseModel] | None = None,
+        **config: Any,
+    ) -> None:
+        BaseModel.__init__(
+            self,
+            name=name,
+            agent=None,
+            config=StepConfig(**config),
+            plugins=[],
+            failure_handlers=[],
+            message_for_user=message_for_user,
+            input_schema=input_schema,
         )
 
 
@@ -312,5 +355,6 @@ __all__ = [
     "StepConfig",
     "LoopStep",
     "ConditionalStep",
+    "HumanInTheLoopStep",
     "BranchKey",
 ]

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -67,3 +67,10 @@ class PipelineAbortSignal(Exception):
 
     def __init__(self, message: str = "Pipeline aborted by hook.") -> None:
         super().__init__(message)
+
+
+class PausedException(Exception):
+    """Internal exception used to pause a pipeline."""
+
+    def __init__(self, message: str = "Pipeline paused for human input.") -> None:
+        super().__init__(message)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,10 @@ nav:
     - 'Controlling Costs': cookbook/cost_control.md
     - 'Lifecycle Hooks': cookbook/lifecycle_hooks.md
     - 'Using Resources': cookbook/using_resources.md
+    - 'HITL Simple Approval': cookbook/hitl_simple_approval.md
+    - 'HITL Dynamic Clarification': cookbook/hitl_dynamic_clarification.md
+    - 'HITL Structured Input': cookbook/hitl_structured_input.md
+    - 'HITL Correction Loop': cookbook/hitl_stateful_correction_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
     - 'v0.3.8': migration/v0.3.8.md

--- a/tests/integration/test_hitl_pipeline.py
+++ b/tests/integration/test_hitl_pipeline.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain.pipeline_dsl import Step, Pipeline
+from flujo.domain.models import PipelineContext
+from flujo.testing.utils import StubAgent
+
+
+@pytest.mark.asyncio
+async def test_static_approval_pause_and_resume() -> None:
+    pipeline = Step("first", StubAgent(["draft"])) >> Step.human_in_the_loop(
+        "approve", message_for_user="OK?"
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("in")
+    ctx = paused.final_pipeline_context
+    assert isinstance(ctx, PipelineContext)
+    assert ctx.scratchpad["status"] == "paused"
+    assert ctx.scratchpad["pause_message"] == "OK?"
+    resumed = await runner.resume_async(paused, "yes")
+    assert resumed.step_history[-1].output == "yes"
+    assert ctx.scratchpad["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_clarification_pause_and_resume() -> None:
+    pipeline = Step("ask", StubAgent(["Need help?"])) >> Step.human_in_the_loop(
+        "clarify"
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("hi")
+    ctx = paused.final_pipeline_context
+    assert ctx.scratchpad["pause_message"] == "Need help?"
+    resumed = await runner.resume_async(paused, "sure")
+    assert resumed.step_history[-1].output == "sure"
+
+
+class Choice(BaseModel):
+    option: int
+
+
+@pytest.mark.asyncio
+async def test_resume_with_structured_input_validation() -> None:
+    step = Step.human_in_the_loop("pick", input_schema=Choice)
+    pipeline = Step("pre", StubAgent(["Q"])) >> step
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("x")
+    resumed = await runner.resume_async(paused, {"option": 1})
+    assert isinstance(resumed.step_history[-1].output, Choice)
+
+
+@pytest.mark.asyncio
+async def test_resume_with_invalid_structured_input() -> None:
+    step = Step.human_in_the_loop("pick", input_schema=Choice)
+    pipeline = Step("pre", StubAgent(["Q"])) >> step
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("x")
+    with pytest.raises(ValidationError):
+        await runner.resume_async(paused, {"bad": 0})
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_correction_loop() -> None:
+    pipeline = (
+        Step("draft1", StubAgent(["bad"]))
+        >> Step.human_in_the_loop("fix1")
+        >> Step("draft2", StubAgent(["good"]))
+        >> Step.human_in_the_loop("fix2")
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("start")
+    paused = await runner.resume_async(paused, "no")
+    paused = await runner.resume_async(paused, "yes")
+    assert paused.step_history[-1].output == "yes"
+
+
+class MetricOut(BaseModel):
+    value: int
+    cost_usd: float = 0.1
+    token_counts: int = 10
+
+
+class MetricAgent:
+    async def run(self, data: int | MetricOut) -> MetricOut:
+        val = data.value if isinstance(data, MetricOut) else data
+        return MetricOut(value=val + 1)
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_metrics() -> None:
+    pipeline = Step("m", MetricAgent()) >> Step.human_in_the_loop("pause")
+    runner = Flujo(pipeline)
+    paused = await runner.run_async(0)
+    cost_before = paused.total_cost_usd
+    resumed = await runner.resume_async(paused, "ok")
+    assert resumed.total_cost_usd == cost_before
+
+
+@pytest.mark.asyncio
+async def test_cannot_resume_non_paused_pipeline() -> None:
+    pipeline = Step("a", StubAgent(["done"]))
+    runner = Flujo(pipeline)
+    result = await runner.run_async("x")
+    with pytest.raises(Exception):
+        await runner.resume_async(result, "irrelevant")


### PR DESCRIPTION
## Summary
- implement HumanInTheLoopStep with proper init and factory
- extend Flujo with pause/resume logic and new `resume_async`
- add built-in PipelineContext details in docs
- document HITL API usage and new cookbook recipes
- provide example script and integration tests

## Testing
- `make test-fast`


------
https://chatgpt.com/codex/tasks/task_e_6850c7d537c4832c8b94ff8ec50deec5