### PR TITLE
Add advanced prompt formatting utilities

### DIFF
--- a/docs/cookbook/advanced_prompting.md
+++ b/docs/cookbook/advanced_prompting.md
@@ -1,0 +1,55 @@
+# Cookbook: Advanced Prompt Formatting
+
+Build dynamic prompts using the built-in `format_prompt` utility. It supports simple substitutions, conditional blocks, loops, nested data access and escaping.
+
+## Basic Usage
+
+```python
+from flujo import format_prompt
+
+result = format_prompt("Hello {{ name }}!", name="World")
+# result -> "Hello World!"
+```
+
+## Conditional Blocks
+
+Include text only when a variable is provided and truthy.
+
+```python
+template = "User query: {{ query }}. {{#if feedback}}Previous feedback: {{ feedback }}{{/if}}"
+print(format_prompt(template, query="a", feedback="It was wrong."))
+# User query: a. Previous feedback: It was wrong.
+
+print(format_prompt(template, query="a", feedback=None))
+# User query: a.
+```
+
+## Iterating Over Lists
+
+```python
+template = "Consider:\n{{#each examples}}- {{ this }}\n{{/each}}"
+print(format_prompt(template, examples=["A", "B"]))
+# Consider:
+# - A
+# - B
+```
+
+## Nested Placeholders
+
+```python
+template = "User: {{ user.name }} ({{ user.email }})"
+user = {"name": "Bob", "email": "b@example.com"}
+print(format_prompt(template, user=user))
+# User: Bob (b@example.com)
+```
+
+## Escaping
+
+Use a backslash before the opening braces to emit literal braces.
+
+```python
+template = r"The syntax is \{{ variable_name }}."
+print(format_prompt(template))
+# The syntax is {{ variable_name }}.
+```
+

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -32,6 +32,7 @@ from .application.eval_adapter import run_pipeline_async
 from .application.self_improvement import evaluate_and_improve, SelfImprovementAgent
 from .domain.models import PipelineResult, StepResult, UsageLimits
 from .testing.utils import StubAgent, DummyPlugin
