### PR TITLE
Switch quickstart to AgenticLoop

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,27 +2,42 @@
 
 This guide explains the fundamental concepts that power `flujo`. Understanding these concepts will help you build more effective AI workflows.
 
-## The Default Recipe
+## AgenticLoop
 
-The **`Default` recipe** is a high-level helper that manages a **standard,
-pre-defined AI workflow**. Think of it as a project manager for a specific team
-structure: a Review Agent, a Solution Agent, a Validator Agent, and optionally a
-Reflection Agent. It handles the flow of information between these fixed roles,
-manages retries based on their internal configuration, and returns the best
-`Candidate` from this standard process. For building custom workflows with
-different steps or logic, you would use the `Pipeline` DSL and the `Flujo`
-engine.
+`AgenticLoop` is the primary pattern for building explorative agent workflows. A
+planner agent emits an `AgentCommand` on each turn—run a tool agent, execute
+Python, ask a human, or finish. The loop executes the command and records it in
+the `PipelineContext`.
+
+```python
+from flujo.recipes import AgenticLoop
+from flujo import make_agent_async
+from flujo.domain.commands import AgentCommand
+from pydantic import TypeAdapter
+
+planner = make_agent_async(
+    "openai:gpt-4o",
+    "Plan the next command and finish when done.",
+    TypeAdapter(AgentCommand),
+)
+loop = AgenticLoop(planner_agent=planner, agent_registry={})
+```
+
+## The Default Recipe (Simplified)
+
+The **`Default` recipe** is a convenient helper that runs a **fixed Review →
+Solution → Validate workflow**. It's useful when you want a quick,
+opinionated pipeline without planning logic. Under the hood it uses the same
+Pipeline DSL described later.
 
 ```python
 from flujo.recipes import Default
-from flujo import review_agent, solution_agent, validator_agent, reflection_agent
+from flujo import review_agent, solution_agent, validator_agent
 
-# Assemble the default recipe with the built-in agents
 recipe = Default(
     review_agent=review_agent,
     solution_agent=solution_agent,
     validator_agent=validator_agent,
-    reflection_agent=reflection_agent,  # Optional but recommended
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,166 +19,48 @@ cp .env.example .env
 Add your API keys to `.env`:
 ```env
 OPENAI_API_KEY=your_key_here
-# Optional: Add other provider keys as needed
-# ANTHROPIC_API_KEY=your_key_here
-# GOOGLE_API_KEY=your_key_here
 ```
 
-## 3. Your First Orchestration
+## 3. Your First AgenticLoop
 
-Create a new file `hello_orchestrator.py`:
+Create a new file `hello_agentic.py`:
 
 ```python
-from flujo.recipes import Default
-from flujo import (
-    Task,
-    review_agent, solution_agent, validator_agent, reflection_agent,
-    init_telemetry,
-)
+from flujo.recipes import AgenticLoop
+from flujo import make_agent_async, init_telemetry
+from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
+from pydantic import TypeAdapter
 
 init_telemetry()
 
