### PR TITLE
Fix runner configuration example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,8 +146,6 @@ pipeline = (
 # Configure the pipeline runner
 runner = Flujo(
     pipeline,
-    max_parallel=2,  # Maximum parallel executions
-    timeout=60,      # Overall timeout
     retry_on_error=True
 )
 ```


### PR DESCRIPTION
## Summary
- update runner config example in docs to remove invalid params

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ca789f2e4832c97ec01156874cf3e