### PR TITLE
Introduce generic context typing

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -254,7 +254,7 @@ step_result = StepResult(
 pipeline_result = PipelineResult(
     step_history: List[StepResult] = [],  # All step results
     total_cost_usd: float = 0.0,          # Total cost
-    final_pipeline_context: Optional[BaseModel] = None,  # Final context
+    final_pipeline_context: Optional[ContextT] = None,  # Final context
 )
 
 ### PipelineContext

--- a/flujo/application/eval_adapter.py
+++ b/flujo/application/eval_adapter.py
@@ -6,9 +6,9 @@ from .flujo_engine import Flujo
 from ..domain.models import PipelineResult
 
 
-async def run_pipeline_async(inputs: Any, *, runner: Flujo[Any, Any]) -> PipelineResult:
+async def run_pipeline_async(inputs: Any, *, runner: Flujo[Any, Any, Any]) -> PipelineResult[Any]:
     """Adapter to run a :class:`Flujo` engine as a pydantic-evals task."""
-    result: PipelineResult | None = None
+    result: PipelineResult[Any] | None = None
     async for item in runner.run_async(inputs):
         result = item
     assert result is not None

--- a/flujo/application/evaluators.py
+++ b/flujo/application/evaluators.py
@@ -2,6 +2,8 @@
 
 from pydantic_evals.evaluators import Evaluator, EvaluatorContext
 
+from typing import Any
+
 from ..domain.models import PipelineResult
 
 
@@ -9,7 +11,7 @@ class FinalSolutionEvaluator(Evaluator):
     """Extracts the final step output from a PipelineResult."""
 
     def evaluate(self, ctx: EvaluatorContext) -> bool:
-        result: PipelineResult = ctx.output
+        result: PipelineResult[Any] = ctx.output
         final_output = None
         if result.step_history:
             final_output = result.step_history[-1].output

--- a/flujo/application/self_improvement.py
+++ b/flujo/application/self_improvement.py
@@ -97,7 +97,7 @@ def _build_context(
     lines.append("--- FAILED CASES ---")
     lines.append("")
     for case in failures:
-        pr: PipelineResult = case.output
+        pr: PipelineResult[Any] = case.output
         lines.append(f"Case: {case.name}")
         input_str = _truncate(_safe_str(case.inputs), 200)
         lines.append(f"Input: {input_str}")
@@ -118,7 +118,7 @@ def _build_context(
 
 
 async def evaluate_and_improve(
-    task_function: Callable[[Any], Awaitable[PipelineResult]],
+    task_function: Callable[[Any], Awaitable[PipelineResult[Any]]],
     dataset: Any,
     improvement_agent: SelfImprovementAgent,
     pipeline_definition: Optional[Pipeline[Any, Any] | Step[Any, Any]] = None,

--- a/flujo/domain/events.py
+++ b/flujo/domain/events.py
@@ -18,7 +18,7 @@ class PreRunPayload(BaseModel):
 
 class PostRunPayload(BaseModel):
     event_name: Literal["post_run"]
-    pipeline_result: PipelineResult
+    pipeline_result: PipelineResult[Any]
     pipeline_context: Optional[BaseModel] = None
     resources: Optional[AppResources] = None
 

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -1,12 +1,14 @@
 """Domain models for flujo."""
 
-from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING
+from typing import Any, List, Optional, Literal, Dict, TYPE_CHECKING, Generic
 import orjson
 from pydantic import BaseModel as PydanticBaseModel, Field, ConfigDict
 from typing import ClassVar
 from datetime import datetime, timezone
 import uuid
 from enum import Enum
+
+from .types import ContextT
 
 if TYPE_CHECKING:
     from .commands import ExecutedCommandLog
@@ -56,12 +58,8 @@ class ChecklistItem(BaseModel):
     """A single item in a checklist for evaluating a solution."""
 
     description: str = Field(..., description="The criterion to evaluate.")
-    passed: Optional[bool] = Field(
-        None, description="Whether the solution passes this criterion."
-    )
-    feedback: Optional[str] = Field(
-        None, description="Feedback if the criterion is not met."
-    )
+    passed: Optional[bool] = Field(None, description="Whether the solution passes this criterion.")
+    feedback: Optional[str] = Field(None, description="Feedback if the criterion is not met.")
 
 
 class Checklist(BaseModel):
@@ -109,16 +107,14 @@ class StepResult(BaseModel):
     )
 
 
-class PipelineResult(BaseModel):
+class PipelineResult(BaseModel, Generic[ContextT]):
     """Aggregated result of running a pipeline."""
 
     step_history: List[StepResult] = Field(default_factory=list)
     total_cost_usd: float = 0.0
-    final_pipeline_context: Optional[BaseModel] = Field(
+    final_pipeline_context: Optional[ContextT] = Field(
         default=None,
-        description=(
-            "The final state of the typed pipeline context, if configured and used."
-        ),
+        description=("The final state of the typed pipeline context, if configured and used."),
     )
 
     model_config: ClassVar[ConfigDict] = {"arbitrary_types_allowed": True}

--- a/flujo/domain/types.py
+++ b/flujo/domain/types.py
@@ -1,11 +1,16 @@
 """Shared type aliases for the domain layer."""
 
-from typing import Callable, Coroutine, Any
+from typing import Callable, Coroutine, Any, TypeVar, TYPE_CHECKING
+from pydantic import BaseModel
 
-from .events import HookPayload
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .events import HookPayload
 
-from .models import PipelineResult, StepResult  # noqa: F401
-from .resources import AppResources  # noqa: F401
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .resources import AppResources  # noqa: F401
+
+# Generic type for pipeline context models
+ContextT = TypeVar("ContextT", bound=BaseModel)
 
 # A hook is an async callable that receives a typed payload object.
-HookCallable = Callable[[HookPayload], Coroutine[Any, Any, None]]
+HookCallable = Callable[["HookPayload"], Coroutine[Any, Any, None]]

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from flujo.domain.models import PipelineResult
 
 
@@ -57,7 +59,7 @@ class PipelineContextInitializationError(OrchestratorError):
 class UsageLimitExceededError(OrchestratorError):
     """Raised when a pipeline run exceeds its defined usage limits."""
 
-    def __init__(self, message: str, result: "PipelineResult") -> None:
+    def __init__(self, message: str, result: "PipelineResult[Any]") -> None:
         super().__init__(message)
         self.result = result
 

--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -56,16 +56,16 @@ class AgenticLoop:
             },
         )
 
-    def run(self, initial_goal: str) -> PipelineResult:
+    def run(self, initial_goal: str) -> PipelineResult[PipelineContext]:
         runner = Flujo(self._pipeline, context_model=PipelineContext)
         return runner.run(
             {"last_command_result": None, "goal": initial_goal},
             initial_context_data={"initial_prompt": initial_goal},
         )
 
-    async def run_async(self, initial_goal: str) -> PipelineResult:
+    async def run_async(self, initial_goal: str) -> PipelineResult[PipelineContext]:
         runner = Flujo(self._pipeline, context_model=PipelineContext)
-        final_result: PipelineResult | None = None
+        final_result: PipelineResult[PipelineContext] | None = None
         async for item in runner.run_async(
             {"last_command_result": None, "goal": initial_goal},
             initial_context_data={"initial_prompt": initial_goal},
@@ -74,15 +74,19 @@ class AgenticLoop:
         assert final_result is not None
         return final_result
 
-    def resume(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+    def resume(
+        self, paused_result: PipelineResult[PipelineContext], human_input: Any
+    ) -> PipelineResult[PipelineContext]:
         runner = Flujo(self._pipeline, context_model=PipelineContext)
 
-        async def _consume() -> PipelineResult:
+        async def _consume() -> PipelineResult[PipelineContext]:
             return await runner.resume_async(paused_result, human_input)
 
         return asyncio.run(_consume())
 
-    async def resume_async(self, paused_result: PipelineResult, human_input: Any) -> PipelineResult:
+    async def resume_async(
+        self, paused_result: PipelineResult[PipelineContext], human_input: Any
+    ) -> PipelineResult[PipelineContext]:
         runner = Flujo(self._pipeline, context_model=PipelineContext)
         return await runner.resume_async(paused_result, human_input)
 

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -101,7 +101,7 @@ class Default:
         self.flujo_engine = Flujo(pipeline, context_model=PipelineContext)
 
     async def run_async(self, task: Task) -> Candidate | None:
-        result: PipelineResult = await gather_result(
+        result: PipelineResult[PipelineContext] = await gather_result(
             self.flujo_engine,
             task.prompt,
             initial_context_data={"initial_prompt": task.prompt},

--- a/tests/mypy_success.py
+++ b/tests/mypy_success.py
@@ -1,5 +1,6 @@
 from flujo.domain import Step, step
 from flujo.testing.utils import StubAgent
+from flujo.application.flujo_engine import Flujo
 from pydantic import BaseModel
 
 
@@ -30,3 +31,13 @@ def test_pipeline_type_continuity() -> None:
     # agent3 = StubAgent(["raw_string"])
     # step3: Step[int, str] = Step.solution(agent3)
     # bad_pipeline = step1 >> step3
+
+
+class MyCtx(BaseModel):
+    counter: int = 0
+
+
+def check_result_typing() -> None:
+    runner = Flujo(Step.solution(StubAgent(["ok"])), context_model=MyCtx)
+    result = runner.run("hi")
+    reveal_type(result.final_pipeline_context)  # noqa: F821


### PR DESCRIPTION
## Summary
- implement `ContextT` TypeVar for pipeline context models
- make `PipelineResult` and `Flujo` generic over `ContextT`
- update engine, events, recipes and docs for new generic API
- add typing demonstration in `tests/mypy_success.py`

## Testing
- `ruff format flujo tests docs`
- `ruff check flujo tests docs`
- `mypy flujo`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a8922d80832c8f3b44916e301617