### PR TITLE
Refactor Makefile to use hatch scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ python --version                    # should print 3.11.x
 
 ### Local Development Workflow
 
+All `make` commands are thin wrappers around `hatch` scripts defined in
+`pyproject.toml`.
+
 1. **Install Hatch:**
    ```bash
    pip install hatch
@@ -56,22 +59,17 @@ python --version                    # should print 3.11.x
 2. **Create Environment & Install Dependencies:**
    ```bash
    make install
-   # or
-   hatch env create
    ```
 
 3. **Run Quality Checks:**
    ```bash
    make quality
-   # or
-   hatch run quality
    ```
 
 4. **Run Tests:**
    ```bash
    make test
-   # or
-   hatch run test
+   # pass arguments with: make test args="-k <pattern>"
    ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
-.PHONY: help install quality test cov bandit cyclonedx pip-dev pip-install clean
+.DEFAULT_GOAL := help
+
+args = $(filter-out $@,$(MAKECMDGOALS))
+
+.PHONY: help install quality lint format type-check test cov bandit sbom pip-dev pip-install clean
 
 help:
-	@echo "Commands:"
-	@echo "  install    : Create a hatch environment and install dependencies."
-	@echo "  pip-dev    : Install development dependencies using pip."
-	@echo "  pip-install: Install the package in development mode using pip."
-	@echo "  quality    : Run all code quality checks (format, lint, types, security)."
-	@echo "  test       : Run all tests with pytest."
-	@echo "  cov        : Run tests and report code coverage."
-	@echo "  bandit     : Run Bandit security scan."
-	@echo "  cyclonedx  : Generate a CycloneDX SBOM."
-	@echo "  clean      : Clean up build artifacts and caches."
+	@echo "Available commands:"
+	@echo "  install       - Install dependencies for development."
+	@echo "  quality       - Run all code quality checks."
+	@echo "  lint          - Run Ruff linting."
+	@echo "  format        - Auto-format the code."
+	@echo "  type-check    - Run MyPy type checking."
+	@echo "  test          - Run the test suite (use 'make test args=\"-k expr\"')."
+	@echo "  cov           - Run tests with coverage (uses args too)."
+	@echo "  bandit        - Run Bandit security scan."
+	@echo "  sbom          - Generate a CycloneDX SBOM."
+	@echo "  clean         - Remove build artifacts and caches."
 
 install:
+	@pip install hatch
 	@hatch env create
 
 pip-dev:
@@ -26,24 +32,28 @@ pip-install:
 	@python -m pip install -e .
 
 quality:
-	@echo "✅ Running all quality checks..."
 	@hatch run quality
 
+lint:
+	@hatch run lint
+
+format:
+	@hatch run format
+
+type-check:
+	@hatch run type-check
+
 test:
-	@echo "🧪 Running tests..."
-	@hatch run test
+	@hatch run test $(args)
 
 cov:
-	@echo "📊 Running tests with coverage..."
-	@hatch run cov
+	@hatch run cov $(args)
 
 bandit:
-	@echo "🔍 Running Bandit security scan..."
 	@hatch run bandit-check
 
-cyclonedx:
-	@echo "📦 Generating CycloneDX SBOM..."
-	@hatch run cyclonedx-py environment --pyproject pyproject.toml --output-file sbom.json --output-format JSON
+sbom:
+	@hatch run cyclonedx
 
 clean:
 	@echo "🧹 Cleaning up build artifacts and caches..."

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -27,37 +27,20 @@ python --version                    # should print 3.11.x
 
 ## 2. Development Environment Setup
 
-The project supports multiple package managers. Choose your preferred one:
+Flujo uses [Hatch](https://hatch.pypa.io/) to manage the development
+environment and command scripts. The provided `Makefile` simply calls these
+`hatch` scripts for convenience.
 
-### Option A: Poetry (Recommended)
 ```bash
-# Install Poetry
-pip install --upgrade poetry
-
-# Install dependencies (includes runtime, dev, docs, and bench extras)
-make poetry-dev
+pip install hatch
+make install        # create the Hatch environment
+make quality        # run format, lint, types and security checks
+make test           # run the test suite
+# pass extra pytest arguments
+make test args="-k my_test"
 ```
 
-### Option B: UV (Fastest)
-```bash
-# Install UV
-pip install --upgrade uv
-
-# Install dependencies
-make uv-dev
-```
-
-### Option C: Standard pip
-```bash
-# Install dependencies
-make pip-dev
-```
-
-> **Important Notes:**
-> - All options install the package in editable mode (`-e`)
-> - Code changes are picked up instantly without reinstalling
-> - `poetry.lock` is tracked in git for reproducible builds
-> - Run `make help` to see all available commands
+Run `make help` to see all available commands.
 
 ---
 
@@ -80,36 +63,17 @@ The orchestrator automatically loads this file via **python-dotenv**.
 
 ## 4. Testing
 
-The project includes comprehensive tests with different runners:
+Run the test suite with:
 
-### Full Test Suite
 ```bash
-# With Poetry
-make poetry-test                    # includes coverage report
-make poetry-test-fast              # without coverage
-
-# With UV (fastest)
-make uv-test                       # includes coverage
-make uv-test-fast                 # without coverage
-
-# With pip (default)
-make test                         # includes coverage
-make test-fast                    # without coverage
+make test
 ```
 
-### Specific Test Types
+Pass additional arguments to `pytest` using the `args` variable:
+
 ```bash
-# Unit Tests
-make test-unit                    # or poetry-test-unit / uv-test-unit
-
-# End-to-End Tests
-make test-e2e                     # or poetry-test-e2e / uv-test-e2e
-
-# Benchmark Tests
-make test-bench                   # or poetry-test-bench / uv-test-bench
+make test args="-k my_test"
 ```
-Run the benchmark suite to measure the framework's internal overhead and catch
-performance regressions introduced by new code.
 
 > **Note:** Async tests are handled automatically by **pytest-asyncio**
 
@@ -125,15 +89,9 @@ make quality                      # runs all quality checks
 ### Individual Quality Checks
 ```bash
 # Code Style
-make lint                        # check with Ruff
-make format                      # format code
-make format-check               # check formatting (CI)
-
-# Type Safety
-make type-check                 # static type checking with MyPy
-
-# Security
-make security                   # vulnerability check with pip-audit
+make lint        # check with Ruff
+make format      # format code
+make type-check  # static type checking with MyPy
 ```
 
 ---
@@ -300,7 +258,7 @@ make release-delete       # delete current release (requires confirmation)
    - Document signing process for maintainers
 
 3. **Dependency Management**
-   - Regularly audit dependencies: `make security`
+   - Regularly audit dependencies with `pip-audit`
    - Pin dependency versions in `pyproject.toml`
    - Document any security-related changes in release notes
 


### PR DESCRIPTION
## Summary
- delegate Makefile targets to `hatch` scripts and add argument passthrough
- document new hatch-based workflow in `CONTRIBUTING.md`
- update developer guide with unified make commands

## Testing
- `make install`
- `make quality`
- `make test`
- `make test args="-k test_utils"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68575f29df50832c9535b778cbea1acd