### PR TITLE
Add agent prompt/output processors

### DIFF
--- a/flujo/processors/__init__.py
+++ b/flujo/processors/__init__.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, List, Optional, Protocol
+import dataclasses
+import orjson
+import re
+from pydantic import BaseModel as PydanticBaseModel, Field, ConfigDict
+from typing import ClassVar
+
+
+class Processor(Protocol):
+    """Generic processor protocol."""
+
+    name: str
+
+    async def process(self, data: Any, context: Optional[PydanticBaseModel]) -> Any: ...
+
+
+class AgentProcessors(PydanticBaseModel):
+    """Container for prompt and output processors."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(arbitrary_types_allowed=True)
+
+    prompt_processors: List[Any] = Field(default_factory=list)
+    output_processors: List[Any] = Field(default_factory=list)
+
+
+class AddContextVariables:
+    """Prepends selected variables from the pipeline context to the prompt."""
+
+    name = "AddContextVariables"
+
+    def __init__(self, *, vars: List[str]):
+        self.vars = vars
+
+    async def process(self, data: Any, context: Optional[PydanticBaseModel]) -> Any:
+        if not isinstance(data, str) or context is None:
+            return data
+        parts = []
+        for var in self.vars:
+            value = getattr(context, var, None)
+            if value is not None:
+                parts.append(f"{var}: {value}")
+        if not parts:
+            return data
+        header = "--- CONTEXT ---\n" + "\n".join(parts) + "\n---\n"
+        return header + data
+
+
+class StripMarkdownFences:
+    """Extracts content from a markdown code block."""
+
+    name = "StripMarkdownFences"
+
+    def __init__(self, *, language: str):
+        self.language = language
+        self._pattern = re.compile(rf"```{re.escape(language)}\s*(.*?)\s*```", re.DOTALL)
+
+    async def process(self, data: Any, context: Optional[PydanticBaseModel]) -> Any:
+        if not isinstance(data, str):
+            return data
+        match = self._pattern.search(data)
+        if match:
+            return match.group(1).strip()
+        return data
+
+
+class EnforceJsonResponse:
+    """Ensures the output is valid JSON, optionally using a fixer callable."""
+
+    name = "EnforceJsonResponse"
+
+    def __init__(self, fixer: Optional[Callable[[str], Awaitable[str]]] = None):
+        self.fixer = fixer
+
+    async def process(self, data: Any, context: Optional[PydanticBaseModel]) -> Any:
+        if not isinstance(data, str):
+            return data
+        try:
+            orjson.loads(data)
+            return data
+        except Exception:
+            if self.fixer is not None:
+                fixed = await self.fixer(data)
+                orjson.loads(fixed)  # may raise
+                return fixed
+            raise ValueError("Invalid JSON output")
+
+
+__all__ = [
+    "Processor",
+    "AgentProcessors",
+    "AddContextVariables",
+    "StripMarkdownFences",
+    "EnforceJsonResponse",
+]

--- a/tests/unit/test_processors.py
+++ b/tests/unit/test_processors.py
@@ -1,0 +1,64 @@
+import pytest
+from flujo.processors import (
+    AddContextVariables,
+    StripMarkdownFences,
+    EnforceJsonResponse,
+    AgentProcessors,
+)
+from flujo.infra.agents import AsyncAgentWrapper
+from flujo.domain.models import BaseModel
+import dataclasses
+
+
+class Ctx(BaseModel):
+    user_id: int
+    session_id: str
+
+
+@dataclasses.dataclass
+class Result:
+    output: str
+
+
+class DummyAgent:
+    async def run(self, data, **kwargs):
+        return Result(output=data)
+
+
+@pytest.mark.asyncio
+async def test_add_context_variables():
+    ctx = Ctx(user_id=1, session_id="abc")
+    proc = AddContextVariables(vars=["user_id", "session_id"])
+    out = await proc.process("hello", ctx)
+    assert "user_id: 1" in out
+    assert out.endswith("hello")
+
+
+@pytest.mark.asyncio
+async def test_strip_markdown_fences():
+    proc = StripMarkdownFences(language="json")
+    text = 'before ```json\n{"a":1}\n``` after'
+    result = await proc.process(text, None)
+    assert result == '{"a":1}'
+
+
+@pytest.mark.asyncio
+async def test_enforce_json_response():
+    proc = EnforceJsonResponse()
+    out = await proc.process('{"a":1}', None)
+    assert out == '{"a":1}'
+    with pytest.raises(ValueError):
+        await proc.process("not json", None)
+
+
+@pytest.mark.asyncio
+async def test_wrapper_applies_processors():
+    processors = AgentProcessors(
+        prompt_processors=[AddContextVariables(vars=["user_id"])],
+        output_processors=[StripMarkdownFences(language="json")],
+    )
+    wrapper = AsyncAgentWrapper(DummyAgent(), processors=processors, output_type=dict)
+    ctx = Ctx(user_id=5, session_id="x")
+    res = await wrapper.run_async('```json\n{"k":1}\n```', context=ctx)
+    assert dataclasses.is_dataclass(res)
+    assert res.output == {"k": 1}


### PR DESCRIPTION
## Summary
- support prompt and output processors for agents
- implement AddContextVariables, StripMarkdownFences, EnforceJsonResponse
- integrate processors with Step execution
- cover new processors with unit tests

## Testing
- `ruff format flujo tests`
- `ruff check flujo tests`
- `mypy flujo`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5f51f20c832c8ea99adfa2573943