### PR TITLE
Finalize decorator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,33 +59,27 @@ print(result.final_pipeline_context.command_log[-1].execution_result)
 ### Pipeline Example
 
 ```python
-from flujo import (
-    Step, Flujo, Task,
-    review_agent, solution_agent, validator_agent,
-)
+from flujo import Flujo, step, PipelineResult
 
-# Build a custom pipeline using the Step DSL. This mirrors the internal
-# workflow used by :class:`Default` but is fully configurable.
-custom_pipeline = (
-    Step.review(review_agent)
-    >> Step.solution(solution_agent)
-    >> Step.validate(validator_agent)
-)
+@step
+async def to_uppercase(text: str) -> str:
+    """A simple step to convert text to uppercase."""
+    return text.upper()
 
-pipeline_runner = Flujo(custom_pipeline)
+@step
+async def add_enthusiasm(text: str) -> str:
+    """A second step to add emphasis."""
+    return f"{text}!!!"
 
-# Run synchronously; Flujo returns a PipelineResult.
-pipeline_result = pipeline_runner.run(
-    "Generate a REST API using FastAPI for a to-do list application."
-)
+# Compose the pipeline using the decorator-created steps
+pipeline = to_uppercase >> add_enthusiasm
+runner = Flujo(pipeline)
 
-print("\nPipeline Execution History:")
-for step_res in pipeline_result.step_history:
-    print(f"- Step '{step_res.name}': Success={step_res.success}")
+# Run the pipeline
+result: PipelineResult[str] = runner.run("hello world")
 
-if len(pipeline_result.step_history) > 1 and pipeline_result.step_history[1].success:
-    solution_output = pipeline_result.step_history[1].output
-    print("\nGenerated Solution:\n", solution_output)
+print(f"Final pipeline output: {result.step_history[-1].output}")
+# Expected Output: Final pipeline output: HELLO WORLD!!!
 ```
 
 ## Documentation

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -1,66 +1,7 @@
 # Typed Pipeline Context
 
-`Flujo` can maintain a mutable Pydantic model instance that is shared across every step during a single run. This feature is sometimes called the *pipeline scratchpad* or *shared context*.
+`Flujo` can share a mutable Pydantic model across all steps in a single run. This is useful for accumulating metrics or passing configuration.
 
-## Why use a context?
+A context instance is created for every call to `run()` and is available to steps, agents and plugins that declare a `pipeline_context` parameter.
 
