### PR TITLE
Add run_python tests and documentation

### DIFF
--- a/docs/recipes/agentic_loop.md
+++ b/docs/recipes/agentic_loop.md
@@ -25,6 +25,27 @@ if paused.status == "paused":
     print(resumed.final_pipeline_context.command_log)
 ```
 
+## AgentCommand Models
+
+Your planner agent must emit one of the following commands on each turn:
+
+- `RunAgentCommand(agent_name, input_data)` – delegate work to a registered sub-agent.
+- `RunPythonCodeCommand(code)` – run a Python snippet. The result should be stored in a variable named `result`.
+- `AskHumanCommand(question)` – pause the loop and wait for human input.
+- `FinishCommand(final_answer)` – end the loop with a final answer.
+
+For example, you can run Python code safely:
+
+```python
+planner = StubAgent([
+    RunPythonCodeCommand(code="result = 1 + 1"),
+    FinishCommand(final_answer="done"),
+])
+loop = AgenticLoop(planner, {})
+result = loop.run("goal")
+print(result.final_pipeline_context.command_log[0].execution_result)
+```
+
 ## Security Note
 
 `RunPythonCodeCommand` executes Python code with built-ins disabled and will

--- a/tests/integration/test_agentic_loop_recipe.py
+++ b/tests/integration/test_agentic_loop_recipe.py
@@ -4,6 +4,7 @@ import pytest
 from flujo.recipes.agentic_loop import AgenticLoop
 from flujo.domain.commands import (
     RunAgentCommand,
+    RunPythonCodeCommand,
     AskHumanCommand,
     FinishCommand,
 )
@@ -65,4 +66,28 @@ async def test_max_loops_failure() -> None:
     assert len(ctx.command_log) == 3
     last_step = result.step_history[-1]
     assert last_step.success is False
+
+
+@pytest.mark.asyncio
+async def test_run_python_safe() -> None:
+    planner = StubAgent([
+        RunPythonCodeCommand(code="result = 1 + 1"),
+        FinishCommand(final_answer="done"),
+    ])
+    loop = AgenticLoop(planner, {})
+    result = await loop.run_async("goal")
+    ctx = result.final_pipeline_context
+    assert ctx.command_log[0].execution_result == 2
+
+
+@pytest.mark.asyncio
+async def test_run_python_rejects_imports() -> None:
+    planner = StubAgent([
+        RunPythonCodeCommand(code="import os\nresult = 42"),
+        FinishCommand(final_answer="done"),
+    ])
+    loop = AgenticLoop(planner, {})
+    result = await loop.run_async("goal")
+    log_entry = result.final_pipeline_context.command_log[0]
+    assert "Imports are not allowed" in str(log_entry.execution_result)
 


### PR DESCRIPTION
## Summary
- document AgentCommand structure in AgenticLoop recipe
- fix PausedException import in AgenticLoop
- add integration tests for RunPythonCodeCommand safe and unsafe paths

## Testing
- `make format`
- `make test-fast`

------
https://chatgpt.com/codex/tasks/task_e_6851b3d59428832c80abdae6cf785498