+from .utils.prompting import format_prompt
 from .plugins.sql_validator import SQLSyntaxValidator
 
 from .infra.agents import (
@@ -94,4 +95,5 @@ __all__ = [
     "StepExecutionRequest",
     "LocalBackend",
     "ConsoleTracer",
+    "format_prompt",
 ]

--- a/flujo/utils/prompting.py
+++ b/flujo/utils/prompting.py
@@ -1,0 +1,79 @@
+import re
+import orjson
+from typing import Any, Dict
+from pydantic import BaseModel
+
+IF_BLOCK_REGEX = re.compile(r"\{\{#if\s*([^\}]+?)\s*\}\}(.*?)\{\{\/if\}\}", re.DOTALL)
+EACH_BLOCK_REGEX = re.compile(
+    r"\{\{#each\s*([^\}]+?)\s*\}\}(.*?)\{\{\/each\}\}", re.DOTALL
+)
+PLACEHOLDER_REGEX = re.compile(r"\{\{\s*([^\}]+?)\s*\}\}")
+
+
+class AdvancedPromptFormatter:
+    """Format prompt templates with conditionals, loops and nested data."""
+
+    def __init__(self, template: str) -> None:
+        self.template = template
+
+    def _get_nested_value(self, data: Dict[str, Any], key: str) -> Any:
+        value: Any = data
+        for part in key.split("."):
+            if isinstance(value, dict):
+                value = value.get(part)
+            else:
+                value = getattr(value, part, None)
+            if value is None:
+                return None
+        return value
+
+    def _serialize(self, value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, BaseModel):
+            return value.model_dump_json()
+        if isinstance(value, (dict, list)):
+            return str(orjson.dumps(value).decode())
+        return str(value)
+
+    def format(self, **kwargs: Any) -> str:
+        ESC_MARKER = "__ESCAPED_OPEN__"
+        processed = self.template.replace(r"\{{", ESC_MARKER)
+
+        def if_replacer(match: re.Match[str]) -> str:
+            key, content = match.groups()
+            value = self._get_nested_value(kwargs, key.strip())
+            return content if value else ""
+
+        processed = IF_BLOCK_REGEX.sub(if_replacer, processed)
+
+        def each_replacer(match: re.Match[str]) -> str:
+            key, block = match.groups()
+            items = self._get_nested_value(kwargs, key.strip())
+            if not isinstance(items, list):
+                return ""
+            parts = []
+            for item in items:
+                inner = block.replace("{{ this }}", self._serialize(item))
+                # allow nested placeholders referring to outer scope as well
+                inner_formatter = AdvancedPromptFormatter(inner)
+                parts.append(inner_formatter.format(**kwargs, this=item))
+            return "".join(parts)
+
+        processed = EACH_BLOCK_REGEX.sub(each_replacer, processed)
+
+        def placeholder_replacer(match: re.Match[str]) -> str:
+            key = match.group(1).strip()
+            value = self._get_nested_value(
+                {**kwargs, **{"this": kwargs.get("this")}}, key
+            )
+            return self._serialize(value)
+
+        processed = PLACEHOLDER_REGEX.sub(placeholder_replacer, processed)
+        processed = processed.replace(ESC_MARKER, "{{")
+        return processed
+
+
+def format_prompt(template: str, **kwargs: Any) -> str:
+    formatter = AdvancedPromptFormatter(template)
+    return formatter.format(**kwargs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - 'HITL Structured Input': cookbook/hitl_structured_input.md
     - 'HITL Correction Loop': cookbook/hitl_stateful_correction_loop.md
     - 'Real-Time Chatbot': cookbook/realtime_chatbot.md
+    - 'Advanced Prompt Formatting': cookbook/advanced_prompting.md
     - 'Agentic Loop': recipes/agentic_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md

--- a/tests/unit/test_prompt_formatter.py
+++ b/tests/unit/test_prompt_formatter.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel
+from flujo import format_prompt
+
+
+class Person(BaseModel):
+    name: str
+    email: str | None = None
+
+
+def test_baseline_placeholder_and_json() -> None:
+    template = "Hello {{ name }}! Data: {{ person }}"
+    person = Person(name="Alice", email="a@example.com")
+    result = format_prompt(template, name="World", person=person)
+    assert result == f"Hello World! Data: {person.model_dump_json()}"
+
+
+def test_if_block() -> None:
+    template = "User query: {{ query }}. {{#if feedback}}Previous feedback: {{ feedback }}{{/if}}"
+    assert (
+        format_prompt(template, query="a", feedback="It was wrong.")
+        == "User query: a. Previous feedback: It was wrong."
+    )
+    assert format_prompt(template, query="a", feedback=None) == "User query: a. "
+
+
+def test_each_block() -> None:
+    template = "Items:\n{{#each examples}}- {{ this }}\n{{/each}}"
+    result = format_prompt(template, examples=["A", "B"])
+    assert "- A" in result and "- B" in result
+    empty = format_prompt(template, examples=[])
+    assert empty == "Items:\n"
+
+
+def test_nested_placeholders() -> None:
+    template = "User: {{ user.name }} ({{ user.email }})"
+    data = {"name": "Bob", "email": "b@example.com"}
+    assert format_prompt(template, user=data) == "User: Bob (b@example.com)"
+    assert format_prompt(template, user={}) == "User:  ()"
+
+
+def test_escaping() -> None:
+    template = r"The syntax is \{{ variable_name }}."
+    assert format_prompt(template) == "The syntax is {{ variable_name }}."


### PR DESCRIPTION
## Summary
- implement `AdvancedPromptFormatter` with conditional blocks, loops, nested access and escaping
- document new features in cookbook
- expose `format_prompt` in package API
- add corresponding unit tests
- register documentation page
- update docs and tests to import the new helper via the package

## Testing
- `make quality`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c4bd278c0832c83d3d38132d4cdb2