### PR TITLE
Introduce typed payloads for hooks

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -313,14 +313,15 @@ You can register callbacks to observe or control pipeline execution.
 
 ```python
 from flujo import HookCallable, PipelineAbortSignal
+from flujo.domain.events import HookPayload
 
-async def my_hook(**kwargs):
-    print("event:", kwargs.get("event_name"))
+async def my_hook(payload: HookPayload) -> None:
+    print("event:", payload.event_name)
 
 runner = Flujo(pipeline, hooks=[my_hook])
 ```
 
-Hooks receive keyword arguments depending on the event. Raise
+Hooks receive a typed payload object describing the event. Raise
 `PipelineAbortSignal` from a hook to stop the run gracefully.
 
 ## Self-Improvement & Evaluation

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -23,6 +23,7 @@ from .domain import (
     AppResources,
 )
 from .domain.types import HookCallable
+from .domain.events import HookPayload
 from .domain.backends import ExecutionBackend, StepExecutionRequest
 from .infra.backends import LocalBackend
 from .tracing import ConsoleTracer
@@ -69,6 +70,7 @@ __all__ = [
     "PipelineResult",
     "StepResult",
     "HookCallable",
+    "HookPayload",
     "PipelineAbortSignal",
     "settings",
     "init_telemetry",

--- a/flujo/domain/events.py
+++ b/flujo/domain/events.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, Union
+
+from pydantic import BaseModel
+
+from .models import PipelineResult, StepResult
+from .pipeline_dsl import Step
+from .resources import AppResources
+
+
+class PreRunPayload(BaseModel):
+    event_name: Literal["pre_run"]
+    initial_input: Any
+    pipeline_context: Optional[BaseModel] = None
+    resources: Optional[AppResources] = None
+
+
+class PostRunPayload(BaseModel):
+    event_name: Literal["post_run"]
+    pipeline_result: PipelineResult
+    pipeline_context: Optional[BaseModel] = None
+    resources: Optional[AppResources] = None
+
+
+class PreStepPayload(BaseModel):
+    event_name: Literal["pre_step"]
+    step: Step
+    step_input: Any
+    pipeline_context: Optional[BaseModel] = None
+    resources: Optional[AppResources] = None
+
+
+class PostStepPayload(BaseModel):
+    event_name: Literal["post_step"]
+    step_result: StepResult
+    pipeline_context: Optional[BaseModel] = None
+    resources: Optional[AppResources] = None
+
+
+class OnStepFailurePayload(BaseModel):
+    event_name: Literal["on_step_failure"]
+    step_result: StepResult
+    pipeline_context: Optional[BaseModel] = None
+    resources: Optional[AppResources] = None
+
+
+HookPayload = Union[
+    PreRunPayload,
+    PostRunPayload,
+    PreStepPayload,
+    PostStepPayload,
+    OnStepFailurePayload,
+]
+

--- a/flujo/domain/types.py
+++ b/flujo/domain/types.py
@@ -2,8 +2,10 @@
 
 from typing import Callable, Coroutine, Any
 
+from .events import HookPayload
+
 from .models import PipelineResult, StepResult  # noqa: F401
 from .resources import AppResources  # noqa: F401
 
-# A hook is an async callable that receives keyword arguments.
-HookCallable = Callable[..., Coroutine[Any, Any, None]]
+# A hook is an async callable that receives a typed payload object.
+HookCallable = Callable[[HookPayload], Coroutine[Any, Any, None]]

--- a/tests/unit/test_hooks_typed.py
+++ b/tests/unit/test_hooks_typed.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import MagicMock
+from typing import Any, cast
+
+from flujo import Flujo, Step
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+from flujo.testing.utils import StubAgent, gather_result
+from flujo.domain.events import HookPayload, PostStepPayload
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_hook_receives_typed_payload() -> None:
+    step = Step("s1", cast(AsyncAgentProtocol[Any, Any], StubAgent(["ok"])))
+    recorder = MagicMock()
+
+    async def hook(payload: HookPayload) -> None:
+        recorder(payload)
+
+    runner = Flujo(step, hooks=[hook])
+    await gather_result(runner, "start")
+
+    post_step_calls = [c.args[0] for c in recorder.call_args_list if isinstance(c.args[0], PostStepPayload)]
+    assert len(post_step_calls) == 1
+    payload = post_step_calls[0]
+    assert isinstance(payload, PostStepPayload)
+    assert payload.step_result.output == "ok"
+

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 from flujo.tracing import ConsoleTracer
 from flujo.domain.models import StepResult
+from flujo.domain.events import PostStepPayload
 
 
 @pytest.mark.asyncio  # type: ignore[misc]
@@ -10,7 +11,8 @@ async def test_console_tracer_hook_prints() -> None:
     spy = MagicMock()
     tracer.console.print = spy
     result = StepResult(name="s", output="out")
-    await tracer.hook(event_name="post_step", step_result=result)
+    payload = PostStepPayload(event_name="post_step", step_result=result)
+    await tracer.hook(payload)
     spy.assert_called()
 
 


### PR DESCRIPTION
## Summary
- define pydantic models for lifecycle hook events
- update HookCallable typing and dispatch logic
- refactor ConsoleTracer to use typed payloads
- adjust docs for new hook pattern
- adapt tests and add unit test for typed hooks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68586cfdfa7c832cb4d4089bcf7879ae