### PR TITLE
Add manual E2E workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,51 @@
+name: Manual E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      re_record_cassette:
+        description: 'Re-record VCR cassette? (deletes old one)'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  run-e2e-tests:
+    name: Run End-to-End Golden Transcript Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install hatch
+          hatch run setup
+
+      - name: Delete cassette if re-recording
+        if: ${{ github.event.inputs.re_record_cassette == 'true' }}
+        run: |
+          echo "Re-recording enabled. Deleting old cassette."
+          rm -f tests/e2e/cassettes/golden.yaml
+
+      - name: Run E2E test against live API
+        env:
+          OPENAI_API_KEY: ${{ secrets.E2E_OPENAI_API_KEY }}
+          CI_E2E_RUN: "true"
+        run: |
+          pytest tests/e2e/test_golden_transcript.py
+
+      - name: Upload new cassette if recorded
+        if: ${{ github.event.inputs.re_record_cassette == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: new-e2e-cassette
+          path: tests/e2e/cassettes/golden.yaml
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,18 @@ new utilities or models, consider writing property-based tests.
 
 You can see examples in `tests/unit/test_utils_properties.py`.
 
+### Running End-to-End Tests
+
+The `tests/e2e` suite is skipped during normal CI runs. Maintainers can execute
+these tests manually via GitHub Actions:
+
+1. Open the **Actions** tab and choose **Manual E2E Tests**.
+2. Click **Run workflow** and optionally enable *Re-record VCR cassette?* to
+   delete the existing cassette and record a new one.
+3. If a new cassette is recorded, download the `new-e2e-cassette` artifact from
+   the workflow run and replace `tests/e2e/cassettes/golden.yaml` before
+   committing.
+
 ---
 
 ## 5. Code Quality

--- a/tests/e2e/test_golden_transcript.py
+++ b/tests/e2e/test_golden_transcript.py
@@ -1,9 +1,16 @@
 import pytest
+import os
+
+# Conditionally skip the test unless explicitly enabled.
+if not os.getenv("CI_E2E_RUN"):
+    pytest.skip(
+        "Skipping E2E golden transcript test; run manually or via E2E workflow.",
+        allow_module_level=True,
+    )
 
 try:
     import vcr
-except Exception:  # pragma: no cover - skip if dependency missing
-    vcr = None
+except ImportError:  # pragma: no cover - skip if dependency missing
     pytest.skip("vcrpy not installed", allow_module_level=True)
 from flujo.recipes import Default
 from flujo.domain.models import Task, Candidate
@@ -13,8 +20,6 @@ from flujo.infra.agents import (
     validator_agent,
     get_reflection_agent,
 )
-
-pytest.skip("Skipping golden transcript", allow_module_level=True)
 
 
 def scrub_auth(request):


### PR DESCRIPTION
## Summary
- add `.github/workflows/e2e_tests.yml` to run the golden transcript test manually
- enable the golden transcript test when `CI_E2E_RUN` is set
- document how maintainers can run the E2E workflow

## Testing
- `hatch run test`

------
https://chatgpt.com/codex/tasks/task_e_6859dd218edc832cbed5cb582b644d1c