### PR TITLE
Add Step.from_mapper helper

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -83,6 +83,13 @@ custom_pipeline = (
 # The `processors` argument lets you run custom pre- and post-processing
 # logic for a step. See [Using Processors](cookbook/using_processors.md).
 
+# You can also build steps from async functions using
+# `Step.from_mapper` or the `mapper` alias:
+async def to_upper(text: str) -> str:
+    return text.upper()
+
+upper_step = Step.from_mapper(to_upper)
+
 runner = Flujo(custom_pipeline)
 # With a shared typed context
 runner_with_ctx = Flujo(

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -17,6 +17,7 @@ from .domain.models import Task, Candidate, Checklist, ChecklistItem
 from .domain import (
     Step,
     step,
+    mapper,
     Pipeline,
     StepConfig,
     MapStep,
@@ -74,6 +75,7 @@ __all__ = [
     "ChecklistItem",
     "Step",
     "step",
+    "mapper",
     "Pipeline",
     "StepConfig",
     "MapStep",

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -10,6 +10,7 @@ from .pipeline_dsl import (
     ConditionalStep,
     BranchKey,
     step,
+    mapper,
 )
 from .plugins import PluginOutcome, ValidationPlugin
 from .validation import Validator, ValidationResult
@@ -21,6 +22,7 @@ from .backends import ExecutionBackend, StepExecutionRequest
 __all__ = [
     "Step",
     "step",
+    "mapper",
     "Pipeline",
     "StepConfig",
     "LoopStep",

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -330,6 +330,33 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
         return step
 
     @classmethod
+    def from_mapper(
+        cls: type["Step[StepInT, StepOutT]"],
+        mapper: Callable[Concatenate[StepInT, P], Coroutine[Any, Any, StepOutT]],
+        name: str | None = None,
+        updates_context: bool = False,
+        processors: Optional[AgentProcessors] = None,
+        persist_feedback_to_context: Optional[str] = None,
+        persist_validation_results_to: Optional[str] = None,
+        **config: Any,
+    ) -> "Step[StepInT, StepOutT]":
+        """Create a :class:`Step` from an async mapper function.
+
+        This is a thin wrapper around :meth:`from_callable` for semantic
+        clarity when the callable merely maps its input to a new value.
+        """
+
+        return cls.from_callable(
+            mapper,
+            name=name,
+            updates_context=updates_context,
+            processors=processors,
+            persist_feedback_to_context=persist_feedback_to_context,
+            persist_validation_results_to=persist_validation_results_to,
+            **config,
+        )
+
+    @classmethod
     def human_in_the_loop(
         cls,
         name: str,
@@ -484,6 +511,10 @@ def step(
         return decorator(func)
 
     return decorator
+
+
+# Convenience alias to create mapping steps
+mapper = Step.from_mapper
 
 
 class HumanInTheLoopStep(Step[Any, Any]):
@@ -802,6 +833,7 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
 __all__ = [
     "Step",
     "step",
+    "mapper",
     "Pipeline",
     "StepConfig",
     "LoopStep",

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -159,6 +159,16 @@ async def test_step_from_callable_untyped_defaults_any() -> None:
 
 
 @pytest.mark.asyncio
+async def test_step_from_mapper_basic() -> None:
+    async def double(x: int) -> int:
+        return x * 2
+
+    step = Step.from_mapper(double)
+    assert isinstance(step, Step)
+    assert await step.arun(3) == 6
+
+
+@pytest.mark.asyncio
 async def test_step_decorator_basic() -> None:
     @step
     async def echo(x: str) -> int:


### PR DESCRIPTION
## Summary
- add Step.from_mapper classmethod
- export mapper alias and update __all__
- document helper in API reference
- test Step.from_mapper

## Testing
- `make test`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_685e02dd0a18832cb47ac46b95f280a4