### PR TITLE
Handle pipeline events in ConsoleTracer

### DIFF
--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -51,5 +51,35 @@ class ConsoleTracer:
             if self.level == "debug" and self.log_outputs:
                 body_text.append(f"\nOutput: {repr(step_result.output)}")
             self.console.print(Panel(body_text, title=title))
+        elif event == "pre_run":
+            initial_input = kwargs.get("initial_input")
+            title = "Pipeline Start"
+            details = Text(f"Input: {initial_input!r}")
+            self.console.print(Panel(details, title=title, border_style="bold blue"))
+        elif event == "post_run":
+            pipeline_result = kwargs.get("pipeline_result")
+            if pipeline_result is None:
+                return
+            title = "Pipeline End"
+            is_success = all(s.success for s in pipeline_result.step_history)
+            status_text = "✅ COMPLETED" if is_success else "❌ FAILED"
+            status_style = "bold green" if is_success else "bold red"
+            details = Text()
+            details.append(f"Final Status: {status_text}\n", style=status_style)
+            details.append(
+                f"Total Steps Executed: {len(pipeline_result.step_history)}\n"
+            )
+            details.append(f"Total Cost: ${pipeline_result.total_cost_usd:.6f}")
+            self.console.print(Panel(details, title=title, border_style="bold blue"))
+        elif event == "on_step_failure":
+            step_result = kwargs.get("step_result")
+            if step_result is None:
+                return
+            title = f"Step Failure: {step_result.name}"
+            details = Text(
+                f"Status: FAILED\nFeedback: {step_result.feedback}",
+                style="red",
+            )
+            self.console.print(Panel(details, title=title, border_style="bold red"))
         else:
             self.console.print(Panel(Text(str(event)), title="Unknown tracer event"))

--- a/tests/integration/test_local_tracer.py
+++ b/tests/integration/test_local_tracer.py
@@ -28,6 +28,7 @@ async def test_tracer_outputs_info_level(capsys: pytest.CaptureFixture[str]) -> 
     runner = Flujo(step, local_tracer="default")
     await gather_result(runner, "in")
     captured = capsys.readouterr().out
+    assert "Pipeline Start" in captured
     assert "Step Start" in captured
     assert "Status" in captured
 
@@ -39,4 +40,5 @@ async def test_tracer_outputs_debug_level(capsys: pytest.CaptureFixture[str]) ->
     runner = Flujo(step, local_tracer=tracer)
     await gather_result(runner, "in")
     captured = capsys.readouterr().out
+    assert "Pipeline Start" in captured
     assert "Output" in captured


### PR DESCRIPTION
## Summary
- show pipeline start and end in ConsoleTracer
- test for new tracer output
- add defensive null checks for `pipeline_result` and `step_result`
- adjust failure panel title to avoid duplicate output

## Testing
- `pytest tests/integration/test_local_tracer.py -q`
- `pytest tests/integration/test_pipeline_hooks.py::test_all_hooks_are_called_in_correct_order -q`
- `pytest tests/integration/test_pipeline_hooks.py::test_on_step_failure_hook_is_called -q`


------
https://chatgpt.com/codex/tasks/task_e_68524524aa30832c942fc77f3d2652e4