### PR TITLE
Enhance step config with temperature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,8 +133,8 @@ pipeline = (
     Step.review(review_agent, timeout=30)  # 30-second timeout
     >> Step.solution(
         solution_agent,
-        retries=3,  # Number of retries
-        backoff_factor=2  # Exponential backoff
+        retries=3,            # Number of retries
+        temperature=0.7,      # Control randomness
     )
     >> Step.validate(validator_agent)
 )

--- a/docs/intelligent_evals.md
+++ b/docs/intelligent_evals.md
@@ -68,7 +68,7 @@ Example snippet of the context:
 ```
 Case: test_sql_error
 - GenerateSQL: Output(content="SELEC * FROM t") (success=True)
-  Config(retries=1, timeout=30s)
+  Config(retries=1, timeout=30s, temperature=0.7)
   SystemPromptSummary: "You are a SQL expert..."
 ```
 

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -505,6 +505,8 @@ async def _run_step_logic(
                 agent_kwargs["pipeline_context"] = pipeline_context
         if resources is not None:
             agent_kwargs["resources"] = resources
+        if step.config.temperature is not None:
+            agent_kwargs["temperature"] = step.config.temperature
         raw_output = await current_agent.run(data, **agent_kwargs)
         result.latency_s += time.monotonic() - start
         last_raw_output = raw_output
@@ -777,6 +779,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
                                 target.stream, "resources"
                             ):
                                 agent_kwargs["resources"] = self.resources
+                            if step.config.temperature is not None:
+                                agent_kwargs["temperature"] = step.config.temperature
                             chunks: list[Any] = []
                             start = time.monotonic()
                             try:

--- a/flujo/application/self_improvement.py
+++ b/flujo/application/self_improvement.py
@@ -73,7 +73,12 @@ def _format_step_output(
     step_obj = _find_step(pipeline_definition, step.name)
     if step_obj is not None:
         cfg = step_obj.config
-        lines.append(f"  Config(retries={cfg.max_retries}, timeout={cfg.timeout_s}s)")
+        temp_str = (
+            f", temperature={cfg.temperature}" if cfg.temperature is not None else ""
+        )
+        lines.append(
+            f"  Config(retries={cfg.max_retries}, timeout={cfg.timeout_s}s{temp_str})"
+        )
         if step_obj.agent is not None:
             summary = summarize_and_redact_prompt(step_obj.agent.system_prompt)
             lines.append(f'  SystemPromptSummary: "{summary}"')

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -32,6 +32,7 @@ class StepConfig(BaseModel):
 
     max_retries: int = 1
     timeout_s: float | None = None
+    temperature: float | None = None
 
 
 class Step(BaseModel, Generic[StepInT, StepOutT]):

--- a/tests/integration/test_pipeline_runner.py
+++ b/tests/integration/test_pipeline_runner.py
@@ -143,3 +143,20 @@ async def test_runner_unpacks_agent_result() -> None:
     assert plugin.data["output"] == "ok"
     assert history.token_counts == 2
     assert result.total_cost_usd == 0.1
+
+
+async def test_step_config_temperature_passed() -> None:
+    class CaptureAgent:
+        def __init__(self):
+            self.kwargs: dict[str, Any] | None = None
+
+        async def run(self, data: Any, **kwargs: Any) -> str:
+            self.kwargs = kwargs
+            return "ok"
+
+    agent = CaptureAgent()
+    step = Step("s", agent, temperature=0.3)
+    runner = Flujo(step)
+    await gather_result(runner, "in")
+    assert agent.kwargs is not None
+    assert agent.kwargs.get("temperature") == 0.3

--- a/tests/integration/test_self_improvement.py
+++ b/tests/integration/test_self_improvement.py
@@ -66,7 +66,7 @@ async def test_self_improvement_context_includes_config_and_prompts(monkeypatch)
 
     agent = StubAgent(["ok"])
     agent.system_prompt = "Test prompt"
-    pipeline = Step.solution(agent, max_retries=5, timeout_s=30)
+    pipeline = Step.solution(agent, max_retries=5, timeout_s=30, temperature=0.5)
     runner = Flujo(pipeline)
     dataset = Dataset(cases=[Case(inputs="i", expected_output="o")])
 
@@ -78,4 +78,5 @@ async def test_self_improvement_context_includes_config_and_prompts(monkeypatch)
     )
 
     assert "Config(retries=5" in captured["prompt"]
+    assert "temperature=0.5" in captured["prompt"]
     assert "SystemPromptSummary" in captured["prompt"]


### PR DESCRIPTION
## Summary
- extend `StepConfig` to include a temperature parameter
- pass temperature when executing steps
- expose temperature in self‑improvement context
- document temperature in configuration docs
- update intelligent evals example
- test that temperature flows through the engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852489e70fc832cabae4c05e700a45b