### PR TITLE
Add AgenticLoop recipe and command log

### DIFF
--- a/docs/recipes/agentic_loop.md
+++ b/docs/recipes/agentic_loop.md
@@ -1,0 +1,20 @@
+# Recipe: AgenticLoop
+
+`AgenticLoop` provides a convenient way to build explorative agent workflows. A planner agent decides which command to run next and the recipe executes it, recording every turn for traceability.
+
+```python
+from flujo import AgenticLoop, StubAgent
+from flujo.domain.commands import RunAgentCommand, FinishCommand
+
+planner = StubAgent([
+    RunAgentCommand(agent_name="helper", input_data="hi"),
+    FinishCommand(final_answer="done"),
+])
+loop = AgenticLoop(planner_agent=planner, agent_registry={"helper": StubAgent(["ok"])})
+result = loop.run("initial goal")
+print(result.final_pipeline_context.command_log)
+```
+
+## Security Note
+
+`RunPythonCodeCommand` executes arbitrary code. Only use it with a secure sandbox.

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -9,7 +9,7 @@ try:
 except Exception:
     __version__ = "0.0.0"
 from .application.flujo_engine import Flujo
-from .recipes import Default
+from .recipes import Default, AgenticLoop
 from .infra.settings import settings
 from .infra.telemetry import init_telemetry
 
