### PR TITLE
Fix StepExecutionRequest generics

### DIFF
--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -12,7 +12,10 @@ from .agent_protocol import AsyncAgentProtocol
 class StepExecutionRequest(BaseModel):
     """Serializable request for executing a single step."""
 
-    step: Step[Any, Any]
+    # Use unparameterized Step here to avoid Pydantic recreating the object and
+    # resetting configuration like ``max_retries`` when a concrete Step instance
+    # is provided.
+    step: Step
     input_data: Any
     pipeline_context: Optional[BaseModel] | None = None
     resources: Optional[AppResources] = None


### PR DESCRIPTION
## Summary
- ensure `StepExecutionRequest` preserves the provided step instance instead of
  re-parsing it which reset `max_retries`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6851e617295c832c89b3f3ade64342a2