### PR TITLE
Add @step decorator for simple pipeline steps

### DIFF
--- a/examples/06_typed_context.py
+++ b/examples/06_typed_context.py
@@ -12,7 +12,7 @@ from typing import Optional, cast, Type
 
 from flujo.domain.models import BaseModel as FlujoBaseModel
 
-from flujo import Flujo, Step, PipelineResult
+from flujo import Flujo, PipelineResult, step
 
 
 # 1. Define the context model. This is our shared data structure for one run.
@@ -24,6 +24,7 @@ class ResearchContext(FlujoBaseModel):
 
 # 2. Define agents that interact with the context.
 #    They declare a keyword-only `pipeline_context` argument to get access.
+@step
 async def plan_research_agent(task: str, *, pipeline_context: ResearchContext) -> str:
     """This agent identifies the core topic and saves it to the context."""
     print("🧠 Planning Agent: Analyzing task to find the core research topic.")
@@ -34,6 +35,7 @@ async def plan_research_agent(task: str, *, pipeline_context: ResearchContext) -
     return f"Research plan for {topic}"
 
 
+@step
 async def gather_sources_agent(
     plan: str, *, pipeline_context: ResearchContext
 ) -> list[str]:
@@ -45,6 +47,7 @@ async def gather_sources_agent(
     return sources
 
 
+@step
 async def summarize_agent(
     sources: list[str], *, pipeline_context: ResearchContext
 ) -> str:
@@ -64,12 +67,8 @@ async def summarize_agent(
     return summary
 
 
-# 3. Define the pipeline using Step.from_callable
-pipeline = (
-    Step.from_callable(plan_research_agent, name="PlanResearch")
-    >> Step.from_callable(gather_sources_agent, name="GatherSources")
-    >> Step.from_callable(summarize_agent, name="Summarize")
-)
+# 3. Define the pipeline using the step decorator
+pipeline = plan_research_agent >> gather_sources_agent >> summarize_agent
 
 # 4. Initialize the Flujo runner, telling it to use our context model.
 

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -16,6 +16,7 @@ from .infra.telemetry import init_telemetry
 from .domain.models import Task, Candidate, Checklist, ChecklistItem
 from .domain import (
     Step,
+    step,
     Pipeline,
     StepConfig,
     PluginOutcome,
@@ -59,6 +60,7 @@ __all__ = [
     "Checklist",
     "ChecklistItem",
     "Step",
+    "step",
     "Pipeline",
     "StepConfig",
     "AppResources",

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -7,6 +7,7 @@ from .pipeline_dsl import (
     LoopStep,
     ConditionalStep,
     BranchKey,
+    step,
 )
 from .plugins import PluginOutcome, ValidationPlugin
 from .resources import AppResources
@@ -15,6 +16,7 @@ from .backends import ExecutionBackend, StepExecutionRequest
 
 __all__ = [
     "Step",
+    "step",
     "Pipeline",
     "StepConfig",
     "LoopStep",

--- a/tests/mypy_success.py
+++ b/tests/mypy_success.py
@@ -1,4 +1,4 @@
-from flujo.domain import Step
+from flujo.domain import Step, step
 from flujo.testing.utils import StubAgent
 from pydantic import BaseModel
 
@@ -18,10 +18,11 @@ def test_pipeline_type_continuity() -> None:
     step2: Step[UserInfo, Report] = Step.solution(agent2)
     _pipeline = step1 >> step2
 
+    @step
     async def foo(x: str) -> int:
         return len(x)
 
-    inferred = Step.from_callable(foo)
+    inferred = foo
     reveal_type(inferred)  # noqa: F821
 
     # pipeline should type check


### PR DESCRIPTION
## Summary
- introduce `step` decorator for converting async callables to `Step`
- export decorator from `flujo` and update `__all__`
- revise docs and examples to showcase `@step`
- add unit tests and mypy test coverage for the decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a3c7214c832ca31add75018d3284