### PR TITLE
Implement pluggable execution backends

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -51,6 +51,7 @@ from flujo import (
     Step, Flujo, Task,
     review_agent, solution_agent, validator_agent,
 )
+from flujo.infra.backends import LocalBackend
 from pydantic import BaseModel
 from typing import Any
 from flujo import AppResources, UsageLimits
@@ -85,6 +86,7 @@ runner_with_ctx = Flujo(
     resources=my_resources,
     usage_limits=UsageLimits(total_cost_usd_limit=10.0),
     hooks=[my_hook],
+    backend=LocalBackend(),
 )
 
 # Advanced constructs
@@ -281,6 +283,29 @@ limits = UsageLimits(
     total_tokens_limit: Optional[int] = None,
 )
 ```
+
+### Execution Backends
+
+`Flujo` delegates step execution to an `ExecutionBackend`. The built-in
+`LocalBackend` runs steps in the current process.
+
+```python
+from flujo.domain.backends import ExecutionBackend, StepExecutionRequest
+from flujo.infra.backends import LocalBackend
+```
+
+`StepExecutionRequest` is the payload sent to a backend:
+
+```python
+StepExecutionRequest(
+    step=Step(...),
+    input_data=..., 
+    pipeline_context=PipelineContext(initial_prompt=""),
+    resources=None,
+)
+```
+
+Custom backends implement `execute_step(request) -> StepResult`.
 
 ### Lifecycle Hooks
 

--- a/flujo/application/self_improvement.py
+++ b/flujo/application/self_improvement.py
@@ -15,6 +15,8 @@ from ..domain.models import (
 from ..domain.pipeline_dsl import Pipeline, Step
 from ..utils.redact import summarize_and_redact_prompt
 
+MAX_STEP_OUTPUT_LENGTH = 150
+
 
 class SelfImprovementAgent:
     """Agent that analyzes failures and suggests improvements."""

--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -4,11 +4,7 @@ from typing import Protocol, Any, Dict, Optional
 from pydantic import BaseModel
 
 from .pipeline_dsl import Step
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from ..application.flujo_engine import Flujo
-from .models import StepResult
+from .models import StepResult, PipelineContext
 from .resources import AppResources
 from .agent_protocol import AsyncAgentProtocol
 
@@ -20,7 +16,9 @@ class StepExecutionRequest(BaseModel):
     input_data: Any
     pipeline_context: Optional[BaseModel] | None = None
     resources: Optional[AppResources] = None
-    engine: Optional["Flujo"] = None
+    # Whether the runner was created with a context model. Needed for
+    # proper context passing semantics.
+    context_model_defined: bool = False
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict, Optional
+
+from ..domain.pipeline_dsl import Step
+from ..domain.resources import AppResources
 
 from ..domain.backends import ExecutionBackend, StepExecutionRequest
 from ..domain.agent_protocol import AsyncAgentProtocol
+from pydantic import BaseModel
 from ..domain.models import StepResult
 from ..application.flujo_engine import _run_step_logic
 
@@ -11,19 +15,32 @@ from ..application.flujo_engine import _run_step_logic
 class LocalBackend(ExecutionBackend):
     """Backend that executes steps in the current process."""
 
-    def __init__(self, agent_registry: Dict[str, AsyncAgentProtocol] | None = None) -> None:
+    def __init__(
+        self, agent_registry: Dict[str, AsyncAgentProtocol] | None = None
+    ) -> None:
         self.agent_registry = agent_registry or {}
-        self.engine = None
 
     async def execute_step(self, request: StepExecutionRequest) -> StepResult:
-        if request.engine is None:
-            engine = self.engine
-        else:
-            engine = request.engine
+        async def executor(
+            step: Step,
+            data: Any,
+            pipeline_context: Optional[BaseModel],
+            resources: Optional[AppResources],
+        ) -> StepResult:
+            nested_request = StepExecutionRequest(
+                step=step,
+                input_data=data,
+                pipeline_context=pipeline_context,
+                resources=resources,
+                context_model_defined=request.context_model_defined,
+            )
+            return await self.execute_step(nested_request)
+
         return await _run_step_logic(
-            engine,
             request.step,
             request.input_data,
             request.pipeline_context,
             request.resources,
+            step_executor=executor,
+            context_model_defined=request.context_model_defined,
         )


### PR DESCRIPTION
## Summary
- add `LocalBackend` default and step execution request model
- refactor engine logic into `_run_step_logic` and pure helpers
- document pluggable execution backends and backend usage
- ensure nested steps dispatch through configured backend and context passing logic is restored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cf20b060832c88bf32ee2ab42fc8