-# Assemble the orchestrator with the default agents. It runs a fixed
-# Review -> Solution -> Validate -> Reflection workflow.
-flujo = Default(
-    review_agent=review_agent,
-    solution_agent=solution_agent,
-    validator_agent=validator_agent,
-    reflection_agent=reflection_agent,
+async def search_agent(query: str) -> str:
+    print(f"   -> Tool Agent searching for '{query}'...")
+    return "Python is a high-level, general-purpose programming language." if "python" in query.lower() else "No information found."
+
+PLANNER_PROMPT = """
+You are a research assistant. Use the `search_agent` to gather information.
+When you have an answer, respond with `FinishCommand`.
+"""
+planner_agent = make_agent_async(
+    "openai:gpt-4o",
+    PLANNER_PROMPT,
+    TypeAdapter(AgentCommand),
 )
 
-task = Task(prompt="Write a haiku about programming")
-
-best_candidate = flujo.run_sync(task)
-
-if best_candidate:
-    print("\n🎉 Best result:")
-    print("-" * 40)
-    print(f"Solution:\n{best_candidate.solution}")
-    if best_candidate.checklist:
-        print("\nQuality Checklist:")
-        for item in best_candidate.checklist.items:
-            status = "✅" if item.passed else "❌"
-            print(f"{status} {item.description}")
+loop = AgenticLoop(planner_agent=planner_agent, agent_registry={"search_agent": search_agent})
+result = loop.run("What is Python?")
 ```
 
-The `Default` recipe provides a quick way to run this standard
-multi-agent workflow. For custom pipelines and advanced control, you'll
-use the `Flujo` engine and `Step` DSL described later.
+When the loop finishes, inspect `result.final_pipeline_context.command_log` to see each decision and tool invocation.
 
-## 4. Run Your First Orchestration
+## 4. Run Your First Loop
 
 ```bash
-python hello_orchestrator.py
+python hello_agentic.py
 ```
 
-## 5. Try the CLI
+You should see a short transcript of the planner running the search tool and finishing with an answer.
 
-The package includes a command-line interface for quick tasks:
+## 5. Next Steps
 
-```bash
-# Solve a simple task
-flujo solve "Write a function to calculate fibonacci numbers"
-
-# Show your current configuration
-flujo show-config
-
-# Run a quick benchmark
-flujo bench "Write a hello world program" --rounds 3
-
-# Check version
-flujo version-cmd
-
-# Explain a pipeline structure
-flujo explain path/to/pipeline.py
-
-# Generate improvement suggestions
-flujo improve path/to/pipeline.py path/to/dataset.py
-
-# Add evaluation case (interactive)
-flujo add-eval-case --dataset path/to/dataset.py
-```
-
-## 6. Next Steps
-
-Now that you've got the basics working, you can:
-
-1. Read the [Tutorial](tutorial.md) for a deeper dive
-2. Explore [Use Cases](use_cases.md) for inspiration
-3. Check out the [API Reference](api_reference.md) for more features
-4. Learn about [Custom Agents](extending.md) to build your own workflows
-
-## Common Patterns
-
-### Using Different Models
-
-```python
-from flujo import make_agent_async
-
-# Create a custom agent with a specific model
-custom_agent = make_agent_async(
-    "openai:gpt-4",  # Model identifier
-    "You are a helpful AI assistant.",  # System prompt
-    str  # Output type
-)
-
-# Use it in your orchestrator
-flujo = Default(
-    review_agent=custom_agent, 
-    solution_agent=solution_agent, 
-    validator_agent=validator_agent,
-    reflection_agent=reflection_agent
-)
-```
-
-### Structured Output
-
-```python
-from pydantic import BaseModel, Field
-
-class CodeSnippet(BaseModel):
-    language: str = Field(..., description="Programming language")
-    code: str = Field(..., description="The actual code")
-    explanation: str = Field(..., description="Brief explanation")
-
-# Create an agent that outputs structured data
-code_agent = make_agent_async(
-    "openai:gpt-4",
-    "You are a programming expert. Write clean, well-documented code.",
-    CodeSnippet
-)
-```
-
-### Custom Pipeline
-
-```python
-from flujo import (
-    Step, Flujo, Task,
-    review_agent, solution_agent, validator_agent,
-)
-
-# Define a custom pipeline (similar to the Default workflow)
-custom_pipeline = (
-    Step.review(review_agent)
-    >> Step.solution(solution_agent)
-    >> Step.validate_step(validator_agent)
-)
-
-runner = Flujo(custom_pipeline)
-
-# The input to `run()` is the prompt for the first step.
-pipeline_result = runner.run("Write a function to sort a list")
-
-print("Pipeline steps and success states:")
-for step_result in pipeline_result.step_history:
-    print(f"  - {step_result.name}: {step_result.success}")
-
-if len(pipeline_result.step_history) > 1:
-    print("Solution output:\n", pipeline_result.step_history[1].output)
-```
-
-## Need Help?
-
-- Check the [Troubleshooting Guide](troubleshooting.md)
-- Join our [Discord Community](https://discord.gg/your-server)
-- Open an [Issue](https://github.com/aandresalvarez/flujo/issues)
+Now that you've seen the basics, explore the [Tutorial](tutorial.md) and [Concepts](concepts.md) pages for a deeper dive.

--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -1,49 +1,75 @@
 """
-A basic "Hello, World!" example showing the high-level Default recipe.
-This is the fastest way to get a multi-agent workflow running.
+A "Hello, World!" example demonstrating the AgenticLoop recipe.
+
+This is the recommended starting point for building powerful, dynamic AI agents
+that can make decisions and use tools to accomplish goals.
 """
-from flujo.recipes import Default
-from flujo import (
-    Task,
-    review_agent,
-    solution_agent,
-    validator_agent,
-    reflection_agent,  # It's a best practice to include the reflection agent.
-    init_telemetry,
-)
+
+from typing import cast
+
+from flujo.recipes import AgenticLoop
+from flujo import make_agent_async, init_telemetry
+from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
+from flujo.domain.models import PipelineContext
+from pydantic import TypeAdapter
+
 
 # It's good practice to initialize telemetry at the start of your application.
-# This configures logging and tracing. See docs/telemetry.md for more info.
 init_telemetry()
 
-# The Default recipe is a pre-built workflow for a common multi-agent pattern:
-# Review -> Solution -> Validate -> Reflection.
-# It's great for getting started quickly without building a custom pipeline.
-print("🤖 Assembling the AI agent team for the standard Default workflow...")
-orch = Default(
-    review_agent=review_agent,
-    solution_agent=solution_agent,
-    validator_agent=validator_agent,
-    reflection_agent=reflection_agent,
+# --- 1. Define the Agents (The "Team") ---
+
+
+# This is our "tool" agent. It's a specialist that only knows how to search.
+# In a real app, this would call a search API. We'll simulate it.
+async def search_agent(query: str) -> str:
+    print(f"   -> Tool Agent: Searching for '{query}'...")
+    if "python" in query.lower():
+        return "Python is a high-level, general-purpose programming language."
+    return "No information found."
+
+
+# This is our planner agent. It decides what to do next.
+PLANNER_PROMPT = """
+You are a research assistant. Your goal is to answer the user's question.
+You can use the 'search_agent' to find information.
+When you have the answer, use the FinishCommand to provide the final result.
+"""
+planner_agent = make_agent_async(
+    model="openai:gpt-4o",
+    system_prompt=PLANNER_PROMPT,
+    output_type=TypeAdapter(AgentCommand),  # type: ignore[arg-type]
 )
 
-task = Task(prompt="Write a Python function that returns the string 'Hello, World!'")
+# --- 2. Assemble and Run the AgenticLoop ---
 
-print("🧠 Running the workflow...")
-best_candidate = orch.run_sync(task)
+print("🤖 Assembling the AgenticLoop...")
+agentic_loop = AgenticLoop(
+    planner_agent=planner_agent,
+    agent_registry={"search_agent": search_agent},  # type: ignore[dict-item]
+)
 
-# The `best_candidate` object contains the final solution, its score, and
-# the checklist used to evaluate it.
-if best_candidate:
-    print("\n🎉 Workflow finished! Here is the best result:")
-    print("-" * 50)
-    print(f"Solution:\n{best_candidate.solution}")
-    print(f"\nQuality Score: {best_candidate.score:.2f}")
-    if best_candidate.checklist:
-        print("\nFinal Quality Checklist:")
-        for item in best_candidate.checklist.items:
-            status = "✅ Passed" if item.passed else "❌ Failed"
-            # The description is left-aligned to 50 characters for clean printing.
-            print(f"  - {item.description:<50} {status}")
+initial_goal = "What is Python?"
+print(f"🎯 Setting initial goal: '{initial_goal}'")
+print("🧠 Running the loop...")
+
+result = agentic_loop.run(initial_goal)
+
+# --- 3. Inspect the Results ---
+if result and result.final_pipeline_context:
+    print("\n✅ Loop finished!")
+    final_context = cast(PipelineContext, result.final_pipeline_context)
+    print("\n--- Agent Transcript ---")
+    for log_entry in final_context.command_log:
+        command_type = log_entry.generated_command.type
+        print(f"Turn #{log_entry.turn}: Planner decided to '{command_type}'")
+        if isinstance(log_entry.generated_command, RunAgentCommand):
+            print(
+                f"   - Details: Run agent '{log_entry.generated_command.agent_name}' with input '{log_entry.generated_command.input_data}'"
+            )
+            print(f"   - Result: '{log_entry.execution_result}'")
+        elif isinstance(log_entry.generated_command, FinishCommand):
+            print(f"   - Final Answer: '{log_entry.execution_result}'")
+    print("----------------------")
 else:
-    print("\n❌ The workflow did not produce a valid solution.")
+    print("\n❌ The loop failed to produce a result.")

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -1,6 +1,6 @@
 """Domain models for flujo."""
 
-from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING
+from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING, cast
 import orjson
 from pydantic import BaseModel as PydanticBaseModel, Field, ConfigDict
 from typing import ClassVar
@@ -21,7 +21,7 @@ class BaseModel(PydanticBaseModel):
 
     def model_dump_json(self, **kwargs: Any) -> str:
         """Override to use orjson for serialization."""
-        return orjson.dumps(self.model_dump(), **kwargs).decode()
+        return cast(str, orjson.dumps(self.model_dump(), **kwargs).decode())
 
     @classmethod
     def model_validate_json(

--- a/flujo/domain/scoring.py
+++ b/flujo/domain/scoring.py
@@ -62,7 +62,7 @@ class RewardScorer:
 
         # The Agent constructor's type hints are not strict enough for mypy strict mode.
         # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-        self.agent = Agent(  # type: ignore[call-overload]
+        self.agent = Agent(
             "openai:gpt-4o-mini",
             system_prompt="You are a reward model. You return a single float score from 0.0 to 1.0.",
             output_type=float,

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -165,7 +165,7 @@ def make_agent(
 
     # The Agent constructor's type hints are not strict enough for mypy strict mode.
     # See: https://github.com/pydantic/pydantic-ai/issues (file an issue if not present)
-    agent: Agent[Any, Any] = Agent(  # type: ignore[call-overload]
+    agent: Agent[Any, Any] = Agent(
         model=model,
         system_prompt=system_prompt,
         output_type=output_type,


### PR DESCRIPTION
## Summary
- refactor quickstart example to use `AgenticLoop`
- update README basic usage and examples table
- rewrite quickstart docs
- reorder tutorial to introduce `AgenticLoop` first
- update concepts guide to start with `AgenticLoop`
- fix mypy issues and remove unused ignores

## Testing
- `ruff check examples/00_quickstart.py --fix`
- `black examples/00_quickstart.py`
- `mypy examples/00_quickstart.py`
- `pytest -q`
- `pre-commit run --files README.md docs/concepts.md docs/quickstart.md docs/tutorial.md examples/00_quickstart.py`


------
https://chatgpt.com/codex/tasks/task_e_6857697bde24832c9b3a431ac80cc4a5