### PR TITLE
Add ConsoleTracer tracing system

### DIFF
--- a/docs/cookbook/console_tracer.md
+++ b/docs/cookbook/console_tracer.md
@@ -1,0 +1,26 @@
+# Cookbook: Using the Console Tracer
+
+## The Problem
+
+When developing pipelines, it can be hard to understand what happens at each step. You want instant feedback in your terminal with minimal setup.
+
+## The Solution
+
+The `ConsoleTracer` provides rich, colorized output for every step in a run. Enable it via the `local_tracer` parameter when constructing `Flujo`.
+
+```python
+from flujo import Flujo, Step
+from flujo.tracing import ConsoleTracer
+from flujo.testing.utils import StubAgent
+
+step = Step("example", StubAgent(["ok"]))
+
+# Quick enablement with the built-in defaults
+runner = Flujo(step, local_tracer="default")
+
+# Or configure it yourself
+custom = ConsoleTracer(level="debug", log_inputs=True)
+runner_custom = Flujo(step, local_tracer=custom)
+```
+
+With `level="info"` only high‑level events are printed. `level="debug"` also shows inputs and outputs.

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -25,6 +25,7 @@ from .domain import (
 from .domain.types import HookCallable
 from .domain.backends import ExecutionBackend, StepExecutionRequest
 from .infra.backends import LocalBackend
+from .tracing import ConsoleTracer
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult, UsageLimits
@@ -88,4 +89,5 @@ __all__ = [
     "ExecutionBackend",
     "StepExecutionRequest",
     "LocalBackend",
+    "ConsoleTracer",
 ]

--- a/flujo/domain/scoring.py
+++ b/flujo/domain/scoring.py
@@ -42,7 +42,9 @@ def weighted_score(check: Checklist, weights: List[Dict[str, Any]]) -> float:
     if total_weight == 0:
         return 0.0
 
-    score = sum(weight_map.get(item.description, 1.0) for item in check.items if item.passed)
+    score = sum(
+        weight_map.get(item.description, 1.0) for item in check.items if item.passed
+    )
     return score / total_weight
 
 
@@ -62,7 +64,7 @@ class RewardScorer:
 
         # The Agent constructor's type hints are not strict enough for mypy strict mode.
         # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-        self.agent = Agent(  # type: ignore[call-overload]
+        self.agent = Agent(
             "openai:gpt-4o-mini",
             system_prompt="You are a reward model. You return a single float score from 0.0 to 1.0.",
             output_type=float,

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -165,7 +165,7 @@ def make_agent(
 
     # The Agent constructor's type hints are not strict enough for mypy strict mode.
     # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-    agent: Agent[Any, Any] = Agent(  # type: ignore[call-overload]
+    agent: Agent[Any, Any] = Agent(
         model=model,
         system_prompt=system_prompt,
         output_type=output_type,
@@ -175,7 +175,9 @@ def make_agent(
     return agent
 
 
-class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]):
+class AsyncAgentWrapper(
+    Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]
+):
     """
     Wraps a pydantic_ai.Agent to provide an asynchronous interface
     with retry and timeout capabilities.
@@ -189,7 +191,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         model_name: str | None = None,
     ) -> None:
         if not isinstance(max_retries, int):
-            raise TypeError(f"max_retries must be an integer, got {type(max_retries).__name__}.")
+            raise TypeError(
+                f"max_retries must be an integer, got {type(max_retries).__name__}."
+            )
         if max_retries < 0:
             raise ValueError("max_retries must be a non-negative integer.")
         if timeout is not None:
@@ -204,7 +208,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         self._timeout_seconds: int | None = (
             timeout if timeout is not None else settings.agent_timeout
         )
-        self._model_name: str | None = model_name or getattr(agent, "model", "unknown_model")
+        self._model_name: str | None = model_name or getattr(
+            agent, "model", "unknown_model"
+        )
 
     def _call_agent_with_dynamic_args(self, *args: Any, **kwargs: Any) -> Any:
         return self._agent.run(*args, **kwargs)
@@ -222,7 +228,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         # internal function-calling message generation, not Pydantic model
         # instances. We automatically serialize any BaseModel inputs here to
         # ensure compatibility.
-        processed_args = [arg.model_dump() if isinstance(arg, BaseModel) else arg for arg in args]
+        processed_args = [
+            arg.model_dump() if isinstance(arg, BaseModel) else arg for arg in args
+        ]
         processed_kwargs = {
             key: value.model_dump() if isinstance(value, BaseModel) else value
             for key, value in kwargs.items()
@@ -244,11 +252,13 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
                         ),
                         timeout=self._timeout_seconds,
                     )
-                    logfire.info(f"Agent '{self._model_name}' raw response: {raw_agent_response}")
+                    logfire.info(
+                        f"Agent '{self._model_name}' raw response: {raw_agent_response}"
+                    )
 
-                    if isinstance(raw_agent_response, str) and raw_agent_response.startswith(
-                        "Agent failed after"
-                    ):
+                    if isinstance(
+                        raw_agent_response, str
+                    ) and raw_agent_response.startswith("Agent failed after"):
                         raise OrchestratorRetryError(raw_agent_response)
 
                     return raw_agent_response
@@ -282,7 +292,9 @@ def make_agent_async(
     Creates a pydantic_ai.Agent and returns an AsyncAgentWrapper exposing .run_async.
     """
     agent = make_agent(model, system_prompt, output_type)
-    return AsyncAgentWrapper(agent, max_retries=max_retries, timeout=timeout, model_name=model)
+    return AsyncAgentWrapper(
+        agent, max_retries=max_retries, timeout=timeout, model_name=model
+    )
 
 
 class NoOpReflectionAgent(AsyncAgentProtocol[Any, str]):
@@ -340,7 +352,9 @@ def get_reflection_agent(
 
 
 # Create a default instance for convenience and API consistency
-reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = get_reflection_agent()
+reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = (
+    get_reflection_agent()
+)
 
 
 def make_self_improvement_agent(
@@ -368,7 +382,9 @@ class LoggingReviewAgent(AsyncAgentProtocol[Any, Any]):
         return await self._run_inner(self.agent.run, *args, **kwargs)
 
     async def _run_async(self, *args: Any, **kwargs: Any) -> Any:
-        if hasattr(self.agent, "run_async") and callable(getattr(self.agent, "run_async")):
+        if hasattr(self.agent, "run_async") and callable(
+            getattr(self.agent, "run_async")
+        ):
             return await self._run_inner(self.agent.run_async, *args, **kwargs)
         else:
             return await self.run(*args, **kwargs)

--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+__all__ = ["ConsoleTracer"]
+
+
+class ConsoleTracer:
+    """Configurable tracer that prints rich output to the console."""
+
+    def __init__(
+        self,
+        *,
+        level: Literal["info", "debug"] = "debug",
+        log_inputs: bool = True,
+        log_outputs: bool = True,
+        colorized: bool = True,
+    ) -> None:
+        self.level = level
+        self.log_inputs = log_inputs
+        self.log_outputs = log_outputs
+        self.console = (
+            Console(highlight=False)
+            if colorized
+            else Console(no_color=True, highlight=False)
+        )
+
+    async def hook(self, **kwargs: Any) -> None:
+        event = kwargs.get("event_name")
+        if event == "pre_step":
+            step = kwargs.get("step")
+            step_input = kwargs.get("step_input")
+            title = f"Step Start: {step.name if step else ''}"
+            if self.level == "debug" and self.log_inputs:
+                body = Text(repr(step_input))
+            else:
+                body = Text("running")
+            self.console.print(Panel(body, title=title))
+        elif event == "post_step":
+            step_result = kwargs.get("step_result")
+            if step_result is None:
+                return
+            title = f"Step End: {step_result.name}"
+            status = "SUCCESS" if step_result.success else "FAILED"
+            color = "green" if step_result.success else "red"
+            body_text = Text(f"Status: {status}", style=f"bold {color}")
+            if self.level == "debug" and self.log_outputs:
+                body_text.append(f"\nOutput: {repr(step_result.output)}")
+            self.console.print(Panel(body_text, title=title))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Cookbook:
     - 'Controlling Costs': cookbook/cost_control.md
     - 'Lifecycle Hooks': cookbook/lifecycle_hooks.md
+    - 'Console Tracer': cookbook/console_tracer.md
     - 'Using Resources': cookbook/using_resources.md
     - 'HITL Simple Approval': cookbook/hitl_simple_approval.md
     - 'HITL Dynamic Clarification': cookbook/hitl_dynamic_clarification.md

--- a/tests/integration/test_local_tracer.py
+++ b/tests/integration/test_local_tracer.py
@@ -1,0 +1,42 @@
+import pytest
+from typing import Any, cast
+from flujo import Flujo, Step
+from flujo.tracing import ConsoleTracer
+from flujo.testing.utils import StubAgent, gather_result
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_default_local_tracer_added() -> None:
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer="default")
+    assert len(runner.hooks) == 1
+    assert callable(runner.hooks[0])
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_custom_console_tracer_instance() -> None:
+    tracer = ConsoleTracer(level="info")
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer=tracer)
+    assert tracer.hook in runner.hooks
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_tracer_outputs_info_level(capsys: pytest.CaptureFixture[str]) -> None:
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer="default")
+    await gather_result(runner, "in")
+    captured = capsys.readouterr().out
+    assert "Step Start" in captured
+    assert "Status" in captured
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_tracer_outputs_debug_level(capsys: pytest.CaptureFixture[str]) -> None:
+    tracer = ConsoleTracer(level="debug")
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer=tracer)
+    await gather_result(runner, "in")
+    captured = capsys.readouterr().out
+    assert "Output" in captured

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import MagicMock
+from typing import Any
+from flujo.tracing import ConsoleTracer
+from flujo.domain.models import StepResult
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_console_tracer_hook_prints() -> None:
+    tracer = ConsoleTracer(level="debug")
+    spy = MagicMock()
+    tracer.console.print = spy
+    result = StepResult(name="s", output="out")
+    await tracer.hook(event_name="post_step", step_result=result)
+    spy.assert_called()
+
+
+def test_console_tracer_config() -> None:
+    tracer = ConsoleTracer(level="info", log_inputs=False, log_outputs=False)
+    assert tracer.level == "info"
+    assert not tracer.log_inputs
+    assert not tracer.log_outputs


### PR DESCRIPTION
## Summary
- implement `ConsoleTracer` for colorized local tracing
- integrate tracer into `Flujo` with new `local_tracer` argument
- document console tracer usage and add to navigation
- update agents module and scoring to drop unused type ignores
- test new tracer functionality

## Testing
- `pre-commit run --files flujo/tracing.py flujo/application/flujo_engine.py flujo/__init__.py flujo/infra/agents.py flujo/domain/scoring.py tests/unit/test_tracing.py tests/integration/test_local_tracer.py docs/cookbook/console_tracer.md mkdocs.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521e1b3e24832cb4893327608d67a5