### PR TITLE
Add pluggable execution backend

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -405,6 +405,24 @@ limits = UsageLimits(total_cost_usd_limit=1.0, total_tokens_limit=5000)
 runner = Flujo(my_pipeline, usage_limits=limits)
 ```
 
+## Pluggable Execution Back-Ends
+
+Advanced users can control where each step executes by implementing the
+`ExecutionBackend` protocol. The default `LocalBackend` runs steps in the
+current process, so behaviour is unchanged for typical usage. Custom back-ends
+can delegate work to remote services or task queues while the orchestration
+logic in `Flujo` stays the same.
+
+```python
+from flujo.infra.backends import LocalBackend
+from flujo import Flujo
+
+runner = Flujo(pipeline, backend=LocalBackend())
+```
+
+See [Creating a Custom Execution Backend](extending.md#creating-a-custom-execution-backend)
+for guidance on building your own.
+
 ## Streaming
 
 `Flujo` can stream output from the final step of a pipeline. Use `stream_async`

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -45,3 +45,30 @@ def ReusableSQLStep(agent, **config) -> Step:
 # Usage:
 pipeline = ReusableSQLStep(my_sql_agent) >> Step.validate(...)
 ```
+
+### Creating a Custom Execution Backend
+
+Execution back-ends allow you to control how and where pipeline steps run.
+Implement the `ExecutionBackend` protocol and pass your implementation to
+`Flujo`.
+
+```python
+from flujo.domain.backends import ExecutionBackend, StepExecutionRequest
+from flujo.domain.models import StepResult
+
+class LoggingBackend(ExecutionBackend):
+    def __init__(self, registry: dict[str, Any]):
+        self.agent_registry = registry
+
+    async def execute_step(self, request: StepExecutionRequest) -> StepResult:
+        print(f"Executing {request.step.name}")
+        agent = request.step.agent
+        output = await agent.run(request.input_data)
+        return StepResult(name=request.step.name, output=output)
+
+custom_backend = LoggingBackend({})
+runner = Flujo(pipeline, backend=custom_backend)
+```
+
+For remote back-ends, use the `agent_registry` to safely map agent names to
+trusted objects.

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -23,6 +23,8 @@ from .domain import (
     AppResources,
 )
 from .domain.types import HookCallable
+from .domain.backends import ExecutionBackend, StepExecutionRequest
+from .infra.backends import LocalBackend
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult, UsageLimits
@@ -83,4 +85,7 @@ __all__ = [
     "DummyPlugin",
     "SQLSyntaxValidator",
     "UsageLimits",
+    "ExecutionBackend",
+    "StepExecutionRequest",
+    "LocalBackend",
 ]

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -11,6 +11,7 @@ from .pipeline_dsl import (
 from .plugins import PluginOutcome, ValidationPlugin
 from .resources import AppResources
 from .types import HookCallable
+from .backends import ExecutionBackend, StepExecutionRequest
 
 __all__ = [
     "Step",
@@ -23,4 +24,6 @@ __all__ = [
     "ValidationPlugin",
     "AppResources",
     "HookCallable",
+    "ExecutionBackend",
+    "StepExecutionRequest",
 ]

--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Protocol, Any, Dict, Optional
+from pydantic import BaseModel
+
+from .pipeline_dsl import Step
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..application.flujo_engine import Flujo
+from .models import StepResult
+from .resources import AppResources
+from .agent_protocol import AsyncAgentProtocol
+
+
+class StepExecutionRequest(BaseModel):
+    """Serializable request for executing a single step."""
+
+    step: Step
+    input_data: Any
+    pipeline_context: Optional[BaseModel] | None = None
+    resources: Optional[AppResources] = None
+    engine: Optional["Flujo"] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class ExecutionBackend(Protocol):
+    """Protocol for executing pipeline steps."""
+
+    agent_registry: Dict[str, AsyncAgentProtocol]
+
+    async def execute_step(self, request: StepExecutionRequest) -> StepResult:
+        """Execute a single step and return the result."""
+        ...

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..domain.backends import ExecutionBackend, StepExecutionRequest
+from ..domain.agent_protocol import AsyncAgentProtocol
+from ..domain.models import StepResult
+from ..application.flujo_engine import _run_step_logic
+
+
+class LocalBackend(ExecutionBackend):
+    """Backend that executes steps in the current process."""
+
+    def __init__(self, agent_registry: Dict[str, AsyncAgentProtocol] | None = None) -> None:
+        self.agent_registry = agent_registry or {}
+        self.engine = None
+
+    async def execute_step(self, request: StepExecutionRequest) -> StepResult:
+        if request.engine is None:
+            engine = self.engine
+        else:
+            engine = request.engine
+        return await _run_step_logic(
+            engine,
+            request.step,
+            request.input_data,
+            request.pipeline_context,
+            request.resources,
+        )

--- a/tests/unit/test_execution_backend.py
+++ b/tests/unit/test_execution_backend.py
@@ -1,0 +1,27 @@
+import pytest
+
+from flujo import Step, Flujo
+from flujo.testing.utils import StubAgent, gather_result
+from flujo.domain.backends import StepExecutionRequest
+from flujo.domain.models import StepResult
+
+
+class DummyBackend:
+    def __init__(self):
+        self.called = 0
+        self.agent_registry = {}
+
+    async def execute_step(self, request: StepExecutionRequest) -> StepResult:
+        self.called += 1
+        return StepResult(name=request.step.name, output="ok")
+
+
+@pytest.mark.asyncio
+async def test_custom_backend_invoked() -> None:
+    backend = DummyBackend()
+    step = Step("s", StubAgent(["ignored"]))
+    runner = Flujo(step, backend=backend)
+    result = await gather_result(runner, "in")
+    assert backend.called == 1
+    assert result.step_history[0].output == "ok"
+    assert step.agent.call_count == 0


### PR DESCRIPTION
## Summary
- introduce `ExecutionBackend` protocol and `StepExecutionRequest`
- implement default `LocalBackend`
- refactor `Flujo` to delegate step execution via backend
- document pluggable back-ends and how to create custom ones
- test custom backend integration

## Testing
- `ruff check flujo docs tests/unit/test_execution_backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bac25b98832c940f605236d50a43