### PR TITLE
Improve run() behavior in async contexts

### DIFF
--- a/tests/integration/test_async_runner_detection.py
+++ b/tests/integration/test_async_runner_detection.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step
+from flujo.testing.utils import StubAgent, gather_result
+
+pipeline = Step("test_step", StubAgent(["OK"]))
+
+
+def test_run_succeeds_in_synchronous_context():
+    runner = Flujo(pipeline)
+    result = runner.run("sync input")
+    assert result.step_history[0].success
+    assert result.step_history[0].output == "OK"
+
+
+@pytest.mark.asyncio
+async def test_run_raises_type_error_in_asynchronous_context():
+    runner = Flujo(pipeline)
+    with pytest.raises(TypeError, match="Flujo.run\(\) cannot be called"):
+        runner.run("async input")
+
+
+@pytest.mark.asyncio
+async def test_run_async_is_unaffected_and_works_correctly():
+    runner = Flujo(pipeline)
+    result = await gather_result(runner, "async input")
+    assert result.step_history[0].success
+    assert result.step_history[0].output == "OK"
+
+
+def test_run_in_simulated_jupyter_environment():
+    runner = Flujo(pipeline)
+
+    async def jupyter_cell_execution():
+        with pytest.raises(TypeError, match="Flujo.run\(\) cannot be called"):
+            runner.run("jupyter input")
+
+    asyncio.run(jupyter_cell_execution())


### PR DESCRIPTION
## Summary
- add defensive check for running event loop in `Flujo.run`
- expand docs for `run_async` and `run`
- add integration tests covering synchronous vs asynchronous usage

## Testing
- `make quality`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d92852970832c9b494bde828d8f7c