### PR TITLE
Add ConsoleTracer tracing system

### DIFF
--- a/docs/cookbook/console_tracer.md
+++ b/docs/cookbook/console_tracer.md
@@ -1,0 +1,26 @@
+# Cookbook: Using the Console Tracer
+
+## The Problem
+
+When developing pipelines, it can be hard to understand what happens at each step. You want instant feedback in your terminal with minimal setup.
+
+## The Solution
+
+The `ConsoleTracer` provides rich, colorized output for every step in a run. Enable it via the `local_tracer` parameter when constructing `Flujo`.
+
+```python
+from flujo import Flujo, Step
+from flujo.tracing import ConsoleTracer
+from flujo.testing.utils import StubAgent
+
+step = Step("example", StubAgent(["ok"]))
+
+# Quick enablement with the built-in defaults
+runner = Flujo(step, local_tracer="default")
+
+# Or configure it yourself
+custom = ConsoleTracer(level="debug", log_inputs=True)
+runner_custom = Flujo(step, local_tracer=custom)
+```
+
+With `level="info"` only high‑level events are printed. `level="debug"` also shows inputs and outputs.

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -25,6 +25,7 @@ from .domain import (
 from .domain.types import HookCallable
 from .domain.backends import ExecutionBackend, StepExecutionRequest
 from .infra.backends import LocalBackend
+from .tracing import ConsoleTracer
 from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult, UsageLimits
@@ -88,4 +89,5 @@ __all__ = [
     "ExecutionBackend",
     "StepExecutionRequest",
     "LocalBackend",
+    "ConsoleTracer",
 ]

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -14,6 +14,7 @@ from typing import (
     TypeVar,
     AsyncIterator,
     Awaitable,
+    Union,
 )
 
 from pydantic import BaseModel, ValidationError
@@ -48,6 +49,7 @@ from pydantic import TypeAdapter
 from ..domain.resources import AppResources
 from ..domain.types import HookCallable
 from ..domain.backends import ExecutionBackend, StepExecutionRequest
+from ..tracing import ConsoleTracer
 
 _agent_command_adapter: TypeAdapter[AgentCommand] = TypeAdapter(AgentCommand)
 
@@ -56,7 +58,9 @@ class InfiniteRedirectError(OrchestratorError):
     """Raised when a redirect loop is detected."""
 
 
-_accepts_param_cache_weak: "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]" = weakref.WeakKeyDictionary()
+_accepts_param_cache_weak: (
+    "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]"
+) = weakref.WeakKeyDictionary()
 _accepts_param_cache_id: weakref.WeakValueDictionary[int, Dict[str, Optional[bool]]] = (
     weakref.WeakValueDictionary()
 )
@@ -84,7 +88,9 @@ def _accepts_param(func: Callable[..., Any], param: str) -> Optional[bool]:
     else:
         if param in sig.parameters:
             result = True
-        elif any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        elif any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        ):
             result = True
         else:
             result = False
@@ -127,7 +133,9 @@ async def _execute_loop_step_logic(
                 f"Error in initial_input_to_loop_body_mapper for LoopStep '{loop_step.name}': {e}"
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = f"Initial input mapper raised an exception: {e}"
+            loop_overall_result.feedback = (
+                f"Initial input mapper raised an exception: {e}"
+            )
             return loop_overall_result
     else:
         current_body_input = loop_step_initial_input
@@ -138,7 +146,9 @@ async def _execute_loop_step_logic(
 
     for i in range(1, loop_step.max_loops + 1):
         loop_overall_result.attempts = i
-        logfire.info(f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}")
+        logfire.info(
+            f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}"
+        )
 
         iteration_succeeded_fully = True
         current_iteration_data_for_body_step = current_body_input
@@ -155,15 +165,21 @@ async def _execute_loop_step_logic(
                 )
 
             loop_overall_result.latency_s += body_step_result_obj.latency_s
-            loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)
-            loop_overall_result.token_counts += getattr(body_step_result_obj, "token_counts", 0)
+            loop_overall_result.cost_usd += getattr(
+                body_step_result_obj, "cost_usd", 0.0
+            )
+            loop_overall_result.token_counts += getattr(
+                body_step_result_obj, "token_counts", 0
+            )
 
             if usage_limits is not None:
                 if (
                     usage_limits.total_cost_usd_limit is not None
                     and loop_overall_result.cost_usd > usage_limits.total_cost_usd_limit
                 ):
