### PR TITLE
Add declarative processors

### DIFF
--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -19,6 +19,7 @@ from .domain import (
     step,
     Pipeline,
     StepConfig,
+    AgentProcessors,
     PluginOutcome,
     ValidationPlugin,
     Validator,
@@ -37,6 +38,12 @@ from .domain.models import PipelineResult, StepResult, UsageLimits
 from .testing.utils import StubAgent, DummyPlugin
 from .utils.prompting import format_prompt
 from .plugins.sql_validator import SQLSyntaxValidator
+from .processors import (
+    Processor,
+    AddContextVariables,
+    StripMarkdownFences,
+    EnforceJsonResponse,
+)
 
 from .infra.agents import (
     review_agent,
@@ -67,6 +74,11 @@ __all__ = [
     "step",
     "Pipeline",
     "StepConfig",
+    "AgentProcessors",
+    "Processor",
+    "AddContextVariables",
+    "StripMarkdownFences",
+    "EnforceJsonResponse",
     "AppResources",
     "PluginOutcome",
     "ValidationPlugin",

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -11,6 +11,7 @@ from .pipeline_dsl import (
 )
 from .plugins import PluginOutcome, ValidationPlugin
 from .validation import Validator, ValidationResult
+from .processors import AgentProcessors
 from .resources import AppResources
 from .types import HookCallable
 from .backends import ExecutionBackend, StepExecutionRequest
@@ -31,4 +32,5 @@ __all__ = [
     "HookCallable",
     "ExecutionBackend",
     "StepExecutionRequest",
+    "AgentProcessors",
 ]

--- a/flujo/domain/processors.py
+++ b/flujo/domain/processors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import List, Any, TYPE_CHECKING
+
+from pydantic import Field
+
+from .models import BaseModel
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..processors.base import Processor  # noqa: F401
+
+
+class AgentProcessors(BaseModel):
+    """Collections of prompt and output processors."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    prompt_processors: List[Any] = Field(default_factory=list)
+    output_processors: List[Any] = Field(default_factory=list)

--- a/flujo/processors/__init__.py
+++ b/flujo/processors/__init__.py
@@ -1,0 +1,9 @@
+from .base import Processor
+from .common import AddContextVariables, StripMarkdownFences, EnforceJsonResponse
+
+__all__ = [
+    "Processor",
+    "AddContextVariables",
+    "StripMarkdownFences",
+    "EnforceJsonResponse",
+]

--- a/flujo/processors/base.py
+++ b/flujo/processors/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Protocol, Any, Optional
+
+from ..domain.models import BaseModel
+
+
+class Processor(Protocol):
+    """Generic processor interface."""
+
+    name: str
+
+    async def process(self, data: Any, context: Optional[BaseModel] = None) -> Any:
+        """Process data with optional pipeline context."""
+        ...

--- a/flujo/processors/common.py
+++ b/flujo/processors/common.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+import json
+from typing import Any, Optional, List
+
+from ..domain.models import BaseModel
+
+
+class AddContextVariables:
+    """Prepend context variables to a prompt."""
+
+    def __init__(self, vars: List[str]):
+        self.vars = vars
+        self.name = "AddContextVariables"
+
+    async def process(self, data: Any, context: Optional[BaseModel] = None) -> Any:
+        if context is None:
+            return data
+        header_lines = ["--- CONTEXT ---"]
+        for var in self.vars:
+            value = getattr(context, var, None)
+            header_lines.append(f"{var}: {value}")
+        header_lines.append("---")
+        prefix = "\n".join(header_lines)
+        return f"{prefix}\n{data}"
+
+
+class StripMarkdownFences:
+    """Extract content from a fenced code block."""
+
+    def __init__(self, language: str):
+        self.language = language
+        self.name = "StripMarkdownFences"
+        self.pattern = re.compile(rf"```{re.escape(language)}\n(.*?)\n```", re.DOTALL)
+
+    async def process(self, data: Any, context: Optional[BaseModel] = None) -> Any:
+        if not isinstance(data, str):
+            return data
+        match = self.pattern.search(data)
+        if match:
+            return match.group(1).strip()
+        return data
+
+
+class EnforceJsonResponse:
+    """Ensure the output is valid JSON."""
+
+    def __init__(self) -> None:
+        self.name = "EnforceJsonResponse"
+
+    async def process(self, data: Any, context: Optional[BaseModel] = None) -> Any:
+        if isinstance(data, (dict, list)):
+            return data
+        if not isinstance(data, str):
+            return data
+        try:
+            return json.loads(data)
+        except Exception:
+            return data


### PR DESCRIPTION
## Summary
- implement generic processor protocol for prompts and outputs
- add AgentProcessors model to store processor lists
- integrate processors into Step and engine
- provide common processors: AddContextVariables, StripMarkdownFences, EnforceJsonResponse
- expose new utilities in public API
- extend make_agent_async to accept processors

## Testing
- `ruff check`
- `ruff format --check`
- `make test`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_685c67111848832c90c3bc5da00ad2b6