@@ -49,6 +49,7 @@ from .exceptions import (
 __all__ = [
     "Flujo",
     "Default",
+    "AgenticLoop",
     "Task",
     "Candidate",
     "Checklist",

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -33,6 +33,7 @@ from ..domain.models import (
     PipelineContext,
     HumanInteraction,
 )
+from ..domain.commands import AgentCommand, ExecutedCommandLog
 from ..domain.resources import AppResources
 from ..domain.types import HookCallable
 
@@ -636,6 +637,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                         if isinstance(current_pipeline_context_instance, PipelineContext):
                             current_pipeline_context_instance.scratchpad["status"] = "paused"
                             current_pipeline_context_instance.scratchpad["pause_message"] = str(e)
+                            scratch = current_pipeline_context_instance.scratchpad
+                            if "paused_step_input" not in scratch:
+                                scratch["paused_step_input"] = data
                         pipeline_result_obj.final_pipeline_context = (
                             current_pipeline_context_instance
                         )
@@ -739,10 +743,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         if start_idx >= len(self.pipeline.steps):
             raise OrchestratorError("No steps remaining to resume")
         paused_step = self.pipeline.steps[start_idx]
-        if not isinstance(paused_step, HumanInTheLoopStep):
-            raise OrchestratorError("Next step is not a HumanInTheLoopStep")
 
-        if paused_step.input_schema is not None:
+        if isinstance(paused_step, HumanInTheLoopStep) and paused_step.input_schema is not None:
             human_input = paused_step.input_schema.model_validate(human_input)
 
         if isinstance(ctx, PipelineContext):
@@ -760,6 +762,15 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             success=True,
             attempts=1,
         )
+        if isinstance(ctx, PipelineContext):
+            pending = ctx.scratchpad.pop("paused_step_input", None)
+            if isinstance(pending, BaseModel) and hasattr(pending, "type"):
+                log_entry = ExecutedCommandLog(
+                    turn=len(ctx.command_log) + 1,
+                    generated_command=pending,
+                    execution_result=human_input,
+                )
+                ctx.command_log.append(log_entry)
         paused_result.step_history.append(paused_step_result)
 
         data = human_input

--- a/flujo/domain/commands.py
+++ b/flujo/domain/commands.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Union
+
+from pydantic import BaseModel, Field
+
+
+class RunAgentCommand(BaseModel):
+    """Instructs the loop to run a registered sub-agent."""
+
+    type: Literal["run_agent"] = "run_agent"
+    agent_name: str = Field(..., description="The name of the agent to run from the registry.")
+    input_data: Any = Field(..., description="The input data to pass to the sub-agent.")
+
+
+class RunPythonCodeCommand(BaseModel):
+    """Execute a snippet of Python code. Requires a secure sandbox."""
+
+    type: Literal["run_python"] = "run_python"
+    code: str = Field(..., description="The Python code to execute.")
+    # Result is expected in variable 'result'
+
+
+class AskHumanCommand(BaseModel):
+    """Pause execution and ask a human for input."""
+
+    type: Literal["ask_human"] = "ask_human"
+    question: str = Field(..., description="The question to present to the human user.")
+
+
+class FinishCommand(BaseModel):
+    """Finish the loop with a final answer."""
+
+    type: Literal["finish"] = "finish"
+    final_answer: Any = Field(..., description="The final result or summary of the task.")
+
+
+AgentCommand = Union[RunAgentCommand, RunPythonCodeCommand, AskHumanCommand, FinishCommand]
+
+
+class ExecutedCommandLog(BaseModel):
+    """Structured log entry for a command executed in the loop."""
+
+    turn: int
+    generated_command: AgentCommand
+    execution_result: Any
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+    model_config = {"arbitrary_types_allowed": True}

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -2,6 +2,7 @@
 
 from typing import Any, List, Optional, Literal, Dict
 from pydantic import BaseModel, Field
+from .commands import ExecutedCommandLog
 from datetime import datetime, timezone
 import uuid
 from enum import Enum
@@ -170,5 +171,9 @@ class PipelineContext(BaseModel):
     initial_prompt: str
     scratchpad: Dict[str, Any] = Field(default_factory=dict)
     hitl_history: List[HumanInteraction] = Field(default_factory=list)
+    command_log: List[ExecutedCommandLog] = Field(
+        default_factory=list,
+        description="A log of commands executed by an AgenticLoop.",
+    )
 
     model_config = {"arbitrary_types_allowed": True}

--- a/flujo/recipes/__init__.py
+++ b/flujo/recipes/__init__.py
@@ -1,3 +1,4 @@
 from .default import Default
+from .agentic_loop import AgenticLoop
 
-__all__ = ["Default"]
+__all__ = ["Default", "AgenticLoop"]

--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import asyncio
+
+from ..domain.agent_protocol import AsyncAgentProtocol
+from ..domain.commands import (
+    AgentCommand,
+    FinishCommand,
+    ExecutedCommandLog,
+)
+from ..domain.models import PipelineResult, PipelineContext
+from ..domain.pipeline_dsl import Step, LoopStep
+from ..application.flujo_engine import Flujo
+
+
+class AgenticLoop:
+    """High-level recipe for explorative agentic workflows."""
+
+    def __init__(
+        self,
+        planner_agent: AsyncAgentProtocol[Any, AgentCommand],
+        agent_registry: Dict[str, AsyncAgentProtocol],
+        max_loops: int = 15,
+    ) -> None:
+        self.planner_agent = planner_agent
+        self.agent_registry = agent_registry
+        self.max_loops = max_loops
+        self._pipeline = self._build_internal_pipeline()
+
+    def _build_internal_pipeline(self) -> LoopStep:
+        executor_step = Step("ExecuteCommand", _CommandExecutor(self.agent_registry))
+        loop_body = Step("DecideNextCommand", self.planner_agent) >> executor_step
+
+        def exit_condition(_: Any, context: PipelineContext) -> bool:
+            last_cmd = context.command_log[-1].generated_command
+            return isinstance(last_cmd, FinishCommand)
+
+        return Step.loop_until(
+            name="AgenticExplorationLoop",
+            loop_body_pipeline=loop_body,
+            exit_condition_callable=exit_condition,
+            max_loops=self.max_loops,
+            iteration_input_mapper=lambda result, ctx, i: {"last_command_result": result},
+        )
+
+    def run(self, initial_goal: str) -> PipelineResult:
+        runner = Flujo(self._pipeline, context_model=PipelineContext)
+        return runner.run(
+            {"last_command_result": None, "goal": initial_goal},
+            initial_context_data={"initial_prompt": initial_goal},
+        )
+
+    async def run_async(self, initial_goal: str) -> PipelineResult:
+        runner = Flujo(self._pipeline, context_model=PipelineContext)
+        result: PipelineResult | None = None
+        async for item in runner.run_async(
+            {"last_command_result": None, "goal": initial_goal},
+            initial_context_data={"initial_prompt": initial_goal},
+        ):
+            result = item
+        assert result is not None
+        return result
+
+    def resume(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+        runner = Flujo(self._pipeline, context_model=PipelineContext)
+        async def _consume() -> PipelineResult:
+            return await runner.resume_async(paused_result, human_input)
+        return asyncio.run(_consume())
+
+    async def resume_async(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+        runner = Flujo(self._pipeline, context_model=PipelineContext)
+        return await runner.resume_async(paused_result, human_input)
+
+
+class _CommandExecutor:
+    def __init__(self, agent_registry: Dict[str, AsyncAgentProtocol]):
+        self.agent_registry = agent_registry
+
+    async def run(self, command: AgentCommand, *, pipeline_context: PipelineContext) -> Any:
+        turn = len(pipeline_context.command_log) + 1
+        result: Any = "Command type not recognized."
+        try:
+            if command.type == "run_agent":
+                agent = self.agent_registry.get(command.agent_name)
+                if not agent:
+                    result = f"Error: Agent '{command.agent_name}' not found."
+                else:
+                    result = await agent.run(command.input_data)
+            elif command.type == "run_python":
+                local_scope: Dict[str, Any] = {}
+                exec(command.code, globals(), local_scope)
+                result = local_scope.get("result", "Python code executed successfully.")
+            elif command.type == "ask_human":
+                from ..exceptions import PausedException
+                if isinstance(pipeline_context, PipelineContext):
+                    pipeline_context.scratchpad["paused_step_input"] = command
+                raise PausedException(message=command.question)
+            elif command.type == "finish":
+                result = command.final_answer
+        except PausedException:
+            raise
+        except Exception as e:  # noqa: BLE001
+            result = f"Error during command execution: {e}"
+
+        log_entry = ExecutedCommandLog(
+            turn=turn,
+            generated_command=command,
+            execution_result=result,
+        )
+        pipeline_context.command_log.append(log_entry)
+        return result

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - 'HITL Structured Input': cookbook/hitl_structured_input.md
     - 'HITL Correction Loop': cookbook/hitl_stateful_correction_loop.md
     - 'Real-Time Chatbot': cookbook/realtime_chatbot.md
+    - 'Agentic Loop': recipes/agentic_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
     - 'v0.3.8': migration/v0.3.8.md

--- a/tests/integration/test_agentic_loop_recipe.py
+++ b/tests/integration/test_agentic_loop_recipe.py
@@ -1,0 +1,54 @@
+from unittest.mock import AsyncMock
+import pytest
+
+from flujo.recipes.agentic_loop import AgenticLoop
+from flujo.domain.commands import (
+    RunAgentCommand,
+    AskHumanCommand,
+    FinishCommand,
+)
+from flujo.testing.utils import StubAgent
+from flujo.domain.models import PipelineContext
+
+
+@pytest.mark.asyncio
+async def test_agent_delegation_and_finish() -> None:
+    planner = StubAgent([
+        RunAgentCommand(agent_name="summarizer", input_data="hi"),
+        FinishCommand(final_answer="done"),
+    ])
+    summarizer = AsyncMock()
+    summarizer.run = AsyncMock(return_value="summary")
+    loop = AgenticLoop(planner, {"summarizer": summarizer})
+    result = await loop.run_async("goal")
+    summarizer.run.assert_called_once_with("hi")
+    ctx = result.final_pipeline_context
+    assert isinstance(ctx, PipelineContext)
+    assert len(ctx.command_log) == 2
+    assert ctx.command_log[-1].execution_result == "done"
+
+
+@pytest.mark.asyncio
+async def test_pause_and_resume_in_loop() -> None:
+    planner = StubAgent([
+        AskHumanCommand(question="Need input"),
+        FinishCommand(final_answer="ok"),
+    ])
+    loop = AgenticLoop(planner, {})
+    paused = await loop.run_async("goal")
+    ctx = paused.final_pipeline_context
+    assert ctx.scratchpad["status"] == "paused"
+    resumed = await loop.resume_async(paused, "human")
+    assert resumed.final_pipeline_context.command_log[0].execution_result == "human"
+    assert resumed.final_pipeline_context.scratchpad["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_max_loops_failure() -> None:
+    planner = StubAgent([RunAgentCommand(agent_name="x", input_data=1)])
+    loop = AgenticLoop(planner, {}, max_loops=3)
+    result = await loop.run_async("goal")
+    ctx = result.final_pipeline_context
+    assert len(ctx.command_log) == 3
+    last_step = result.step_history[-1]
+    assert last_step.success is False


### PR DESCRIPTION
## Summary
- introduce models for AgentCommand and command log entries
- extend `PipelineContext` with `command_log`
- implement `AgenticLoop` recipe to orchestrate agentic loops
- support pausing from inside a step in `Flujo` engine
- document usage of `AgenticLoop`
- test agentic loop behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68519eff99dc832cbcea899bd004baff