### PR TITLE
Add runnable cookbook examples

### DIFF
--- a/docs/cookbook/cost_control.md
+++ b/docs/cookbook/cost_control.md
@@ -50,3 +50,6 @@ except UsageLimitExceededError as e:
 7.  The exception contains the `result` object with the history up to the point of failure, which is useful for debugging.
 
 This mechanism is a critical safety feature for running `Flujo` in production.
+
+A full, runnable version of this example can be found in [examples/10_cost_control.py](https://github.com/aandresalvarez/flujo/blob/main/examples/10_cost_control.py).
+

--- a/docs/cookbook/hitl_stateful_correction_loop.md
+++ b/docs/cookbook/hitl_stateful_correction_loop.md
@@ -18,3 +18,6 @@ paused = await runner.run_async("start")
 paused = await runner.resume_async(paused, "not ok")
 final = await runner.resume_async(paused, "ok")
 ```
+
+A full, runnable version of this example can be found in [examples/11_stateful_hitl.py](https://github.com/aandresalvarez/flujo/blob/main/examples/11_stateful_hitl.py).
+

--- a/docs/cookbook/lifecycle_hooks.md
+++ b/docs/cookbook/lifecycle_hooks.md
@@ -52,3 +52,6 @@ print(f"\nPipeline finished. It ran {len(result.step_history)} steps before bein
 6.  The engine catches this special signal and gracefully terminates the entire run, returning the partial `PipelineResult`.
 
 This provides a powerful and clean way to add cross-cutting concerns like logging, metrics, and custom control flow to your pipelines.
+
+A full, runnable version of this example can be found in [examples/13_lifecycle_hooks.py](https://github.com/aandresalvarez/flujo/blob/main/examples/13_lifecycle_hooks.py).
+

--- a/docs/cookbook/using_resources.md
+++ b/docs/cookbook/using_resources.md
@@ -54,3 +54,6 @@ print(f"\n✅ Agent successfully used the database connection to find: {result.s
 5.  The agent can then use the methods on the injected object (e.g., `resources.db_conn.get_user_by_id`).
 
 This dependency injection pattern keeps your agents clean and decoupled from how resources are created, making them much easier to test and maintain.
+
+A full, runnable version of this example can be found in [examples/12_using_resources.py](https://github.com/aandresalvarez/flujo/blob/main/examples/12_using_resources.py).
+

--- a/examples/10_cost_control.py
+++ b/examples/10_cost_control.py
@@ -1,0 +1,48 @@
+"""Example: Enforcing cost limits with `UsageLimits`.
+
+This script corresponds to `docs/cookbook/cost_control.md`.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from flujo import Flujo, Step, UsageLimits, UsageLimitExceededError
+
+
+class CostlyAgent:
+    """An agent that always incurs a fixed cost."""
+
+    async def run(self, x: int) -> BaseModel:
+        class Output(BaseModel):
+            value: int
+            cost_usd: float = 0.05
+            token_counts: int = 50
+
+        return Output(value=x + 1)
+
+
+def build_runner() -> Flujo[int, BaseModel]:
+    pipeline = (
+        Step("step_1", CostlyAgent())
+        >> Step("step_2", CostlyAgent())
+        >> Step("step_3", CostlyAgent())
+    )
+    limits = UsageLimits(total_cost_usd_limit=0.12)
+    return Flujo(pipeline, usage_limits=limits)
+
+
+def main() -> None:
+    runner = build_runner()
+    print("🚀 Running pipeline with a cost limit of $0.12...")
+    try:
+        runner.run(0)
+    except UsageLimitExceededError as exc:
+        print("\n✅ Pipeline halted as expected!")
+        print(f"   Reason: {exc}")
+        print(f"   The pipeline ran {len(exc.result.step_history)} steps before stopping.")
+        print(f"   Final recorded cost was ${exc.result.total_cost_usd:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/11_stateful_hitl.py
+++ b/examples/11_stateful_hitl.py
@@ -1,0 +1,47 @@
+"""Example: Stateful correction loop with human input.
+
+This script corresponds to `docs/cookbook/hitl_stateful_correction_loop.md`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from flujo import Flujo, Step, Pipeline
+from flujo.testing.utils import StubAgent
+
+
+def build_runner() -> Flujo[str, str]:
+    loop_body = Step("draft", StubAgent(["bad", "good"])) >> Step.human_in_the_loop("fix")
+    loop = Step.loop_until(
+        name="correction",
+        loop_body_pipeline=Pipeline.from_step(loop_body),
+        exit_condition_callable=lambda out, _ctx: out == "ok",
+        max_loops=2,
+    )
+    return Flujo(loop)
+
+
+async def main() -> None:
+    runner = build_runner()
+    print("🚀 Starting correction loop...")
+    result = None
+    async for item in runner.run_async("start"):
+        result = item
+    ctx = result.final_pipeline_context
+    print(f"Paused with message: {ctx.scratchpad['pause_message']}")
+
+    responses = iter(["not ok", "ok"])
+    while ctx.scratchpad.get("status") == "paused":
+        response = next(responses)
+        print(f"\nSimulated human responds: {response}")
+        result = await runner.resume_async(result, response)
+        ctx = result.final_pipeline_context
+        if ctx.scratchpad.get("status") == "paused":
+            print(f"Paused again with message: {ctx.scratchpad['pause_message']}")
+
+    print("\n✅ Pipeline finished!")
+    print("Final output:", result.step_history[-1].output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/12_using_resources.py
+++ b/examples/12_using_resources.py
@@ -1,0 +1,42 @@
+"""Example: Sharing resources across steps with `AppResources`.
+
+This script corresponds to `docs/cookbook/using_resources.md`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from flujo import Flujo, Step, AppResources
+
+
+class MyWebAppResources(AppResources):
+    """Defines the shared resources for the app."""
+
+    db_conn: MagicMock
+
+
+class UserLookupAgent:
+    async def run(self, user_id: int, *, resources: MyWebAppResources) -> str:
+        print(f"AGENT: Looking up user {user_id}...")
+        return resources.db_conn.get_user_by_id(user_id)
+
+
+def build_runner() -> tuple[Flujo[int, str], MyWebAppResources]:
+    resources = MyWebAppResources(db_conn=MagicMock())
+    resources.db_conn.get_user_by_id.return_value = "Alice"
+
+    pipeline = Step("lookup_user", UserLookupAgent())
+    runner = Flujo(pipeline, resources=resources)
+    return runner, resources
+
+
+def main() -> None:
+    runner, resources = build_runner()
+    result = runner.run(123)
+    resources.db_conn.get_user_by_id.assert_called_once_with(123)
+    print(f"\n✅ Agent successfully used the database to find: {result.step_history[0].output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/13_lifecycle_hooks.py
+++ b/examples/13_lifecycle_hooks.py
@@ -1,0 +1,46 @@
+"""Example: Observing pipeline events with lifecycle hooks.
+
+This script corresponds to `docs/cookbook/lifecycle_hooks.md`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from flujo import Flujo, Step
+from flujo.exceptions import PipelineAbortSignal
+from flujo.domain.events import HookPayload, OnStepFailurePayload
+
+
+async def simple_logger_hook(payload: HookPayload) -> None:
+    """Print the name of each event."""
+
+    print(f"HOOK FIRED: {payload.event_name}")
+
+
+async def abort_on_failure_hook(payload: OnStepFailurePayload) -> None:
+    """Abort the run if any step fails."""
+
+    step_name = payload.step_result.name
+    print(f"HOOK: Step '{step_name}' failed. Aborting the run.")
+    raise PipelineAbortSignal("Aborted due to failure in '{step_name}'")
+
+
+def build_runner() -> Flujo[str, str]:
+    failing_step = Step("failing", agent=MagicMock(side_effect=RuntimeError("oops")))
+    pipeline = Step("start", agent=MagicMock(return_value="ok")) >> failing_step
+    runner = Flujo(pipeline, hooks=[simple_logger_hook, abort_on_failure_hook])
+    return runner
+
+
+def main() -> None:
+    runner = build_runner()
+    print("🚀 Running pipeline with hooks...")
+    result = runner.run("hi")
+    print(
+        f"\nPipeline finished. It ran {len(result.step_history)} steps before being aborted by the hook."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,10 @@
 | **06_typed_context.py** | Sharing state with Typed Pipeline Context. |
 | **07_loop_step.py** | Iterative refinement using LoopStep. |
 | **08_branch_step.py** | Dynamic routing with ConditionalStep. |
+| **10_cost_control.py** | Enforcing usage limits to control cost. |
+| **11_stateful_hitl.py** | Multi-turn correction loop with simulated HITL. |
+| **12_using_resources.py** | Dependency injection via AppResources. |
+| **13_lifecycle_hooks.py** | Observing pipeline events with hooks. |
 
 Each script is standalone – activate your virtualenv, set `OPENAI_API_KEY`, then:
 

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -16,6 +16,7 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Union,
+    cast,
 )
 
 from flujo.domain.models import BaseModel
@@ -611,7 +612,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT]):
         if PayloadCls is None:
             return
 
-        payload = PayloadCls(event_name=event_name, **kwargs)
+        payload = PayloadCls(event_name=cast(Any, event_name), **kwargs)
 
         for hook in self.hooks:
             try:

--- a/flujo/domain/events.py
+++ b/flujo/domain/events.py
@@ -25,7 +25,7 @@ class PostRunPayload(BaseModel):
 
 class PreStepPayload(BaseModel):
     event_name: Literal["pre_step"]
-    step: Step
+    step: Step[Any, Any]
     step_input: Any
     pipeline_context: Optional[BaseModel] = None
     resources: Optional[AppResources] = None
@@ -52,4 +52,3 @@ HookPayload = Union[
     PostStepPayload,
     OnStepFailurePayload,
 ]
-

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -1,6 +1,6 @@
 """Domain models for flujo."""
 
-from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING, cast
+from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING
 import orjson
 from pydantic import BaseModel as PydanticBaseModel, Field, ConfigDict
 from typing import ClassVar
@@ -55,12 +55,8 @@ class ChecklistItem(BaseModel):
     """A single item in a checklist for evaluating a solution."""
 
     description: str = Field(..., description="The criterion to evaluate.")
-    passed: Optional[bool] = Field(
-        None, description="Whether the solution passes this criterion."
-    )
-    feedback: Optional[str] = Field(
-        None, description="Feedback if the criterion is not met."
-    )
+    passed: Optional[bool] = Field(None, description="Whether the solution passes this criterion.")
+    feedback: Optional[str] = Field(None, description="Feedback if the criterion is not met.")
 
 
 class Checklist(BaseModel):
@@ -115,9 +111,7 @@ class PipelineResult(BaseModel):
     total_cost_usd: float = 0.0
     final_pipeline_context: Optional[BaseModel] = Field(
         default=None,
-        description=(
-            "The final state of the typed pipeline context, if configured and used."
-        ),
+        description=("The final state of the typed pipeline context, if configured and used."),
     )
 
     model_config: ClassVar[ConfigDict] = {"arbitrary_types_allowed": True}

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import Any, Optional, TYPE_CHECKING, cast
 
 from flujo.domain.models import PipelineContext
@@ -39,21 +38,30 @@ class Default:
             return await target(data)
 
         class ReviewWrapper:
-            async def run(self, prompt: str, *, pipeline_context: PipelineContext) -> str:
-                result = await _invoke(review_agent, prompt)
+            async def run(self, data: Any, **kwargs: Any) -> Any:
+                pipeline_context: PipelineContext = kwargs["pipeline_context"]
+                result = await _invoke(review_agent, data)
                 checklist = cast(Checklist, getattr(result, "output", result))
                 pipeline_context.scratchpad["checklist"] = checklist
-                return prompt
+                return cast(str, data)
+
+            async def run_async(self, data: Any, **kwargs: Any) -> Any:
+                return await self.run(data, **kwargs)
 
         class SolutionWrapper:
-            async def run(self, prompt: str, *, pipeline_context: PipelineContext) -> str:
-                result = await _invoke(solution_agent, prompt)
+            async def run(self, data: Any, **kwargs: Any) -> Any:
+                pipeline_context: PipelineContext = kwargs["pipeline_context"]
+                result = await _invoke(solution_agent, data)
                 solution = cast(str, getattr(result, "output", result))
                 pipeline_context.scratchpad["solution"] = solution
                 return solution
 
+            async def run_async(self, data: Any, **kwargs: Any) -> Any:
+                return await self.run(data, **kwargs)
+
         class ValidatorWrapper:
-            async def run(self, _data: str, *, pipeline_context: PipelineContext) -> Checklist:
+            async def run(self, _data: Any, **kwargs: Any) -> Any:
+                pipeline_context: PipelineContext = kwargs["pipeline_context"]
                 payload = {
                     "solution": pipeline_context.scratchpad.get("solution"),
                     "checklist": pipeline_context.scratchpad.get("checklist"),
@@ -63,13 +71,19 @@ class Default:
                 pipeline_context.scratchpad["checklist"] = validated
                 return validated
 
+            async def run_async(self, _data: Any, **kwargs: Any) -> Any:
+                return await self.run(_data, **kwargs)
+
         pipeline = (
-            Step.review(ReviewWrapper(), max_retries=3)
-            >> Step.solution(SolutionWrapper(), max_retries=3)
-            >> Step.validate_step(ValidatorWrapper(), max_retries=3)
+            Step.review(cast("AsyncAgentProtocol[Any, Any]", ReviewWrapper()), max_retries=3)
+            >> Step.solution(cast("AsyncAgentProtocol[Any, Any]", SolutionWrapper()), max_retries=3)
+            >> Step.validate_step(
+                cast("AsyncAgentProtocol[Any, Any]", ValidatorWrapper()), max_retries=3
+            )
         )
 
         if reflection_agent is not None:
+
             async def reflection_step(_: Any, *, pipeline_context: PipelineContext) -> str:
                 payload = {
                     "solution": pipeline_context.scratchpad.get("solution"),
@@ -80,7 +94,9 @@ class Default:
                 pipeline_context.scratchpad["reflection"] = reflection
                 return reflection
 
-            pipeline = pipeline >> Step.from_callable(reflection_step, name="reflection", max_retries=3)
+            pipeline = pipeline >> Step.from_callable(
+                reflection_step, name="reflection", max_retries=3
+            )
 
         self.flujo_engine = Flujo(pipeline, context_model=PipelineContext)
 

--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Literal
+from typing import Any, Callable, Dict, Literal, cast
 
 from .domain.events import (
     HookPayload,
@@ -36,11 +36,11 @@ class ConsoleTracer:
             Console(highlight=False) if colorized else Console(no_color=True, highlight=False)
         )
         self.event_handlers: Dict[str, Callable[[HookPayload], Any]] = {
-            "pre_run": self._handle_pre_run,
-            "post_run": self._handle_post_run,
-            "pre_step": self._handle_pre_step,
-            "post_step": self._handle_post_step,
-            "on_step_failure": self._handle_on_step_failure,
+            "pre_run": cast(Callable[[HookPayload], Any], self._handle_pre_run),
+            "post_run": cast(Callable[[HookPayload], Any], self._handle_post_run),
+            "pre_step": cast(Callable[[HookPayload], Any], self._handle_pre_step),
+            "post_step": cast(Callable[[HookPayload], Any], self._handle_post_step),
+            "on_step_failure": cast(Callable[[HookPayload], Any], self._handle_on_step_failure),
         }
 
     def _handle_pre_run(self, payload: PreRunPayload) -> None:
@@ -100,6 +100,4 @@ class ConsoleTracer:
             else:
                 handler(payload)
         else:
-            self.console.print(
-                Panel(Text(str(payload.event_name)), title="Unknown tracer event")
-            )
+            self.console.print(Panel(Text(str(payload.event_name)), title="Unknown tracer event"))

--- a/tests/mypy_success.py
+++ b/tests/mypy_success.py
@@ -22,7 +22,7 @@ def test_pipeline_type_continuity() -> None:
         return len(x)
 
     inferred = Step.from_callable(foo)
-    reveal_type(inferred)
+    reveal_type(inferred)  # noqa: F821
 
     # pipeline should type check
     # The following should fail mypy if uncommented:


### PR DESCRIPTION
## Summary
- add runnable scripts demonstrating cost control, stateful HITL, shared resources, and hooks
- link cookbook docs to the new examples
- extend examples README with the new scripts
- fix lint and type issues in default recipe and infrastructure

## Testing
- `ruff format examples/ tests/ flujo/`
- `ruff check flujo tests`
- `make lint`
- `mypy flujo`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6858809d51fc832c80659dee8652beb1