### PR TITLE
Refactor Default recipe

### DIFF
--- a/tests/integration/test_default_recipe.py
+++ b/tests/integration/test_default_recipe.py
@@ -7,7 +7,6 @@ ensuring each agent receives the appropriate inputs.
 """
 
 import pytest
-import json
 from unittest.mock import AsyncMock, patch
 
 from flujo.recipes.default import Default
@@ -69,10 +68,9 @@ async def test_default_recipe_data_flow(mock_agents: dict[str, AsyncMock]):
     mock_agents["solution"].run.assert_called_once_with("Test prompt")
 
     mock_agents["validator"].run.assert_called_once()
-    validator_input_str = mock_agents["validator"].run.call_args[0][0]
-    validator_input_dict = json.loads(validator_input_str)
+    validator_input_dict = mock_agents["validator"].run.call_args.args[0]
     assert validator_input_dict["solution"] == "The final solution."
-    assert validator_input_dict["checklist"]["items"][0]["description"] == "item 1"
+    assert validator_input_dict["checklist"].items[0].description == "item 1"
 
     assert isinstance(result, Candidate)
     assert result.solution == "The final solution."


### PR DESCRIPTION
## Summary
- refactor `Default` recipe to build pipelines with core `Step` factories
- wrap user-provided agents in simple classes so they work with the standard engine
- send dict payloads to validator and reflection agents instead of JSON
- update integration test

## Testing
- `pytest -q`
- `pytest tests/integration/test_default_recipe.py::test_default_recipe_data_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_685864880d5c832ca7e59b0b261d378b