### PR TITLE
Add release notes for 0.4.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.22] - 2025-06-23
+
+### Added
+- Distributed `py.typed` for PEP 561 type hint compatibility.
+
+### Fixed
+- Improved CI/CD workflows to gracefully handle Git tag conflicts.
+
 ## [0.4.18] - 2024-12-19
 
 ### Fixed


### PR DESCRIPTION
## Summary
- document version 0.4.22 changes in CHANGELOG

## Testing
- `make test` *(fails: hatch: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ca768edf0832c80da60364ed19f93