### PR TITLE
Add detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,6 @@ repos:
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:
-      - id: detect-secrets 
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .secrets.baseline

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,127 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2025-06-22T16:55:54Z"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,27 @@ make bandit
 
 The CI pipeline will fail if any high-confidence issues are detected.
 
+#### Security: Secret Detection
+
+Our project uses `detect-secrets` to prevent API keys and other sensitive credentials from being committed. This hook runs automatically every time you make a commit.
+
+**What to do if your commit is blocked:**
+
+1. **If it's a real secret:**
+   - **Do not bypass the hook.**
+   - Remove the secret from your staged changes.
+   - Place the secret in your local `.env` file (which is git-ignored) and access it via `os.getenv()` or `flujo.settings`.
+   - Re-add the file and commit again.
+
+2. **If it's a false positive (e.g., a test ID):**
+   - Update the baseline to tell `detect-secrets` that this string is acceptable.
+   - Run the following commands:
+     ```bash
+     detect-secrets scan . > .secrets.baseline
+     git add .secrets.baseline
+     ```
+   - Commit your changes again. This will update the baseline for all contributors.
+
 ---
 
 ## 6. Documentation

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -94,6 +94,27 @@ make format      # format code
 make type-check  # static type checking with MyPy
 ```
 
+#### Security: Secret Detection
+
+Our project uses `detect-secrets` to prevent API keys and other sensitive credentials from being committed. This hook runs automatically every time you make a commit.
+
+**What to do if your commit is blocked:**
+
+1. **If it's a real secret:**
+   - **Do not bypass the hook.**
+   - Remove the secret from your staged changes.
+   - Place the secret in your local `.env` file (which is git-ignored) and access it via `os.getenv()` or `flujo.settings`.
+   - Re-add the file and commit again.
+
+2. **If it's a false positive (e.g., a test ID):**
+   - Update the baseline to tell `detect-secrets` that this string is acceptable.
+   - Run the following commands:
+     ```bash
+     detect-secrets scan . > .secrets.baseline
+     git add .secrets.baseline
+     ```
+   - Commit your changes again. This will update the baseline for all contributors.
+
 ---
 
 ## 6. Documentation


### PR DESCRIPTION
## Summary
- configure detect-secrets hook to use `.secrets.baseline`
- generate initial baseline
- document how to handle secret detection in CONTRIBUTING and developer docs

## Testing
- `pip install hatch`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68583531d1b0832cb189622eea06dd75