-                    logfire.warn(f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded")
+                    logfire.warn(
+                        f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+                    )
                     loop_overall_result.success = False
                     loop_overall_result.feedback = (
                         f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
@@ -172,16 +188,19 @@ async def _execute_loop_step_logic(
                         step_history=[loop_overall_result],
                         total_cost_usd=loop_overall_result.cost_usd,
                     )
-                    pr.final_pipeline_context = pipeline_context
+                    Flujo._set_final_context(pr, pipeline_context)
                     raise UsageLimitExceededError(
                         loop_overall_result.feedback,
                         pr,
                     )
                 if (
                     usage_limits.total_tokens_limit is not None
-                    and loop_overall_result.token_counts > usage_limits.total_tokens_limit
+                    and loop_overall_result.token_counts
+                    > usage_limits.total_tokens_limit
                 ):
-                    logfire.warn(f"Token limit of {usage_limits.total_tokens_limit} exceeded")
+                    logfire.warn(
+                        f"Token limit of {usage_limits.total_tokens_limit} exceeded"
+                    )
                     loop_overall_result.success = False
                     loop_overall_result.feedback = (
                         f"Token limit of {usage_limits.total_tokens_limit} exceeded"
@@ -190,7 +209,7 @@ async def _execute_loop_step_logic(
                         step_history=[loop_overall_result],
                         total_cost_usd=loop_overall_result.cost_usd,
                     )
-                    pr.final_pipeline_context = pipeline_context
+                    Flujo._set_final_context(pr, pipeline_context)
                     raise UsageLimitExceededError(
                         loop_overall_result.feedback,
                         pr,
@@ -215,13 +234,19 @@ async def _execute_loop_step_logic(
                 final_body_output_of_last_iteration, pipeline_context
             )
         except Exception as e:
-            logfire.error(f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}")
+            logfire.error(
+                f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}"
+            )
             loop_overall_result.success = False
-            loop_overall_result.feedback = f"Exit condition callable raised an exception: {e}"
+            loop_overall_result.feedback = (
+                f"Exit condition callable raised an exception: {e}"
+            )
             break
 
         if should_exit:
-            logfire.info(f"LoopStep '{loop_step.name}' exit condition met at iteration {i}.")
+            logfire.info(
+                f"LoopStep '{loop_step.name}' exit condition met at iteration {i}."
+            )
             loop_overall_result.success = iteration_succeeded_fully
             if not iteration_succeeded_fully:
                 loop_overall_result.feedback = (
@@ -263,18 +288,20 @@ async def _execute_loop_step_logic(
                     last_successful_iteration_body_output, pipeline_context
                 )
             except Exception as e:
-                logfire.error(f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}")
+                logfire.error(
+                    f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}"
+                )
                 loop_overall_result.success = False
-                loop_overall_result.feedback = f"Loop output mapper raised an exception: {e}"
+                loop_overall_result.feedback = (
+                    f"Loop output mapper raised an exception: {e}"
+                )
                 loop_overall_result.output = None
         else:
             loop_overall_result.output = last_successful_iteration_body_output
     else:
         loop_overall_result.output = final_body_output_of_last_iteration
         if not loop_overall_result.feedback:
-            loop_overall_result.feedback = (
-                "Loop did not complete successfully or exit condition not met positively."
-            )
+            loop_overall_result.feedback = "Loop did not complete successfully or exit condition not met positively."
 
     return loop_overall_result
 
@@ -313,7 +340,9 @@ async def _execute_conditional_step_logic(
                 conditional_overall_result.success = False
                 conditional_overall_result.feedback = err_msg
                 return conditional_overall_result
-            logfire.info(f"ConditionalStep '{conditional_step.name}': Executing default branch.")
+            logfire.info(
+                f"ConditionalStep '{conditional_step.name}': Executing default branch."
+            )
         else:
             logfire.info(
                 f"ConditionalStep '{conditional_step.name}': Executing branch for key '{branch_key_to_execute}'."
@@ -341,7 +370,9 @@ async def _execute_conditional_step_logic(
                 )
 
             conditional_overall_result.latency_s += branch_step_result_obj.latency_s
-            conditional_overall_result.cost_usd += getattr(branch_step_result_obj, "cost_usd", 0.0)
+            conditional_overall_result.cost_usd += getattr(
+                branch_step_result_obj, "cost_usd", 0.0
+            )
             conditional_overall_result.token_counts += getattr(
                 branch_step_result_obj, "token_counts", 0
             )
@@ -367,15 +398,19 @@ async def _execute_conditional_step_logic(
             exc_info=True,
         )
         conditional_overall_result.success = False
-        conditional_overall_result.feedback = f"Error executing conditional logic or branch: {e}"
+        conditional_overall_result.feedback = (
+            f"Error executing conditional logic or branch: {e}"
+        )
         return conditional_overall_result
 
     conditional_overall_result.success = branch_succeeded
     if branch_succeeded:
         if conditional_step.branch_output_mapper:
             try:
-                conditional_overall_result.output = conditional_step.branch_output_mapper(
-                    branch_output, executed_branch_key, pipeline_context
+                conditional_overall_result.output = (
+                    conditional_step.branch_output_mapper(
+                        branch_output, executed_branch_key, pipeline_context
+                    )
                 )
             except Exception as e:  # noqa: BLE001
                 logfire.error(
@@ -393,8 +428,12 @@ async def _execute_conditional_step_logic(
 
     conditional_overall_result.attempts = 1
     if executed_branch_key is not None:
-        conditional_overall_result.metadata_ = conditional_overall_result.metadata_ or {}
-        conditional_overall_result.metadata_["executed_branch_key"] = str(executed_branch_key)
+        conditional_overall_result.metadata_ = (
+            conditional_overall_result.metadata_ or {}
+        )
+        conditional_overall_result.metadata_["executed_branch_key"] = str(
+            executed_branch_key
+        )
 
     return conditional_overall_result
 
@@ -432,7 +471,9 @@ async def _run_step_logic(
             usage_limits=usage_limits,
         )
     if isinstance(step, HumanInTheLoopStep):
-        message = step.message_for_user if step.message_for_user is not None else str(data)
+        message = (
+            step.message_for_user if step.message_for_user is not None else str(data)
+        )
         if isinstance(pipeline_context, PipelineContext):
             pipeline_context.scratchpad["status"] = "paused"
         raise PausedException(message)
@@ -494,7 +535,9 @@ async def _run_step_logic(
                 if resources is not None and accepts_resources:
                     plugin_kwargs["resources"] = resources
                 plugin_result: PluginOutcome = await asyncio.wait_for(
-                    plugin.validate({"input": data, "output": unpacked_output}, **plugin_kwargs),
+                    plugin.validate(
+                        {"input": data, "output": unpacked_output}, **plugin_kwargs
+                    ),
                     timeout=step.config.timeout_s,
                 )
             except asyncio.TimeoutError as e:
@@ -525,7 +568,9 @@ async def _run_step_logic(
 
         if redirect_to:
             if redirect_to in visited:
-                raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
+                raise InfiniteRedirectError(
+                    f"Redirect loop detected in step {step.name}"
+                )
             visited.add(redirect_to)
             current_agent = redirect_to
         else:
@@ -542,10 +587,14 @@ async def _run_step_logic(
     result.success = False
     result.feedback = last_feedback
     result.token_counts += (
-        getattr(last_raw_output, "token_counts", 1) if last_raw_output is not None else 0
+        getattr(last_raw_output, "token_counts", 1)
+        if last_raw_output is not None
+        else 0
     )
     result.cost_usd += (
-        getattr(last_raw_output, "cost_usd", 0.0) if last_raw_output is not None else 0.0
+        getattr(last_raw_output, "cost_usd", 0.0)
+        if last_raw_output is not None
+        else 0.0
     )
     return result
 
@@ -562,6 +611,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         usage_limits: Optional[UsageLimits] = None,
         hooks: Optional[list[HookCallable]] = None,
         backend: Optional[ExecutionBackend] = None,
+        local_tracer: Union[str, "ConsoleTracer", None] = None,
     ) -> None:
         if isinstance(pipeline, Step):
             pipeline = Pipeline.from_step(pipeline)
@@ -571,6 +621,13 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         self.resources = resources
         self.usage_limits = usage_limits
         self.hooks = hooks or []
+        tracer_instance = None
+        if isinstance(local_tracer, ConsoleTracer):
+            tracer_instance = local_tracer
+        elif local_tracer == "default":
+            tracer_instance = ConsoleTracer()
+        if tracer_instance:
+            self.hooks.append(tracer_instance.hook)
         if backend is None:
             from ..infra.backends import LocalBackend
 
@@ -623,7 +680,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     span.set_attribute("governor_breached", True)
                 except Exception:  # noqa: BLE001
                     pass
-            logfire.warn(f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded")
+            logfire.warn(
+                f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded"
+            )
             raise UsageLimitExceededError(
                 f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded",
                 pipeline_result,
@@ -638,11 +697,18 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     span.set_attribute("governor_breached", True)
                 except Exception:  # noqa: BLE001
                     pass
-            logfire.warn(f"Token limit of {self.usage_limits.total_tokens_limit} exceeded")
+            logfire.warn(
+                f"Token limit of {self.usage_limits.total_tokens_limit} exceeded"
+            )
             raise UsageLimitExceededError(
                 f"Token limit of {self.usage_limits.total_tokens_limit} exceeded",
                 pipeline_result,
             )
+
+    @staticmethod
+    def _set_final_context(result: PipelineResult, ctx: Optional[BaseModel]) -> None:
+        if ctx is not None:
+            result.final_pipeline_context = ctx
 
     async def run_async(
         self,
@@ -666,7 +732,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                 ) from e
 
         else:
-            current_pipeline_context_instance = PipelineContext(initial_prompt=str(initial_input))
+            current_pipeline_context_instance = PipelineContext(
+                initial_prompt=str(initial_input)
+            )
 
         if isinstance(current_pipeline_context_instance, PipelineContext):
             current_pipeline_context_instance.scratchpad["status"] = "running"
@@ -691,13 +759,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                 with logfire.span(step.name) as span:
                     try:
                         is_last = idx == len(self.pipeline.steps) - 1
-                        if is_last and step.agent is not None and hasattr(step.agent, "stream"):
+                        if (
+                            is_last
+                            and step.agent is not None
+                            and hasattr(step.agent, "stream")
+                        ):
                             agent_kwargs: Dict[str, Any] = {}
                             target = getattr(step.agent, "_agent", step.agent)
-                            if current_pipeline_context_instance is not None and _accepts_param(
-                                target.stream, "pipeline_context"
+                            if (
+                                current_pipeline_context_instance is not None
+                                and _accepts_param(target.stream, "pipeline_context")
                             ):
-                                agent_kwargs["pipeline_context"] = current_pipeline_context_instance
+                                agent_kwargs["pipeline_context"] = (
+                                    current_pipeline_context_instance
+                                )
                             if self.resources is not None and _accepts_param(
                                 target.stream, "resources"
                             ):
@@ -705,7 +780,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                             chunks: list[Any] = []
                             start = time.monotonic()
                             try:
-                                async for chunk in step.agent.stream(data, **agent_kwargs):
+                                async for chunk in step.agent.stream(
+                                    data, **agent_kwargs
+                                ):
                                     chunks.append(chunk)
                                     yield chunk
                                 latency = time.monotonic() - start
@@ -744,14 +821,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                                 resources=self.resources,
                             )
                     except PausedException as e:
-                        if isinstance(current_pipeline_context_instance, PipelineContext):
-                            current_pipeline_context_instance.scratchpad["status"] = "paused"
-                            current_pipeline_context_instance.scratchpad["pause_message"] = str(e)
+                        if isinstance(
+                            current_pipeline_context_instance, PipelineContext
+                        ):
+                            current_pipeline_context_instance.scratchpad["status"] = (
+                                "paused"
+                            )
+                            current_pipeline_context_instance.scratchpad[
+                                "pause_message"
+                            ] = str(e)
                             scratch = current_pipeline_context_instance.scratchpad
                             if "paused_step_input" not in scratch:
                                 scratch["paused_step_input"] = data
-                        pipeline_result_obj.final_pipeline_context = (
-                            current_pipeline_context_instance
+                        self._set_final_context(
+                            pipeline_result_obj, current_pipeline_context_instance
                         )
                         break
                     if step_result.metadata_:
@@ -777,7 +860,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                         pipeline_context=current_pipeline_context_instance,
                         resources=self.resources,
                     )
-                    logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
+                    logfire.warn(
+                        f"Step '{step.name}' failed. Halting pipeline execution."
+                    )
                     break
                 step_output: Optional[RunnerInT] = step_result.output
                 data = step_output
@@ -789,13 +874,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             logfire.info(str(e))
         except UsageLimitExceededError as e:
             if current_pipeline_context_instance is not None:
-                pipeline_result_obj.final_pipeline_context = current_pipeline_context_instance
+                self._set_final_context(
+                    pipeline_result_obj, current_pipeline_context_instance
+                )
             raise e
         finally:
             if current_pipeline_context_instance is not None:
-                pipeline_result_obj.final_pipeline_context = current_pipeline_context_instance
+                self._set_final_context(
+                    pipeline_result_obj, current_pipeline_context_instance
+                )
                 if isinstance(current_pipeline_context_instance, PipelineContext):
-                    if current_pipeline_context_instance.scratchpad.get("status") != "paused":
+                    if (
+                        current_pipeline_context_instance.scratchpad.get("status")
+                        != "paused"
+                    ):
                         status = (
                             "completed"
                             if all(s.success for s in pipeline_result_obj.step_history)
@@ -821,7 +913,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         *,
         initial_context_data: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[Any]:
-        async for item in self.run_async(initial_input, initial_context_data=initial_context_data):
+        async for item in self.run_async(
+            initial_input, initial_context_data=initial_context_data
+        ):
             yield item
 
     def run(
@@ -841,7 +935,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
 
         return asyncio.run(_consume())
 
-    async def resume_async(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+    async def resume_async(
+        self, paused_result: PipelineResult, human_input: Any
+    ) -> PipelineResult:
         """Resume a paused pipeline with human input."""
         ctx = paused_result.final_pipeline_context
         if ctx is None:
@@ -854,7 +950,10 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
             raise OrchestratorError("No steps remaining to resume")
         paused_step = self.pipeline.steps[start_idx]
 
-        if isinstance(paused_step, HumanInTheLoopStep) and paused_step.input_schema is not None:
+        if (
+            isinstance(paused_step, HumanInTheLoopStep)
+            and paused_step.input_schema is not None
+        ):
             human_input = paused_step.input_schema.model_validate(human_input)
 
         if isinstance(ctx, PipelineContext):
@@ -909,7 +1008,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                     if isinstance(ctx, PipelineContext):
                         ctx.scratchpad["status"] = "paused"
                         ctx.scratchpad["pause_message"] = str(e)
-                    paused_result.final_pipeline_context = ctx
+                    self._set_final_context(paused_result, ctx)
                     break
                 if step_result.metadata_:
                     for key, value in step_result.metadata_.items():
@@ -941,9 +1040,11 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         if isinstance(ctx, PipelineContext):
             if ctx.scratchpad.get("status") != "paused":
                 status = (
-                    "completed" if all(s.success for s in paused_result.step_history) else "failed"
+                    "completed"
+                    if all(s.success for s in paused_result.step_history)
+                    else "failed"
                 )
                 ctx.scratchpad["status"] = status
 
-        paused_result.final_pipeline_context = ctx
+        self._set_final_context(paused_result, ctx)
         return paused_result

--- a/flujo/domain/scoring.py
+++ b/flujo/domain/scoring.py
@@ -42,7 +42,9 @@ def weighted_score(check: Checklist, weights: List[Dict[str, Any]]) -> float:
     if total_weight == 0:
         return 0.0
 
-    score = sum(weight_map.get(item.description, 1.0) for item in check.items if item.passed)
+    score = sum(
+        weight_map.get(item.description, 1.0) for item in check.items if item.passed
+    )
     return score / total_weight
 
 
@@ -62,7 +64,7 @@ class RewardScorer:
 
         # The Agent constructor's type hints are not strict enough for mypy strict mode.
         # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-        self.agent = Agent(  # type: ignore[call-overload]
+        self.agent = Agent(
             "openai:gpt-4o-mini",
             system_prompt="You are a reward model. You return a single float score from 0.0 to 1.0.",
             output_type=float,

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -165,7 +165,7 @@ def make_agent(
 
     # The Agent constructor's type hints are not strict enough for mypy strict mode.
     # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-    agent: Agent[Any, Any] = Agent(  # type: ignore[call-overload]
+    agent: Agent[Any, Any] = Agent(
         model=model,
         system_prompt=system_prompt,
         output_type=output_type,
@@ -175,7 +175,9 @@ def make_agent(
     return agent
 
 
-class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]):
+class AsyncAgentWrapper(
+    Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentInT, AgentOutT]
+):
     """
     Wraps a pydantic_ai.Agent to provide an asynchronous interface
     with retry and timeout capabilities.
@@ -189,7 +191,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         model_name: str | None = None,
     ) -> None:
         if not isinstance(max_retries, int):
-            raise TypeError(f"max_retries must be an integer, got {type(max_retries).__name__}.")
+            raise TypeError(
+                f"max_retries must be an integer, got {type(max_retries).__name__}."
+            )
         if max_retries < 0:
             raise ValueError("max_retries must be a non-negative integer.")
         if timeout is not None:
@@ -204,7 +208,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         self._timeout_seconds: int | None = (
             timeout if timeout is not None else settings.agent_timeout
         )
-        self._model_name: str | None = model_name or getattr(agent, "model", "unknown_model")
+        self._model_name: str | None = model_name or getattr(
+            agent, "model", "unknown_model"
+        )
 
     def _call_agent_with_dynamic_args(self, *args: Any, **kwargs: Any) -> Any:
         return self._agent.run(*args, **kwargs)
@@ -222,7 +228,9 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         # internal function-calling message generation, not Pydantic model
         # instances. We automatically serialize any BaseModel inputs here to
         # ensure compatibility.
-        processed_args = [arg.model_dump() if isinstance(arg, BaseModel) else arg for arg in args]
+        processed_args = [
+            arg.model_dump() if isinstance(arg, BaseModel) else arg for arg in args
+        ]
         processed_kwargs = {
             key: value.model_dump() if isinstance(value, BaseModel) else value
             for key, value in kwargs.items()
@@ -244,11 +252,13 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
                         ),
                         timeout=self._timeout_seconds,
                     )
-                    logfire.info(f"Agent '{self._model_name}' raw response: {raw_agent_response}")
+                    logfire.info(
+                        f"Agent '{self._model_name}' raw response: {raw_agent_response}"
+                    )
 
-                    if isinstance(raw_agent_response, str) and raw_agent_response.startswith(
-                        "Agent failed after"
-                    ):
+                    if isinstance(
+                        raw_agent_response, str
+                    ) and raw_agent_response.startswith("Agent failed after"):
                         raise OrchestratorRetryError(raw_agent_response)
 
                     return raw_agent_response
@@ -282,7 +292,9 @@ def make_agent_async(
     Creates a pydantic_ai.Agent and returns an AsyncAgentWrapper exposing .run_async.
     """
     agent = make_agent(model, system_prompt, output_type)
-    return AsyncAgentWrapper(agent, max_retries=max_retries, timeout=timeout, model_name=model)
+    return AsyncAgentWrapper(
+        agent, max_retries=max_retries, timeout=timeout, model_name=model
+    )
 
 
 class NoOpReflectionAgent(AsyncAgentProtocol[Any, str]):
@@ -340,7 +352,9 @@ def get_reflection_agent(
 
 
 # Create a default instance for convenience and API consistency
-reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = get_reflection_agent()
+reflection_agent: AsyncAgentProtocol[Any, Any] | NoOpReflectionAgent = (
+    get_reflection_agent()
+)
 
 
 def make_self_improvement_agent(
@@ -368,7 +382,9 @@ class LoggingReviewAgent(AsyncAgentProtocol[Any, Any]):
         return await self._run_inner(self.agent.run, *args, **kwargs)
 
     async def _run_async(self, *args: Any, **kwargs: Any) -> Any:
-        if hasattr(self.agent, "run_async") and callable(getattr(self.agent, "run_async")):
+        if hasattr(self.agent, "run_async") and callable(
+            getattr(self.agent, "run_async")
+        ):
             return await self._run_inner(self.agent.run_async, *args, **kwargs)
         else:
             return await self.run(*args, **kwargs)

--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+__all__ = ["ConsoleTracer"]
+
+
+class ConsoleTracer:
+    """Configurable tracer that prints rich output to the console."""
+
+    def __init__(
+        self,
+        *,
+        level: Literal["info", "debug"] = "debug",
+        log_inputs: bool = True,
+        log_outputs: bool = True,
+        colorized: bool = True,
+    ) -> None:
+        self.level = level
+        self.log_inputs = log_inputs
+        self.log_outputs = log_outputs
+        self.console = (
+            Console(highlight=False)
+            if colorized
+            else Console(no_color=True, highlight=False)
+        )
+
+    async def hook(self, **kwargs: Any) -> None:
+        event = kwargs.get("event_name")
+        if event == "pre_step":
+            step = kwargs.get("step")
+            step_input = kwargs.get("step_input")
+            title = f"Step Start: {step.name if step else ''}"
+            if self.level == "debug" and self.log_inputs:
+                body = Text(repr(step_input))
+            else:
+                body = Text("running")
+            self.console.print(Panel(body, title=title))
+        elif event == "post_step":
+            step_result = kwargs.get("step_result")
+            if step_result is None:
+                return
+            title = f"Step End: {step_result.name}"
+            status = "SUCCESS" if step_result.success else "FAILED"
+            color = "green" if step_result.success else "red"
+            body_text = Text(f"Status: {status}", style=f"bold {color}")
+            if self.level == "debug" and self.log_outputs:
+                body_text.append(f"\nOutput: {repr(step_result.output)}")
+            self.console.print(Panel(body_text, title=title))
+        else:
+            self.console.print(Panel(Text(str(event)), title="Unknown tracer event"))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Cookbook:
     - 'Controlling Costs': cookbook/cost_control.md
     - 'Lifecycle Hooks': cookbook/lifecycle_hooks.md
+    - 'Console Tracer': cookbook/console_tracer.md
     - 'Using Resources': cookbook/using_resources.md
     - 'HITL Simple Approval': cookbook/hitl_simple_approval.md
     - 'HITL Dynamic Clarification': cookbook/hitl_dynamic_clarification.md

--- a/tests/integration/test_local_tracer.py
+++ b/tests/integration/test_local_tracer.py
@@ -1,0 +1,42 @@
+import pytest
+from typing import Any, cast
+from flujo import Flujo, Step
+from flujo.tracing import ConsoleTracer
+from flujo.testing.utils import StubAgent, gather_result
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_default_local_tracer_added() -> None:
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer="default")
+    assert len(runner.hooks) == 1
+    assert callable(runner.hooks[0])
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_custom_console_tracer_instance() -> None:
+    tracer = ConsoleTracer(level="info")
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer=tracer)
+    assert tracer.hook in runner.hooks
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_tracer_outputs_info_level(capsys: pytest.CaptureFixture[str]) -> None:
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer="default")
+    await gather_result(runner, "in")
+    captured = capsys.readouterr().out
+    assert "Step Start" in captured
+    assert "Status" in captured
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_tracer_outputs_debug_level(capsys: pytest.CaptureFixture[str]) -> None:
+    tracer = ConsoleTracer(level="debug")
+    step = Step("s", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    runner = Flujo(step, local_tracer=tracer)
+    await gather_result(runner, "in")
+    captured = capsys.readouterr().out
+    assert "Output" in captured

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import MagicMock
+from flujo.tracing import ConsoleTracer
+from flujo.domain.models import StepResult
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_console_tracer_hook_prints() -> None:
+    tracer = ConsoleTracer(level="debug")
+    spy = MagicMock()
+    tracer.console.print = spy
+    result = StepResult(name="s", output="out")
+    await tracer.hook(event_name="post_step", step_result=result)
+    spy.assert_called()
+
+
+def test_console_tracer_config() -> None:
+    tracer = ConsoleTracer(level="info", log_inputs=False, log_outputs=False)
+    assert tracer.level == "info"
+    assert not tracer.log_inputs
+    assert not tracer.log_outputs


### PR DESCRIPTION
## Summary
- implement `ConsoleTracer` for colorized local tracing
- integrate tracer into `Flujo` with new `local_tracer` argument
- document console tracer usage and add to navigation
- update agents module and scoring to drop unused type ignores
- test new tracer functionality
- add debug message for unknown tracer events
- centralize final context assignment via helper

## Testing
- `pre-commit run --files flujo/tracing.py flujo/application/flujo_engine.py tests/unit/test_tracing.py tests/integration/test_local_tracer.py docs/cookbook/console_tracer.md mkdocs.yml flujo/__init__.py flujo/infra/agents.py flujo/domain/scoring.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521e1b3e24832cb4893327608d67a5