### PR TITLE
Implement base HITL features

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -88,6 +88,12 @@ loop_body_pipeline=Pipeline.from_step(Step.solution(solution_agent)),
     exit_condition_callable=lambda out, ctx: "done" in out.lower(),
 )
 
+# Pause for human input
+approval_step = Step.human_in_the_loop(
+    name="approval",
+    message_for_user="Is the draft acceptable?",
+)
+
 # Conditional branching
 router = Step.branch_on(
     name="router",
@@ -232,6 +238,19 @@ pipeline_result = PipelineResult(
     total_cost_usd: float = 0.0,          # Total cost
     final_pipeline_context: Optional[BaseModel] = None,  # Final context
 )
+
+### PipelineContext
+
+Each run gets a `PipelineContext` with:
+
+- `run_id`: unique identifier
+- `initial_prompt`: the first input
+- `scratchpad`: a mutable dictionary for agents
+- `hitl_history`: list of `HumanInteraction` records
+
+### Resuming a Paused Pipeline
+
+Use `Flujo.resume_async(paused_result, human_input)` to continue after a `HumanInTheLoopStep`.
 ```
 
 ### UsageLimits

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -116,6 +116,10 @@ operations, the agents used at each stage, and the integration of plugins.
 Steps declare a `pipeline_context` parameter to access or modify this object. See
 [Typed Pipeline Context](pipeline_context.md) for full documentation.
 
+## The Pipeline Context: Built-in Memory
+
+Every run automatically receives a `PipelineContext` instance. It includes a `run_id`, the initial prompt, a mutable `scratchpad` dictionary and a record of all human interactions (`hitl_history`). This allows agents to share state without additional setup.
+
 The built-in [**Default recipe**](#the-default-recipe) uses this DSL under the hood. When you need different logic, you can use the same tools directly through the `Flujo` engine. The DSL also supports advanced constructs like [**LoopStep**](pipeline_looping.md) for iteration and [**ConditionalStep**](pipeline_branching.md) for branching workflows.
 
 ```python
@@ -185,6 +189,10 @@ router_step = Step.branch_on(
     },
 )
 ```
+
+#### Human-in-the-Loop Steps
+
+Use `Step.human_in_the_loop()` to pause execution and wait for structured human input. The step optionally validates the response with a Pydantic model and all interactions are saved to the `PipelineContext`.
 
 ## Scoring
 

--- a/docs/cookbook/hitl_dynamic_clarification.md
+++ b/docs/cookbook/hitl_dynamic_clarification.md
@@ -1,0 +1,14 @@
+# Cookbook: Dynamic Clarification
+
+Let an earlier step produce the question for the human by omitting `message_for_user`.
+
+```python
+from flujo import Step, Flujo
+from flujo.testing.utils import StubAgent
+
+pipeline = Step("ask", StubAgent(["Is this ok?"])) >> Step.human_in_the_loop("clarify")
+runner = Flujo(pipeline)
+result = await runner.run_async("hello")
+# display pause message from context and resume
+result = await runner.resume_async(result, "sure")
+```

--- a/docs/cookbook/hitl_simple_approval.md
+++ b/docs/cookbook/hitl_simple_approval.md
@@ -1,0 +1,15 @@
+# Cookbook: Simple Human Approval
+
+Use a `HumanInTheLoopStep` to pause a pipeline until a person approves the result.
+
+```python
+from flujo import Step, Pipeline, Flujo
+from flujo.testing.utils import StubAgent
+
+pipeline = Step("draft", StubAgent(["draft text"])) >> Step.human_in_the_loop("approve", message_for_user="Approve the draft?")
+runner = Flujo(pipeline)
+result = await runner.run_async("start")
+# show result.final_pipeline_context.scratchpad["pause_message"] to the user
+# then resume
+result = await runner.resume_async(result, "yes")
+```

--- a/docs/cookbook/hitl_stateful_correction_loop.md
+++ b/docs/cookbook/hitl_stateful_correction_loop.md
@@ -1,0 +1,20 @@
+# Cookbook: Stateful Correction Loop
+
+Combine `LoopStep` with human input to allow bounded multi-turn corrections.
+
+```python
+from flujo import Step, Pipeline, Flujo
+from flujo.testing.utils import StubAgent
+
+loop_body = Step("draft", StubAgent(["bad", "good"])) >> Step.human_in_the_loop("fix")
+loop = Step.loop_until(
+    name="correction",
+    loop_body_pipeline=Pipeline.from_step(loop_body),
+    exit_condition_callable=lambda out, ctx: out == "ok",
+    max_loops=2,
+)
+runner = Flujo(loop)
+paused = await runner.run_async("start")
+paused = await runner.resume_async(paused, "not ok")
+final = await runner.resume_async(paused, "ok")
+```

--- a/docs/cookbook/hitl_structured_input.md
+++ b/docs/cookbook/hitl_structured_input.md
@@ -1,0 +1,20 @@
+# Cookbook: Structured Human Input
+
+Validate human input against a Pydantic model for robustness.
+
+```python
+from pydantic import BaseModel
+from flujo import Step, Flujo
+from flujo.testing.utils import StubAgent
+
+class Answer(BaseModel):
+    choice: int
+
+step = Step.human_in_the_loop("pick", input_schema=Answer)
+pipeline = Step("start", StubAgent(["Q"])) >> step
+runner = Flujo(pipeline)
+paused = await runner.run_async("x")
+# paused.final_pipeline_context.scratchpad["pause_message"] has the question
+resumed = await runner.resume_async(paused, {"choice": 1})
+assert isinstance(resumed.step_history[-1].output, Answer)
+```

--- a/examples/09_human_in_the_loop.py
+++ b/examples/09_human_in_the_loop.py
@@ -1,0 +1,21 @@
+"""Demonstrates pausing a pipeline for human input."""
+import asyncio
+from typing import Any
+from flujo import Flujo, Step
+from flujo.testing.utils import StubAgent
+
+
+async def main() -> None:
+    pipeline = Step("draft", StubAgent(["A short draft"])) >> Step.human_in_the_loop(
+        "approval", message_for_user="Approve draft?"
+    )
+    runner = Flujo(pipeline)
+    result = await runner.run_async("start")
+    msg = result.final_pipeline_context.scratchpad.get("pause_message")
+    print(f"Pipeline paused with message: {msg}")
+    resumed = await runner.resume_async(result, "yes")
+    print("Final output:", resumed.step_history[-1].output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import time
 from typing import Any, Dict, Generic, Optional, Type, TypeVar
 
@@ -13,16 +14,24 @@ from ..exceptions import (
     PipelineContextInitializationError,
     UsageLimitExceededError,
     PipelineAbortSignal,
+    PausedException,
 )
 from ..domain.pipeline_dsl import (
     Pipeline,
     Step,
     LoopStep,
     ConditionalStep,
+    HumanInTheLoopStep,
     BranchKey,
 )
 from ..domain.plugins import PluginOutcome
-from ..domain.models import PipelineResult, StepResult, UsageLimits
+from ..domain.models import (
+    PipelineResult,
+    StepResult,
+    UsageLimits,
+    PipelineContext,
+    HumanInteraction,
+)
 from ..domain.resources import AppResources
 from ..domain.types import HookCallable
 
@@ -75,13 +84,15 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
     ) -> StepResult:
         visited: set[Any] = set()
         if isinstance(step, LoopStep):
-            return await self._execute_loop_step(
-                step, data, pipeline_context, resources
-            )
+            return await self._execute_loop_step(step, data, pipeline_context, resources)
         elif isinstance(step, ConditionalStep):
-            return await self._execute_conditional_step(
-                step, data, pipeline_context, resources
-            )
+            return await self._execute_conditional_step(step, data, pipeline_context, resources)
+        elif isinstance(step, HumanInTheLoopStep):
+            # Prepare message to human
+            message = step.message_for_user if step.message_for_user is not None else str(data)
+            if isinstance(pipeline_context, PipelineContext):
+                pipeline_context.scratchpad["status"] = "paused"
+            raise PausedException(message)
 
         result = StepResult(name=step.name)
         original_agent = step.agent
@@ -97,7 +108,27 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             start = time.monotonic()
             agent_kwargs = {}
             if pipeline_context is not None:
-                agent_kwargs["pipeline_context"] = pipeline_context
+                sigs = []
+                inner = getattr(current_agent, "_agent", None)
+                target = inner if inner is not None else current_agent
+                try:
+                    sigs.append(inspect.signature(target.run))
+                except (TypeError, ValueError):
+                    sigs.append(None)
+
+                pass_ctx = False
+                for sig in sigs:
+                    if sig is None:
+                        continue
+                    if "pipeline_context" in sig.parameters or any(
+                        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+                    ):
+                        pass_ctx = True
+                        break
+                if self.context_model is not None:
+                    pass_ctx = True
+                if pass_ctx:
+                    agent_kwargs["pipeline_context"] = pipeline_context
             if resources is not None:
                 agent_kwargs["resources"] = resources
             raw_output = await current_agent.run(data, **agent_kwargs)
@@ -115,12 +146,42 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             for plugin, _ in sorted_plugins:
                 try:
                     plugin_kwargs = {}
+                    try:
+                        sig = inspect.signature(plugin.validate)
+                    except (TypeError, ValueError):
+                        sig = None
+
                     if pipeline_context is not None:
-                        plugin_kwargs["pipeline_context"] = pipeline_context
-                    if resources is not None:
+                        pass_ctx = False
+                        if self.context_model is not None:
+                            pass_ctx = True
+                        elif sig is not None and (
+                            "pipeline_context" in sig.parameters
+                            or any(
+                                p.kind == inspect.Parameter.VAR_KEYWORD
+                                for p in sig.parameters.values()
+                            )
+                        ):
+                            pass_ctx = True
+                        if pass_ctx:
+                            plugin_kwargs["pipeline_context"] = pipeline_context
+
+                    if (
+                        resources is not None
+                        and sig is not None
+                        and (
+                            "resources" in sig.parameters
+                            or any(
+                                p.kind == inspect.Parameter.VAR_KEYWORD
+                                for p in sig.parameters.values()
+                            )
+                        )
+                    ):
                         plugin_kwargs["resources"] = resources
                     plugin_result: PluginOutcome = await asyncio.wait_for(
-                        plugin.validate({"input": data, "output": unpacked_output}, **plugin_kwargs),
+                        plugin.validate(
+                            {"input": data, "output": unpacked_output}, **plugin_kwargs
+                        ),
                         timeout=step.config.timeout_s,
                     )
                 except asyncio.TimeoutError as e:
@@ -153,9 +214,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             # Handle redirection for next attempt
             if redirect_to:
                 if redirect_to in visited:
-                    raise InfiniteRedirectError(
-                        f"Redirect loop detected in step {step.name}"
-                    )
+                    raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
                 visited.add(redirect_to)
                 current_agent = redirect_to
             else:
@@ -200,9 +259,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     f"Error in initial_input_to_loop_body_mapper for LoopStep '{loop_step.name}': {e}"
                 )
                 loop_overall_result.success = False
-                loop_overall_result.feedback = (
-                    f"Initial input mapper raised an exception: {e}"
-                )
+                loop_overall_result.feedback = f"Initial input mapper raised an exception: {e}"
                 return loop_overall_result
         else:
             current_body_input = loop_step_initial_input
@@ -232,12 +289,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     )
 
                 loop_overall_result.latency_s += body_step_result_obj.latency_s
-                loop_overall_result.cost_usd += getattr(
-                    body_step_result_obj, "cost_usd", 0.0
-                )
-                loop_overall_result.token_counts += getattr(
-                    body_step_result_obj, "token_counts", 0
-                )
+                loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)
+                loop_overall_result.token_counts += getattr(body_step_result_obj, "token_counts", 0)
 
                 if not body_step_result_obj.success:
                     logfire.warn(
@@ -250,9 +303,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                 current_iteration_data_for_body_step = body_step_result_obj.output
 
             if iteration_succeeded_fully:
-                last_successful_iteration_body_output = (
-                    current_iteration_data_for_body_step
-                )
+                last_successful_iteration_body_output = current_iteration_data_for_body_step
             final_body_output_of_last_iteration = current_iteration_data_for_body_step
 
             try:
@@ -264,15 +315,11 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}"
                 )
                 loop_overall_result.success = False
-                loop_overall_result.feedback = (
-                    f"Exit condition callable raised an exception: {e}"
-                )
+                loop_overall_result.feedback = f"Exit condition callable raised an exception: {e}"
                 break
 
             if should_exit:
-                logfire.info(
-                    f"LoopStep '{loop_step.name}' exit condition met at iteration {i}."
-                )
+                logfire.info(f"LoopStep '{loop_step.name}' exit condition met at iteration {i}.")
                 loop_overall_result.success = iteration_succeeded_fully
                 if not iteration_succeeded_fully:
                     loop_overall_result.feedback = (
@@ -303,7 +350,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                 f"LoopStep '{loop_step.name}' reached max_loops ({loop_step.max_loops}) without exit condition being met."
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = f"Reached max_loops ({loop_step.max_loops}) without meeting exit condition."
+            loop_overall_result.feedback = (
+                f"Reached max_loops ({loop_step.max_loops}) without meeting exit condition."
+            )
 
         if loop_overall_result.success and loop_exited_successfully_by_condition:
             if loop_step.loop_output_mapper:
@@ -316,16 +365,16 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                         f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}"
                     )
                     loop_overall_result.success = False
-                    loop_overall_result.feedback = (
-                        f"Loop output mapper raised an exception: {e}"
-                    )
+                    loop_overall_result.feedback = f"Loop output mapper raised an exception: {e}"
                     loop_overall_result.output = None
             else:
                 loop_overall_result.output = last_successful_iteration_body_output
         else:
             loop_overall_result.output = final_body_output_of_last_iteration
             if not loop_overall_result.feedback:
-                loop_overall_result.feedback = "Loop did not complete successfully or exit condition not met positively."
+                loop_overall_result.feedback = (
+                    "Loop did not complete successfully or exit condition not met positively."
+                )
 
         return loop_overall_result
 
@@ -350,9 +399,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             )
             executed_branch_key = branch_key_to_execute
 
-            selected_branch_pipeline = conditional_step.branches.get(
-                branch_key_to_execute
-            )
+            selected_branch_pipeline = conditional_step.branches.get(branch_key_to_execute)
             if selected_branch_pipeline is None:
                 selected_branch_pipeline = conditional_step.default_branch_pipeline
                 if selected_branch_pipeline is None:
@@ -428,10 +475,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         if branch_succeeded:
             if conditional_step.branch_output_mapper:
                 try:
-                    conditional_overall_result.output = (
-                        conditional_step.branch_output_mapper(
-                            branch_output, executed_branch_key, pipeline_context
-                        )
+                    conditional_overall_result.output = conditional_step.branch_output_mapper(
+                        branch_output, executed_branch_key, pipeline_context
                     )
                 except Exception as e:  # noqa: BLE001
                     logfire.error(
@@ -449,12 +494,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
 
         conditional_overall_result.attempts = 1
         if executed_branch_key is not None:
-            conditional_overall_result.metadata_ = (
-                conditional_overall_result.metadata_ or {}
-            )
-            conditional_overall_result.metadata_["executed_branch_key"] = str(
-                executed_branch_key
-            )
+            conditional_overall_result.metadata_ = conditional_overall_result.metadata_ or {}
+            conditional_overall_result.metadata_["executed_branch_key"] = str(executed_branch_key)
 
         return conditional_overall_result
 
@@ -477,9 +518,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     span.set_attribute("governor_breached", True)
                 except Exception:  # noqa: BLE001
                     pass
-            logfire.warn(
-                f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded"
-            )
+            logfire.warn(f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded")
             raise UsageLimitExceededError(
                 f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded",
                 pipeline_result,
@@ -494,9 +533,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     span.set_attribute("governor_breached", True)
                 except Exception:  # noqa: BLE001
                     pass
-            logfire.warn(
-                f"Token limit of {self.usage_limits.total_tokens_limit} exceeded"
-            )
+            logfire.warn(f"Token limit of {self.usage_limits.total_tokens_limit} exceeded")
             raise UsageLimitExceededError(
                 f"Token limit of {self.usage_limits.total_tokens_limit} exceeded",
                 pipeline_result,
@@ -523,6 +560,12 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data. Validation errors:\n{e}"
                 ) from e
 
+        else:
+            current_pipeline_context_instance = PipelineContext(initial_prompt=str(initial_input))
+
+        if isinstance(current_pipeline_context_instance, PipelineContext):
+            current_pipeline_context_instance.scratchpad["status"] = "running"
+
         data: Optional[RunnerInT] = initial_input
         pipeline_result_obj = PipelineResult()
         try:
@@ -541,12 +584,21 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     resources=self.resources,
                 )
                 with logfire.span(step.name) as span:
-                    step_result = await self._run_step(
-                        step,
-                        data,
-                        pipeline_context=current_pipeline_context_instance,
-                        resources=self.resources,
-                    )
+                    try:
+                        step_result = await self._run_step(
+                            step,
+                            data,
+                            pipeline_context=current_pipeline_context_instance,
+                            resources=self.resources,
+                        )
+                    except PausedException as e:
+                        if isinstance(current_pipeline_context_instance, PipelineContext):
+                            current_pipeline_context_instance.scratchpad["status"] = "paused"
+                            current_pipeline_context_instance.scratchpad["pause_message"] = str(e)
+                        pipeline_result_obj.final_pipeline_context = (
+                            current_pipeline_context_instance
+                        )
+                        break
                     if step_result.metadata_:
                         for key, value in step_result.metadata_.items():
                             try:
@@ -570,9 +622,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                         pipeline_context=current_pipeline_context_instance,
                         resources=self.resources,
                     )
-                    logfire.warn(
-                        f"Step '{step.name}' failed. Halting pipeline execution."
-                    )
+                    logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
                     break
                 step_output: Optional[RunnerInT] = step_result.output
                 data = step_output
@@ -583,15 +633,19 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             logfire.info(str(e))
         except UsageLimitExceededError as e:
             if current_pipeline_context_instance is not None:
-                pipeline_result_obj.final_pipeline_context = (
-                    current_pipeline_context_instance
-                )
+                pipeline_result_obj.final_pipeline_context = current_pipeline_context_instance
             raise e
         finally:
             if current_pipeline_context_instance is not None:
-                pipeline_result_obj.final_pipeline_context = (
-                    current_pipeline_context_instance
-                )
+                pipeline_result_obj.final_pipeline_context = current_pipeline_context_instance
+                if isinstance(current_pipeline_context_instance, PipelineContext):
+                    if current_pipeline_context_instance.scratchpad.get("status") != "paused":
+                        status = (
+                            "completed"
+                            if all(s.success for s in pipeline_result_obj.step_history)
+                            else "failed"
+                        )
+                        current_pipeline_context_instance.scratchpad["status"] = status
             try:
                 await self._dispatch_hook(
                     "post_run",
@@ -608,3 +662,98 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         self, initial_input: RunnerInT, *, initial_context_data: Optional[Dict[str, Any]] = None
     ) -> PipelineResult:
         return asyncio.run(self.run_async(initial_input, initial_context_data=initial_context_data))
+
+    async def resume_async(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+        """Resume a paused pipeline with human input."""
+        ctx = paused_result.final_pipeline_context
+        if ctx is None:
+            raise OrchestratorError("Cannot resume pipeline without context")
+        scratch = getattr(ctx, "scratchpad", {})
+        if scratch.get("status") != "paused":
+            raise OrchestratorError("Pipeline is not paused")
+        start_idx = len(paused_result.step_history)
+        if start_idx >= len(self.pipeline.steps):
+            raise OrchestratorError("No steps remaining to resume")
+        paused_step = self.pipeline.steps[start_idx]
+        if not isinstance(paused_step, HumanInTheLoopStep):
+            raise OrchestratorError("Next step is not a HumanInTheLoopStep")
+
+        if paused_step.input_schema is not None:
+            human_input = paused_step.input_schema.model_validate(human_input)
+
+        if isinstance(ctx, PipelineContext):
+            ctx.hitl_history.append(
+                HumanInteraction(
+                    message_to_human=scratch.get("pause_message", ""),
+                    human_response=human_input,
+                )
+            )
+            ctx.scratchpad["status"] = "running"
+
+        paused_step_result = StepResult(
+            name=paused_step.name,
+            output=human_input,
+            success=True,
+            attempts=1,
+        )
+        paused_result.step_history.append(paused_step_result)
+
+        data = human_input
+        for step in self.pipeline.steps[start_idx + 1 :]:
+            await self._dispatch_hook(
+                "pre_step",
+                step=step,
+                step_input=data,
+                pipeline_context=ctx,
+                resources=self.resources,
+            )
+            with logfire.span(step.name) as span:
+                try:
+                    step_result = await self._run_step(
+                        step,
+                        data,
+                        pipeline_context=ctx,
+                        resources=self.resources,
+                    )
+                except PausedException as e:
+                    if isinstance(ctx, PipelineContext):
+                        ctx.scratchpad["status"] = "paused"
+                        ctx.scratchpad["pause_message"] = str(e)
+                    paused_result.final_pipeline_context = ctx
+                    break
+                if step_result.metadata_:
+                    for key, value in step_result.metadata_.items():
+                        try:
+                            span.set_attribute(key, value)
+                        except Exception:  # noqa: BLE001
+                            pass
+                paused_result.step_history.append(step_result)
+                paused_result.total_cost_usd += step_result.cost_usd
+                self._check_usage_limits(paused_result, span)
+            if step_result.success:
+                await self._dispatch_hook(
+                    "post_step",
+                    step_result=step_result,
+                    pipeline_context=ctx,
+                    resources=self.resources,
+                )
+            else:
+                await self._dispatch_hook(
+                    "on_step_failure",
+                    step_result=step_result,
+                    pipeline_context=ctx,
+                    resources=self.resources,
+                )
+                logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
+                break
+            data = step_result.output
+
+        if isinstance(ctx, PipelineContext):
+            if ctx.scratchpad.get("status") != "paused":
+                status = (
+                    "completed" if all(s.success for s in paused_result.step_history) else "failed"
+                )
+                ctx.scratchpad["status"] = status
+
+        paused_result.final_pipeline_context = ctx
+        return paused_result

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -1,7 +1,9 @@
 """Domain models for flujo."""
 
-from typing import Any, List, Optional, Literal
+from typing import Any, List, Optional, Literal, Dict
 from pydantic import BaseModel, Field
+from datetime import datetime
+import uuid
 from enum import Enum
 
 
@@ -16,12 +18,8 @@ class ChecklistItem(BaseModel):
     """A single item in a checklist for evaluating a solution."""
 
     description: str = Field(..., description="The criterion to evaluate.")
-    passed: Optional[bool] = Field(
-        None, description="Whether the solution passes this criterion."
-    )
-    feedback: Optional[str] = Field(
-        None, description="Feedback if the criterion is not met."
-    )
+    passed: Optional[bool] = Field(None, description="Whether the solution passes this criterion.")
+    feedback: Optional[str] = Field(None, description="Feedback if the criterion is not met.")
 
 
 class Checklist(BaseModel):
@@ -76,9 +74,7 @@ class PipelineResult(BaseModel):
     total_cost_usd: float = 0.0
     final_pipeline_context: Optional[BaseModel] = Field(
         default=None,
-        description=(
-            "The final state of the typed pipeline context, if configured and used."
-        ),
+        description=("The final state of the typed pipeline context, if configured and used."),
     )
 
     model_config = {"arbitrary_types_allowed": True}
@@ -157,3 +153,22 @@ class ImprovementReport(BaseModel):
     """Aggregated improvement suggestions returned by the agent."""
 
     suggestions: list[ImprovementSuggestion] = Field(default_factory=list)
+
+
+class HumanInteraction(BaseModel):
+    """Records a single human interaction in a HITL conversation."""
+
+    message_to_human: str
+    human_response: Any
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class PipelineContext(BaseModel):
+    """A built-in context object shared across the pipeline run."""
+
+    run_id: str = Field(default_factory=lambda: f"run_{uuid.uuid4().hex}")
+    initial_prompt: str
+    scratchpad: Dict[str, Any] = Field(default_factory=dict)
+    hitl_history: List[HumanInteraction] = Field(default_factory=list)
+
+    model_config = {"arbitrary_types_allowed": True}

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -11,6 +11,7 @@ from typing import (
     Sequence,
     TypeVar,
     Dict,
+    Type,
 )
 from pydantic import BaseModel, Field, ConfigDict
 from .agent_protocol import AsyncAgentProtocol
@@ -94,6 +95,20 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
         """Construct a validation step using the provided agent."""
         return cls("validate", agent, **config)
 
+    @classmethod
+    def human_in_the_loop(
+        cls,
+        name: str,
+        message_for_user: str | None = None,
+        input_schema: Type[BaseModel] | None = None,
+    ) -> "HumanInTheLoopStep":
+        """Create a step that pauses execution for human input."""
+        return HumanInTheLoopStep(
+            name=name,
+            message_for_user=message_for_user,
+            input_schema=input_schema,
+        )
+
     def add_plugin(self, plugin: ValidationPlugin, priority: int = 0) -> "Step[StepInT, StepOutT]":
         """Add a validation plugin to this step."""
         self.plugins.append((plugin, priority))
@@ -154,6 +169,34 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             branch_input_mapper=branch_input_mapper,
             branch_output_mapper=branch_output_mapper,
             **config_kwargs,
+        )
+
+
+class HumanInTheLoopStep(Step[Any, Any]):
+    """A step that pauses the pipeline for human input."""
+
+    message_for_user: str | None = Field(default=None)
+    input_schema: Type[BaseModel] | None = Field(default=None)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        message_for_user: str | None = None,
+        input_schema: Type[BaseModel] | None = None,
+        **config: Any,
+    ) -> None:
+        BaseModel.__init__(
+            self,
+            name=name,
+            agent=None,
+            config=StepConfig(**config),
+            plugins=[],
+            failure_handlers=[],
+            message_for_user=message_for_user,
+            input_schema=input_schema,
         )
 
 
@@ -312,5 +355,6 @@ __all__ = [
     "StepConfig",
     "LoopStep",
     "ConditionalStep",
+    "HumanInTheLoopStep",
     "BranchKey",
 ]

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -67,3 +67,10 @@ class PipelineAbortSignal(Exception):
 
     def __init__(self, message: str = "Pipeline aborted by hook.") -> None:
         super().__init__(message)
+
+
+class PausedException(Exception):
+    """Internal exception used to pause a pipeline."""
+
+    def __init__(self, message: str = "Pipeline paused for human input.") -> None:
+        super().__init__(message)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,10 @@ nav:
     - 'Controlling Costs': cookbook/cost_control.md
     - 'Lifecycle Hooks': cookbook/lifecycle_hooks.md
     - 'Using Resources': cookbook/using_resources.md
+    - 'HITL Simple Approval': cookbook/hitl_simple_approval.md
+    - 'HITL Dynamic Clarification': cookbook/hitl_dynamic_clarification.md
+    - 'HITL Structured Input': cookbook/hitl_structured_input.md
+    - 'HITL Correction Loop': cookbook/hitl_stateful_correction_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
     - 'v0.3.8': migration/v0.3.8.md

--- a/tests/integration/test_hitl_pipeline.py
+++ b/tests/integration/test_hitl_pipeline.py
@@ -1,0 +1,117 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain.pipeline_dsl import Step, Pipeline
+from flujo.domain.models import PipelineContext
+from flujo.exceptions import OrchestratorError
+from flujo.testing.utils import StubAgent
+
+
+@pytest.mark.asyncio
+async def test_static_approval_pause_and_resume() -> None:
+    pipeline = Step("first", StubAgent(["draft"])) >> Step.human_in_the_loop(
+        "approve", message_for_user="OK?"
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("in")
+    ctx = paused.final_pipeline_context
+    assert isinstance(ctx, PipelineContext)
+    assert ctx.scratchpad["status"] == "paused"
+    assert ctx.scratchpad["pause_message"] == "OK?"
+    resumed = await runner.resume_async(paused, "yes")
+    assert resumed.step_history[-1].output == "yes"
+    assert ctx.scratchpad["status"] == "completed"
+    assert len(ctx.hitl_history) == 1
+    record = ctx.hitl_history[0]
+    assert record.message_to_human == "OK?"
+    assert record.human_response == "yes"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_clarification_pause_and_resume() -> None:
+    pipeline = Step("ask", StubAgent(["Need help?"])) >> Step.human_in_the_loop(
+        "clarify"
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("hi")
+    ctx = paused.final_pipeline_context
+    assert ctx.scratchpad["pause_message"] == "Need help?"
+    resumed = await runner.resume_async(paused, "sure")
+    assert resumed.step_history[-1].output == "sure"
+    assert len(ctx.hitl_history) == 1
+    assert ctx.hitl_history[0].message_to_human == "Need help?"
+    assert ctx.hitl_history[0].human_response == "sure"
+
+
+class Choice(BaseModel):
+    option: int
+
+
+@pytest.mark.asyncio
+async def test_resume_with_structured_input_validation() -> None:
+    step = Step.human_in_the_loop("pick", input_schema=Choice)
+    pipeline = Step("pre", StubAgent(["Q"])) >> step
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("x")
+    resumed = await runner.resume_async(paused, {"option": 1})
+    assert isinstance(resumed.step_history[-1].output, Choice)
+
+
+@pytest.mark.asyncio
+async def test_resume_with_invalid_structured_input() -> None:
+    step = Step.human_in_the_loop("pick", input_schema=Choice)
+    pipeline = Step("pre", StubAgent(["Q"])) >> step
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("x")
+    with pytest.raises(ValidationError):
+        await runner.resume_async(paused, {"bad": 0})
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_correction_loop() -> None:
+    pipeline = (
+        Step("draft1", StubAgent(["bad"]))
+        >> Step.human_in_the_loop("fix1")
+        >> Step("draft2", StubAgent(["good"]))
+        >> Step.human_in_the_loop("fix2")
+    )
+    runner = Flujo(pipeline)
+    paused = await runner.run_async("start")
+    paused = await runner.resume_async(paused, "no")
+    paused = await runner.resume_async(paused, "yes")
+    assert paused.step_history[-1].output == "yes"
+    ctx = paused.final_pipeline_context
+    assert ctx is not None
+    assert len(ctx.hitl_history) == 2
+
+
+class MetricOut(BaseModel):
+    value: int
+    cost_usd: float = 0.1
+    token_counts: int = 10
+
+
+class MetricAgent:
+    async def run(self, data: int | MetricOut) -> MetricOut:
+        val = data.value if isinstance(data, MetricOut) else data
+        return MetricOut(value=val + 1)
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_metrics() -> None:
+    pipeline = Step("m", MetricAgent()) >> Step.human_in_the_loop("pause")
+    runner = Flujo(pipeline)
+    paused = await runner.run_async(0)
+    cost_before = paused.total_cost_usd
+    resumed = await runner.resume_async(paused, "ok")
+    assert resumed.total_cost_usd == cost_before
+
+
+@pytest.mark.asyncio
+async def test_cannot_resume_non_paused_pipeline() -> None:
+    pipeline = Step("a", StubAgent(["done"]))
+    runner = Flujo(pipeline)
+    result = await runner.run_async("x")
+    with pytest.raises(OrchestratorError):
+        await runner.resume_async(result, "irrelevant")


### PR DESCRIPTION
## Summary
- implement HumanInTheLoopStep with proper init and factory
- extend Flujo with pause/resume logic and new `resume_async`
- add built-in PipelineContext details in docs
- document HITL API usage and new cookbook recipes
- provide example script and integration tests
- handle signature inspection errors and verify HITL history in tests

## Testing
- `make test-fast`


------
https://chatgpt.com/codex/tasks/task_e_6850c7d537c4832c8b94ff8ec50deec5