### PR TITLE
Finalize processor and validator enhancements

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -69,14 +69,19 @@ custom_pipeline = (
     Step.review(review_agent)      # Review step
     >> Step.solution(              # Solution step
         solution_agent,
-        tools=[tool1, tool2]       # Optional tools
+        tools=[tool1, tool2],      # Optional tools
+        processors=my_processors   # Optional processors
     )
     >> Step.validate_step(              # Validation step
         validator_agent,
         plugins=[plugin1],         # Optional validation plugins
-        validators=[validator1]    # Optional programmatic validators
+        validators=[validator1],   # Optional programmatic validators
+        processors=my_processors
     )
 )
+
+# The `processors` argument lets you run custom pre- and post-processing
+# logic for a step. See [Using Processors](cookbook/using_processors.md).
 
 runner = Flujo(custom_pipeline)
 # With a shared typed context

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -173,6 +173,10 @@ validate_step = Step.validate_step(
 See [Hybrid Validation Cookbook](cookbook/hybrid_validation.md) for a complete example.
 ```
 
+All step factories also accept a `processors: Optional[AgentProcessors]` parameter
+to run pre-processing and post-processing hooks. See [Using Processors](cookbook/using_processors.md)
+for details.
+
 ## Advanced Features
 
 ### Parallel Execution

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -26,7 +26,7 @@ from .domain import (
     ValidationResult,
     AppResources,
 )
-from .validation import BaseValidator
+from .validation import BaseValidator, validator
 from .domain.types import HookCallable
 from .domain.events import HookPayload
 from .domain.backends import ExecutionBackend, StepExecutionRequest
@@ -85,6 +85,7 @@ __all__ = [
     "Validator",
     "ValidationResult",
     "BaseValidator",
+    "validator",
     "run_pipeline_async",
     "evaluate_and_improve",
     "SelfImprovementAgent",

--- a/flujo/validation.py
+++ b/flujo/validation.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Callable, Tuple
 from pydantic import BaseModel
 
 from .domain.validation import Validator, ValidationResult
@@ -18,3 +18,30 @@ class BaseValidator(Validator):
         *,
         context: Optional[BaseModel] = None,
     ) -> ValidationResult: ...
+
+
+def validator(func: Callable[[Any], Tuple[bool, Optional[str]]]) -> Validator:
+    """Decorator to create a stateless Validator from a function."""
+
+    class FunctionalValidator(BaseValidator):
+        async def validate(
+            self,
+            output_to_check: Any,
+            *,
+            context: Optional[BaseModel] = None,
+        ) -> ValidationResult:
+            try:
+                is_valid, feedback = func(output_to_check)
+                return ValidationResult(
+                    is_valid=is_valid,
+                    feedback=feedback,
+                    validator_name=func.__name__,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                return ValidationResult(
+                    is_valid=False,
+                    feedback=f"Validator function raised an exception: {e}",
+                    validator_name=func.__name__,
+                )
+
+    return FunctionalValidator(name=func.__name__)

--- a/tests/integration/test_processors.py
+++ b/tests/integration/test_processors.py
@@ -1,0 +1,78 @@
+import pytest
+from pydantic import BaseModel
+
+from flujo import Flujo, Step, AgentProcessors
+from flujo.testing.utils import StubAgent, gather_result
+
+
+class AddWorld:
+    name = "AddWorld"
+
+    async def process(self, data: str, context=None) -> str:
+        return data + " world"
+
+
+class DoubleOutput:
+    name = "DoubleOutput"
+
+    async def process(self, data: str, context=None) -> str:
+        return data * 2
+
+
+class ContextPrefix:
+    name = "CtxPrefix"
+
+    async def process(self, data: str, context=None) -> str:
+        prefix = getattr(context, "prefix", "") if context else ""
+        return f"{prefix}:{data}"
+
+
+class FailingProc:
+    name = "Fail"
+
+    async def process(self, data, context=None):
+        raise RuntimeError("boom")
+
+
+class Ctx(BaseModel):
+    prefix: str = "P"
+
+
+@pytest.mark.asyncio
+async def test_prompt_processor_modifies_input() -> None:
+    agent = StubAgent(["ok"])
+    procs = AgentProcessors(prompt_processors=[AddWorld()])
+    step = Step.solution(agent, processors=procs)
+    runner = Flujo(step)
+    await gather_result(runner, "hello")
+    assert agent.inputs[0] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_output_processor_modifies_output() -> None:
+    agent = StubAgent(["hi"])
+    procs = AgentProcessors(output_processors=[DoubleOutput()])
+    step = Step.solution(agent, processors=procs)
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    assert result.step_history[0].output == "hihi"
+
+
+@pytest.mark.asyncio
+async def test_processor_receives_context() -> None:
+    agent = StubAgent(["ok"])
+    procs = AgentProcessors(prompt_processors=[ContextPrefix()])
+    step = Step.solution(agent, processors=procs)
+    runner = Flujo(step, context_model=Ctx, initial_context_data={"prefix": "X"})
+    await gather_result(runner, "hello")
+    assert agent.inputs[0].startswith("X:")
+
+
+@pytest.mark.asyncio
+async def test_failing_processor_does_not_crash() -> None:
+    agent = StubAgent(["ok"])
+    procs = AgentProcessors(prompt_processors=[FailingProc()])
+    step = Step.solution(agent, processors=procs)
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    assert result.step_history[0].success is True


### PR DESCRIPTION
## Summary
- add `validator` decorator for simple checks
- improve processor logging and validator error handling in the engine
- document processor usage and mention processors in DSL and API docs
- expose `validator` function in package init
- add integration tests for processors
- run formatting via `make quality`

## Testing
- `make test`
- `make quality`
- `ruff check flujo tests`

------
https://chatgpt.com/codex/tasks/task_e_685c6eb4c994832ca23f6cb18d4b8340