-- Accumulate metrics or intermediate results across steps.
-- Provide configuration or runtime parameters to non‑adjacent steps.
-- Keep your data flow explicit and type safe.
-
-## Defining a context model
-
-```python
-from pydantic import BaseModel
-
-class MyContext(BaseModel):
-    user_query: str
-    counter: int = 0
-```
-
-## Initializing the runner
-
-```python
-runner = Flujo(
-    pipeline,
-    context_model=MyContext,
-    initial_context_data={"user_query": "hello"},
-)
-```
-
-The initial data is validated against the Pydantic model. If validation fails a `PipelineContextInitializationError` is raised and the run is aborted.
-
-## Accessing the context in components
-
-Implement the `ContextAwareAgentProtocol` or `ContextAwarePluginProtocol` to receive a strongly typed context without casts.
-
-```python
-from flujo.domain.agent_protocol import ContextAwareAgentProtocol
-from flujo.domain.plugins import ContextAwarePluginProtocol, PluginOutcome
-
-class CountingAgent(ContextAwareAgentProtocol[str, str, MyContext]):
-    async def run(self, data: str, *, pipeline_context: MyContext, **kwargs: Any) -> str:
-        pipeline_context.counter += 1
-        return data
-
-class MyPlugin(ContextAwarePluginProtocol[MyContext]):
-    async def validate(self, data: dict[str, Any], *, pipeline_context: MyContext, **kwargs: Any) -> PluginOutcome:
-        return PluginOutcome(success=True)
-```
-
-Legacy agents that merely accept a `pipeline_context` parameter will still work but will trigger a `DeprecationWarning`. Updating them to implement the `ContextAware` protocol is recommended.
-
-## Lifecycle
-
-A fresh context instance is created for every call to `run()` or `run_async()`. Mutations by one step are visible to all subsequent steps in that run. Separate runs do not share state unless you explicitly pass previous context data as `initial_context_data`.
-
-## Retrieving the final state
-
-After execution, `PipelineResult.final_pipeline_context` holds the mutated context instance:
-
-```python
-result = runner.run("hi")
-print(result.final_pipeline_context.counter)
-```
-
-For a complete example, see the [Typed Pipeline Context section](pipeline_dsl.md#typed-pipeline-context) of the Pipeline DSL guide. A runnable demonstration is available in [this script on GitHub](https://github.com/aandresalvarez/flujo/blob/main/examples/06_typed_context.py).
+For complete details on implementing context aware components see the [Stateful Pipelines](typing_guide.md#stateful-pipelines-the-contextaware-protocols) section of the Typing Guide.

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -13,16 +13,23 @@ The Pipeline DSL lets you:
 
 ## Basic Usage
 
+!!! tip "Recommended Pattern"
+    For creating pipeline steps from your own `async` functions, the `@step` decorator is the simplest and most powerful approach. It automatically infers types and reduces boilerplate, making your code cleaner and safer.
+
 ### Creating a Pipeline
 
 ```python
-from flujo import Step, Flujo, step
+from flujo import Flujo, step
 
 @step
 async def add_one(x: int) -> int:
     return x + 1
 
-pipeline = add_one >> add_one
+@step
+async def add_two(x: int) -> int:
+    return x + 2
+
+pipeline = add_one >> add_two
 runner = Flujo(pipeline)
 result = runner.run(1)
 ```
@@ -30,36 +37,21 @@ result = runner.run(1)
 The `@step` decorator infers the input and output types from the
 function's signature so the pipeline is typed as `Step[int, int]`.
 
-```python
-from flujo.infra.agents import (
-    review_agent, solution_agent, validator_agent,
-)
-
-# Built-in step factories are still available
-pipeline = (
-    Step.review(review_agent)
-    >> Step.solution(solution_agent)
-    >> Step.validate_step(validator_agent)
-)
-
-runner = Flujo(pipeline)
-result = runner.run("Write a function to sort a list")
-```
-
 ### Pipeline Composition
 
 The `>>` operator chains steps together:
 
 ```python
-# Create reusable steps
-review_step = Step.review(review_agent)
-solution_step = Step.solution(solution_agent)
-validate_step = Step.validate_step(validator_agent)
+@step
+async def multiply(x: int) -> int:
+    return x * 2
 
-# Compose them in different ways
-pipeline1 = review_step >> solution_step >> validate_step
-pipeline2 = solution_step >> validate_step  # Skip review
-pipeline3 = review_step >> solution_step >> solution_step >> validate_step  # Double solution
+@step
+async def add_three(x: int) -> int:
+    return x + 3
+
+pipeline1 = multiply >> add_three
+pipeline2 = add_three >> multiply
 ```
 
 ### Creating Steps from Functions

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -64,14 +64,42 @@ for entry in result.final_pipeline_context.command_log:
 ```
 This loop lets the planner decide when to call the tool and when to finish. The command log shows each decision.
 
-## 2. The Budget-Aware Workflow: Customizing Agents for `Default`
+## 2. Building Your First Custom Step with `@step`
+
+The easiest way to extend a pipeline is to decorate an async function with `@step`.
+
+```python
+from flujo import step
+
+@step
+async def shout(text: str) -> str:
+    return text.upper()
+```
+
+`shout` is now a typed `Step[str, str]` that you can compose with others.
+
+## 3. Composing Your First Custom Pipeline
+
+```python
+from flujo import Flujo, step, PipelineResult
+
+@step
+async def to_upper(text: str) -> str:
+    return text.upper()
+
+@step
+async def add_excitement(text: str) -> str:
+    return f"{text}!"
+
+pipeline = to_upper >> add_excitement
+runner = Flujo(pipeline)
+result: PipelineResult[str] = runner.run("hello")
+print(result.step_history[-1].output)  # HELLO!
+```
+
+## 4. The Budget-Aware Workflow: Customizing Agents for `Default`
 
 The `Default` recipe is still handy for simple, fixed workflows. You can customize its agents to mix models for cost and quality.
-
----
-
-
-## 2. The Budget-Aware Workflow: Customizing Agents for `Default`
 
 Professional AI workflows often involve a mix of models to balance cost, speed, and quality. Here, we'll use a **cheaper, faster model** for the initial draft (`solution_agent`) but retain the **smarter models** for the critical thinking roles (planning, quality control, and strategy).
 
@@ -96,7 +124,7 @@ This "cheap drafter, smart reviewer" pattern is a powerful way to get high-quali
 
 ---
 
-## 3. Outputting Structured Data with a Custom Pipeline
+## 5. Outputting Structured Data with a Custom Pipeline
 
 So far, our agents have only outputted simple strings. What if we need structured data, like JSON? The underlying `pydantic-ai` library excels at this. You can specify a Pydantic `BaseModel` as the `output_type` for an agent.
 
@@ -169,7 +197,7 @@ else:
 
 ---
 
-## 4. The Grand Finale: A Fully Custom Pipeline with Tools
+## 6. The Grand Finale: A Fully Custom Pipeline with Tools
 
 Now for the ultimate challenge. Let's build a workflow where **every agent is customized**, and our `solution_agent` can use **external tools** to get information it doesn't have.
 
@@ -256,7 +284,7 @@ This concludes our tour! You've journeyed from a simple prompt to a sophisticate
 -   Generate clean, **structured JSON** using Pydantic models.
 -   Empower agents with **external tools** to overcome their knowledge limitations.
 
-## 5. Building Custom Pipelines
+## 7. Building Custom Pipelines
 
 The new Pipeline DSL lets you compose your own workflow using `Step` objects. Execute the pipeline with `Flujo`:
 

--- a/docs/typing_guide.md
+++ b/docs/typing_guide.md
@@ -1,49 +1,99 @@
 # Typing Guide
 
-`flujo` embraces Python's type hints to make pipelines safer and easier to use.
-The `Step.from_callable` factory automatically infers a step's input and output
-types from an async function.
+`flujo` uses Python type hints to help you build robust pipelines. This guide shows how the `@step` decorator, `ContextAware` protocols and static type checkers work together.
+
+## The `@step` Decorator: Effortless Typed Steps
+
+Wrapping an async function with `@step` automatically creates a `Step[In, Out]` object using the function's signature. No manual generics are required.
 
 ```python
-from flujo import Step
+from flujo import step
 
-async def process(data: str) -> int:
+async def legacy_process(data: str) -> int:
     return len(data)
 
-step = Step.from_callable(process)
+process_step = step(legacy_process)  # Step[str, int]
 ```
 
-Static type checkers like `mypy` infer `step` as `Step[str, int]` so pipelines
-compose cleanly without manual casts. If a callable lacks annotations, the
-factory falls back to `Any`.
+The decorator can also be used directly on your function:
+
+```python
+from flujo import step
+
+@step
+async def to_upper(text: str) -> str:
+    return text.upper()
+```
+
+Here `to_upper` is already a `Step[str, str]` ready to be composed with other steps.
+
+## Type Safety in Pipelines
+
+Pipelines are strongly typed. If you try to chain incompatible steps, static analyzers such as `mypy` will flag an error.
+
+```python
+from flujo import step
+
+@step
+async def first(x: str) -> int:
+    return len(x)
+
+@step
+async def second(x: str) -> str:
+    return x
+
+pipeline = first >> second  # ❌ mypy: incompatible types
+```
+
+Because `first` outputs an `int` while `second` expects a `str`, `mypy` warns that the composition is invalid.
+
+## Stateful Pipelines: The `ContextAware` Protocols
+
+To share state across steps, define a Pydantic model and have your agents or plugins implement one of the context aware protocols. They receive a typed context instance automatically.
 
 ```python
 from pydantic import BaseModel
+from flujo.domain.agent_protocol import ContextAwareAgentProtocol
+from flujo.domain.plugins import ContextAwarePluginProtocol, PluginOutcome
 
-class Info(BaseModel):
-    message: str
-    count: int
+class MyContext(BaseModel):
+    user_query: str
+    counter: int = 0
 
-async def increment(info: Info) -> Info:
-    info.count += 1
-    return info
+class CountingAgent(ContextAwareAgentProtocol[str, str, MyContext]):
+    async def run(self, data: str, *, pipeline_context: MyContext, **_: object) -> str:
+        pipeline_context.counter += 1
+        return data
 
-typed = Step.from_callable(increment)
-# inferred as Step[Info, Info]
-
-async def untyped(x):
-    return x
-
-any_step = Step.from_callable(untyped)
-# inferred as Step[Any, Any]
-
-async def uses_context(data: str, *, pipeline_context: Info) -> str:
-    return data + pipeline_context.message
-
-context_step = Step.from_callable(uses_context)
+class MyPlugin(ContextAwarePluginProtocol[MyContext]):
+    async def validate(self, data: dict[str, object], *, pipeline_context: MyContext, **_: object) -> PluginOutcome:
+        return PluginOutcome(success=True)
 ```
 
-Keyword-only parameters such as ``pipeline_context`` or ``resources`` are
-ignored when inferring the input type. They are still passed through during
-execution, allowing you to access shared state or application resources without
-affecting the step's signature.
+Every call to `Flujo.run()` creates a fresh context instance. Mutations are visible to all subsequent steps.
+
+## A Complete Example
+
+```python
+from flujo import Flujo, step, PipelineResult
+
+class Ctx(BaseModel):
+    history: list[str] = []
+
+@step
+async def record(text: str, *, pipeline_context: Ctx) -> str:
+    pipeline_context.history.append(text)
+    return text.upper()
+
+@step
+async def cheer(text: str) -> str:
+    return f"{text}!"
+
+pipeline = record >> cheer
+runner = Flujo(pipeline, context_model=Ctx)
+result: PipelineResult[str] = runner.run("hello")
+print(result.final_pipeline_context.history)  # ['hello']
+print(result.step_history[-1].output)        # 'HELLO!'
+```
+
+This pipeline records each input in the context while producing an enthusiastic response.


### PR DESCRIPTION
## Summary
- promote the `@step` decorator in the README example
- overhaul the typing guide with decorator usage and context protocols
- simplify pipeline context page and link to the typing guide
- restructure the tutorial to introduce `@step` early
- highlight decorator usage in the Pipeline DSL guide

## Testing
- `pre-commit run --files README.md docs/typing_guide.md docs/pipeline_context.md docs/tutorial.md docs/pipeline_dsl.md`
- `mkdocs build -q`


------
https://chatgpt.com/codex/tasks/task_e_6859d3a8c098832ca32593b43522b8ac