### PR TITLE
Fix release workflow dependencies

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Hatch
+        run: pip install hatch
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         python-version: "3.11"
 
+    - name: Install Hatch
+      run: pip install hatch
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- ensure release workflows install Hatch before running tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854a6923a1c832cb99ae005e9876e87