### PR TITLE
Add testing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ All `make` commands are thin wrappers around `hatch` scripts defined in
    make test
    # pass arguments with: make test args="-k <pattern>"
    ```
+   See the [Testing Guide](docs/testing_guide.md) for tips on creating effective unit and integration tests.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ print(f"Final pipeline output: {result.step_history[-1].output}")
 
 - [Contributing Guide](CONTRIBUTING.md): How to contribute to the project
 - [Development Guide](docs/dev.md): Development setup and workflow
+- [Testing Guide](docs/testing_guide.md): Best practices for writing tests
 - [Code of Conduct](CODE_OF_CONDUCT.md): Community guidelines
 - [License](LICENSE): Dual License (AGPL-3.0 + Commercial)
 

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -1,40 +1,122 @@
 # Testing Guide
 
-This guide covers best practices for testing `flujo` pipelines.
+This guide explains how to write reliable unit and integration tests for `flujo` pipelines. It highlights the built in utilities found in `flujo.testing.utils` and showcases patterns for testing steps, pipelines, and resources.
 
-## Common Pitfalls
+## 1. Unit Testing Pipelines with `StubAgent`
 
-### Unconfigured mocks
+`StubAgent` lets you replace real agents with predictable canned outputs. Provide a list of responses and the stub will return them sequentially whenever `run()` is called.
 
-When a mocked agent returns the default `Mock` object, the engine will raise:
+```python
+from flujo import Flujo, Step
+from flujo.testing.utils import StubAgent
+
+# Two step pipeline that normally calls real agents
+pipeline = Step("draft", StubAgent(["draft-1", "draft-2"])) >> Step("review", StubAgent(["ok"]))
+
+async def test_pipeline() -> None:
+    runner = Flujo(pipeline)
+    result = await runner.arun("start")
+    assert result.step_history[-1].output == "ok"
+    assert pipeline.steps[0].agent.inputs == ["start"]
+```
+
+Use this pattern to verify branching logic or retry behaviour without making API calls.
+
+## 2. Testing Steps with `DummyPlugin`
+
+`DummyPlugin` simulates validation plugins. Pass a sequence of `PluginOutcome` objects to control whether a step succeeds or fails on each attempt.
+
+```python
+from unittest.mock import MagicMock
+from flujo import Flujo, Step
+from flujo.domain import PluginOutcome
+from flujo.testing.utils import StubAgent, DummyPlugin
+
+plugin = DummyPlugin([
+    PluginOutcome(success=False, feedback="bad input"),
+    PluginOutcome(success=True),
+])
+step = Step("validate", StubAgent(["fixed", "final"]), plugins=[plugin])
+
+async def test_plugin_step() -> None:
+    runner = Flujo(step)
+    result = await runner.arun("data")
+    assert plugin.call_count == 2
+    assert result.step_history[0].output == "final"
+```
+
+## 3. Testing Individual Steps
+
+Use the :meth:`Step.arun` method to execute a single step in isolation. This bypasses pipeline orchestration and is ideal for fast unit tests.
+
+```python
+from flujo import step
+
+@step
+async def uppercase(text: str) -> str:
+    return text.upper()
+
+async def test_uppercase() -> None:
+    result = await uppercase.arun("hi")
+    assert result == "HI"
+```
+
+## 4. Pipelines with a Typed `PipelineContext`
+
+When your pipeline uses a context model, provide `initial_context_data` to the runner and assert the `final_pipeline_context` in your test.
+
+```python
+from pydantic import BaseModel
+from flujo import Flujo, Step, step
+from flujo.testing.utils import StubAgent
+
+class Ctx(BaseModel):
+    counter: int = 0
+
+@step
+async def increment(x: int, *, pipeline_context: Ctx) -> int:
+    pipeline_context.counter += 1
+    return x + 1
+
+pipeline = Step("a", increment) >> Step("b", increment)
+
+async def test_context_flow() -> None:
+    runner = Flujo(pipeline, context_model=Ctx, initial_context_data={"counter": 0})
+    result = await runner.arun(1)
+    assert result.step_history[-1].output == 3
+    assert result.final_pipeline_context.counter == 2
+```
+
+## 5. Steps Requiring `AppResources`
+
+Agents and plugins can declare a `resources` dependency. Pass mock resources to the runner and verify interactions.
+
+```python
+from unittest.mock import MagicMock
+from flujo import Flujo, Step, AppResources
+
+class MyResources(AppResources):
+    db: MagicMock
+
+class LookupAgent:
+    async def run(self, user_id: int, *, resources: MyResources) -> str:
+        return resources.db.get_user(user_id)
+
+async def test_with_resources() -> None:
+    resources = MyResources(db=MagicMock())
+    resources.db.get_user.return_value = "Alice"
+    runner = Flujo(Step("lookup", LookupAgent()), resources=resources)
+    result = await runner.arun(1)
+    resources.db.get_user.assert_called_once_with(1)
+    assert result.step_history[0].output == "Alice"
+```
+
+## 6. Common Pitfalls
+
+If a mocked agent returns the default `Mock` object, the engine raises:
 
 ```text
-TypeError: Step 'my_step' returned a Mock object. This is usually due to an unconfigured mock in a test. Please configure your mock agent to return a concrete value.
+TypeError: Step 'my_step' returned a Mock object. This is usually due to an unconfigured mock in a test.
 ```
 
-Configure your mock to return a value:
-
-```python
-from unittest.mock import AsyncMock
-
-my_agent = AsyncMock()
-my_agent.run.return_value = "expected"
-```
-
-## Testing Individual Steps
-
-Use the :meth:`Step.arun` method to exercise a single step in isolation. This
-executes the step's underlying agent without any orchestration logic.
-
-```python
-from my_app.steps import process_data_step  # a @step decorated object
-import asyncio
-
-async def test_process_data_step() -> None:
-    input_data = "some raw data"
-    expected_output = "SOME RAW DATA"
-
-    result = await process_data_step.arun(input_data)
-
-    assert result == expected_output
-```
+Always set a return value on your mocks. See the [Troubleshooting Guide](troubleshooting.md) for more details.


### PR DESCRIPTION
## Summary
- extend testing guide with StubAgent and DummyPlugin examples
- mention the new guide in README and CONTRIBUTING

## Testing
- `make quality`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c889319cc832cbb7044f79dab07e3