### PR TITLE
Add integration tests for pipeline behaviors

### DIFF
--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -4,7 +4,7 @@ from typing import Protocol, Any, Dict, Optional
 from pydantic import BaseModel
 
 from .pipeline_dsl import Step
-from .models import StepResult
+from .models import StepResult, UsageLimits
 from .resources import AppResources
 from .agent_protocol import AsyncAgentProtocol
 
@@ -12,16 +12,18 @@ from .agent_protocol import AsyncAgentProtocol
 class StepExecutionRequest(BaseModel):
     """Serializable request for executing a single step."""
 
-    # Use unparameterized Step here to avoid Pydantic recreating the object and
-    # resetting configuration like ``max_retries`` when a concrete Step instance
-    # is provided.
-    step: Step[Any, Any]
+    # Use unparameterized ``Step`` type so Pydantic will not recreate the object
+    # and accidentally reset attributes like ``max_retries``.
+    step: Step
     input_data: Any
     pipeline_context: Optional[BaseModel] | None = None
     resources: Optional[AppResources] = None
     # Whether the runner was created with a context model. Needed for
     # proper context passing semantics.
     context_model_defined: bool = False
+    # Usage limits, propagated so nested executions (e.g., LoopStep) can enforce
+    # governor checks mid-execution.
+    usage_limits: Optional["UsageLimits"] = None
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -22,7 +22,7 @@ class LocalBackend(ExecutionBackend):
 
     async def execute_step(self, request: StepExecutionRequest) -> StepResult:
         async def executor(
-            step: Step[Any, Any],
+            step: Step,
             data: Any,
             pipeline_context: Optional[BaseModel],
             resources: Optional[AppResources],
@@ -33,6 +33,7 @@ class LocalBackend(ExecutionBackend):
                 pipeline_context=pipeline_context,
                 resources=resources,
                 context_model_defined=request.context_model_defined,
+                usage_limits=request.usage_limits,
             )
             return await self.execute_step(nested_request)
 
@@ -43,4 +44,5 @@ class LocalBackend(ExecutionBackend):
             request.resources,
             step_executor=executor,
             context_model_defined=request.context_model_defined,
+            usage_limits=request.usage_limits,
         )

--- a/tests/integration/test_execution_backend_protocol.py
+++ b/tests/integration/test_execution_backend_protocol.py
@@ -1,0 +1,18 @@
+import pytest
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step
+from flujo.testing.utils import StubAgent, DummyRemoteBackend
+
+
+def test_pipeline_runs_correctly_with_custom_backend() -> None:
+    backend = DummyRemoteBackend()
+    pipeline = Step("a", StubAgent(["x"])) >> Step("b", StubAgent(["y"]))
+    runner = Flujo(pipeline, backend=backend)
+
+    result = runner.run("start")
+
+    assert backend.call_counter == 2
+    assert len(result.step_history) == 2
+    assert all(sr.success for sr in result.step_history)
+    assert result.step_history[-1].output == "y"


### PR DESCRIPTION
## Summary
- add FailingStreamAgent and DummyRemoteBackend helpers
- implement tests for governor breach mid-loop, streaming errors, backend protocol, concurrent contexts, and HITL state serialization
- fix backend step configuration preservation and governor enforcement mid-loop
- handle streaming agent failures gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f153b960832c918dfd67938ac663