### PR TITLE
Improve tracing spans and tracer depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.23] - 2025-06-27
+
+### Fixed
+- Loop iteration spans now wrap each iteration, eliminating redundant spans
+- Conditional branch spans record the executed branch key for clarity
+- Console tracer tracks nesting depth, indenting start/end messages accordingly
+
 ## [0.4.22] - 2025-06-23
 
 ### Added

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -78,7 +78,9 @@ class InfiniteRedirectError(OrchestratorError):
     """Raised when a redirect loop is detected."""
 
 
-_accepts_param_cache_weak: "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]" = weakref.WeakKeyDictionary()
+_accepts_param_cache_weak: (
+    "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]"
+) = weakref.WeakKeyDictionary()
 _accepts_param_cache_id: weakref.WeakValueDictionary[int, Dict[str, Optional[bool]]] = (
     weakref.WeakValueDictionary()
 )
@@ -101,7 +103,9 @@ def _accepts_param(func: Callable[..., Any], param: str) -> Optional[bool]:
         sig = inspect.signature(func)
         if param in sig.parameters:
             result = True
-        elif any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        elif any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        ):
             result = True
         else:
             result = False
@@ -145,7 +149,9 @@ async def _execute_loop_step_logic(
                 f"Error in initial_input_to_loop_body_mapper for LoopStep '{loop_step.name}': {e}"
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = f"Initial input mapper raised an exception: {e}"
+            loop_overall_result.feedback = (
+                f"Initial input mapper raised an exception: {e}"
+            )
             return loop_overall_result
     else:
         current_body_input = loop_step_initial_input
@@ -156,15 +162,15 @@ async def _execute_loop_step_logic(
 
     for i in range(1, loop_step.max_loops + 1):
         loop_overall_result.attempts = i
-        logfire.info(f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}")
+        logfire.info(
+            f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}"
+        )
 
         iteration_succeeded_fully = True
         current_iteration_data_for_body_step = current_body_input
 
-        for body_s in loop_step.loop_body_pipeline.steps:
-            with logfire.span(
-                f"LoopStep '{loop_step.name}' Iteration {i} - Body Step '{body_s.name}'"
-            ):
+        with logfire.span(f"Loop '{loop_step.name}' - Iteration {i}"):
+            for body_s in loop_step.loop_body_pipeline.steps:
                 body_step_result_obj = await step_executor(
                     body_s,
                     current_iteration_data_for_body_step,
@@ -172,57 +178,65 @@ async def _execute_loop_step_logic(
                     resources,
                 )
 
-            loop_overall_result.latency_s += body_step_result_obj.latency_s
-            loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)
-            loop_overall_result.token_counts += getattr(body_step_result_obj, "token_counts", 0)
-
-            if usage_limits is not None:
-                if (
-                    usage_limits.total_cost_usd_limit is not None
-                    and loop_overall_result.cost_usd > usage_limits.total_cost_usd_limit
-                ):
-                    logfire.warn(f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded")
-                    loop_overall_result.success = False
-                    loop_overall_result.feedback = (
-                        f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
-                    )
-                    pr: PipelineResult[ContextT] = PipelineResult(
-                        step_history=[loop_overall_result],
-                        total_cost_usd=loop_overall_result.cost_usd,
-                    )
-                    Flujo._set_final_context(pr, pipeline_context)
-                    raise UsageLimitExceededError(
-                        loop_overall_result.feedback,
-                        pr,
-                    )
-                if (
-                    usage_limits.total_tokens_limit is not None
-                    and loop_overall_result.token_counts > usage_limits.total_tokens_limit
-                ):
-                    logfire.warn(f"Token limit of {usage_limits.total_tokens_limit} exceeded")
-                    loop_overall_result.success = False
-                    loop_overall_result.feedback = (
-                        f"Token limit of {usage_limits.total_tokens_limit} exceeded"
-                    )
-                    pr_tokens: PipelineResult[ContextT] = PipelineResult(
-                        step_history=[loop_overall_result],
-                        total_cost_usd=loop_overall_result.cost_usd,
-                    )
-                    Flujo._set_final_context(pr_tokens, pipeline_context)
-                    raise UsageLimitExceededError(
-                        loop_overall_result.feedback,
-                        pr_tokens,
-                    )
-
-            if not body_step_result_obj.success:
-                logfire.warn(
-                    f"Body Step '{body_s.name}' in LoopStep '{loop_step.name}' (Iteration {i}) failed."
+                loop_overall_result.latency_s += body_step_result_obj.latency_s
+                loop_overall_result.cost_usd += getattr(
+                    body_step_result_obj, "cost_usd", 0.0
                 )
-                iteration_succeeded_fully = False
-                final_body_output_of_last_iteration = body_step_result_obj.output
-                break
+                loop_overall_result.token_counts += getattr(
+                    body_step_result_obj, "token_counts", 0
+                )
 
-            current_iteration_data_for_body_step = body_step_result_obj.output
+                if usage_limits is not None:
+                    if (
+                        usage_limits.total_cost_usd_limit is not None
+                        and loop_overall_result.cost_usd
+                        > usage_limits.total_cost_usd_limit
+                    ):
+                        logfire.warn(
+                            f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+                        )
+                        loop_overall_result.success = False
+                        loop_overall_result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+                        pr: PipelineResult[ContextT] = PipelineResult(
+                            step_history=[loop_overall_result],
+                            total_cost_usd=loop_overall_result.cost_usd,
+                        )
+                        Flujo._set_final_context(pr, pipeline_context)
+                        raise UsageLimitExceededError(
+                            loop_overall_result.feedback,
+                            pr,
+                        )
+                    if (
+                        usage_limits.total_tokens_limit is not None
+                        and loop_overall_result.token_counts
+                        > usage_limits.total_tokens_limit
+                    ):
+                        logfire.warn(
+                            f"Token limit of {usage_limits.total_tokens_limit} exceeded"
+                        )
+                        loop_overall_result.success = False
+                        loop_overall_result.feedback = (
+                            f"Token limit of {usage_limits.total_tokens_limit} exceeded"
+                        )
+                        pr_tokens: PipelineResult[ContextT] = PipelineResult(
+                            step_history=[loop_overall_result],
+                            total_cost_usd=loop_overall_result.cost_usd,
+                        )
+                        Flujo._set_final_context(pr_tokens, pipeline_context)
+                        raise UsageLimitExceededError(
+                            loop_overall_result.feedback,
+                            pr_tokens,
+                        )
+
+                if not body_step_result_obj.success:
+                    logfire.warn(
+                        f"Body Step '{body_s.name}' in LoopStep '{loop_step.name}' (Iteration {i}) failed."
+                    )
+                    iteration_succeeded_fully = False
+                    final_body_output_of_last_iteration = body_step_result_obj.output
+                    break
+
+                current_iteration_data_for_body_step = body_step_result_obj.output
 
         if iteration_succeeded_fully:
             last_successful_iteration_body_output = current_iteration_data_for_body_step
@@ -233,13 +247,19 @@ async def _execute_loop_step_logic(
                 final_body_output_of_last_iteration, pipeline_context
             )
         except Exception as e:
-            logfire.error(f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}")
+            logfire.error(
+                f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}"
+            )
             loop_overall_result.success = False
-            loop_overall_result.feedback = f"Exit condition callable raised an exception: {e}"
+            loop_overall_result.feedback = (
+                f"Exit condition callable raised an exception: {e}"
+            )
             break
 
         if should_exit:
-            logfire.info(f"LoopStep '{loop_step.name}' exit condition met at iteration {i}.")
+            logfire.info(
+                f"LoopStep '{loop_step.name}' exit condition met at iteration {i}."
+            )
             loop_overall_result.success = iteration_succeeded_fully
             if not iteration_succeeded_fully:
                 loop_overall_result.feedback = (
@@ -281,18 +301,20 @@ async def _execute_loop_step_logic(
                     last_successful_iteration_body_output, pipeline_context
                 )
             except Exception as e:
-                logfire.error(f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}")
+                logfire.error(
+                    f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}"
+                )
                 loop_overall_result.success = False
-                loop_overall_result.feedback = f"Loop output mapper raised an exception: {e}"
+                loop_overall_result.feedback = (
+                    f"Loop output mapper raised an exception: {e}"
+                )
                 loop_overall_result.output = None
         else:
             loop_overall_result.output = last_successful_iteration_body_output
     else:
         loop_overall_result.output = final_body_output_of_last_iteration
         if not loop_overall_result.feedback:
-            loop_overall_result.feedback = (
-                "Loop did not complete successfully or exit condition not met positively."
-            )
+            loop_overall_result.feedback = "Loop did not complete successfully or exit condition not met positively."
 
     return loop_overall_result
 
@@ -331,7 +353,9 @@ async def _execute_conditional_step_logic(
                 conditional_overall_result.success = False
                 conditional_overall_result.feedback = err_msg
                 return conditional_overall_result
-            logfire.info(f"ConditionalStep '{conditional_step.name}': Executing default branch.")
+            logfire.info(
+                f"ConditionalStep '{conditional_step.name}': Executing default branch."
+            )
         else:
             logfire.info(
                 f"ConditionalStep '{conditional_step.name}': Executing branch for key '{branch_key_to_execute}'."
@@ -350,7 +374,14 @@ async def _execute_conditional_step_logic(
         for branch_s in selected_branch_pipeline.steps:
             with logfire.span(
                 f"ConditionalStep '{conditional_step.name}' Branch '{branch_key_to_execute}' - Step '{branch_s.name}'"
-            ):
+            ) as span:
+                if executed_branch_key is not None:
+                    try:
+                        span.set_attribute(
+                            "executed_branch_key", str(executed_branch_key)
+                        )
+                    except Exception as e:  # pragma: no cover - defensive
+                        logfire.error(f"Error setting span attribute: {e}")
                 branch_step_result_obj = await step_executor(
                     branch_s,
                     current_branch_data,
@@ -359,7 +390,9 @@ async def _execute_conditional_step_logic(
                 )
 
             conditional_overall_result.latency_s += branch_step_result_obj.latency_s
-            conditional_overall_result.cost_usd += getattr(branch_step_result_obj, "cost_usd", 0.0)
+            conditional_overall_result.cost_usd += getattr(
+                branch_step_result_obj, "cost_usd", 0.0
+            )
             conditional_overall_result.token_counts += getattr(
                 branch_step_result_obj, "token_counts", 0
             )
@@ -385,15 +418,19 @@ async def _execute_conditional_step_logic(
             exc_info=True,
         )
         conditional_overall_result.success = False
-        conditional_overall_result.feedback = f"Error executing conditional logic or branch: {e}"
+        conditional_overall_result.feedback = (
+            f"Error executing conditional logic or branch: {e}"
+        )
         return conditional_overall_result
 
     conditional_overall_result.success = branch_succeeded
     if branch_succeeded:
         if conditional_step.branch_output_mapper:
             try:
-                conditional_overall_result.output = conditional_step.branch_output_mapper(
-                    branch_output, executed_branch_key, pipeline_context
+                conditional_overall_result.output = (
+                    conditional_step.branch_output_mapper(
+                        branch_output, executed_branch_key, pipeline_context
+                    )
                 )
             except Exception as e:
                 logfire.error(
@@ -411,8 +448,12 @@ async def _execute_conditional_step_logic(
 
     conditional_overall_result.attempts = 1
     if executed_branch_key is not None:
-        conditional_overall_result.metadata_ = conditional_overall_result.metadata_ or {}
-        conditional_overall_result.metadata_["executed_branch_key"] = str(executed_branch_key)
+        conditional_overall_result.metadata_ = (
+            conditional_overall_result.metadata_ or {}
+        )
+        conditional_overall_result.metadata_["executed_branch_key"] = str(
+            executed_branch_key
+        )
 
     return conditional_overall_result
 
@@ -434,7 +475,9 @@ async def _execute_parallel_step_logic(
     branch_results: Dict[str, StepResult] = {}
 
     async def run_branch(key: str, branch_pipe: Pipeline[Any, Any]) -> None:
-        ctx_copy = copy.deepcopy(pipeline_context) if pipeline_context is not None else None
+        ctx_copy = (
+            copy.deepcopy(pipeline_context) if pipeline_context is not None else None
+        )
         current = parallel_input
         branch_res = StepResult(name=f"{parallel_step.name}:{key}")
         for s in branch_pipe.steps:
@@ -464,7 +507,9 @@ async def _execute_parallel_step_logic(
         result.cost_usd += br.cost_usd
         result.token_counts += br.token_counts
         if not br.success and result.feedback is None:
-            result.feedback = f"Branch failed: {br.feedback}" if br.feedback else "Branch failed"
+            result.feedback = (
+                f"Branch failed: {br.feedback}" if br.feedback else "Branch failed"
+            )
 
     result.success = all(br.success for br in branch_results.values())
 
@@ -474,7 +519,9 @@ async def _execute_parallel_step_logic(
             and result.cost_usd > usage_limits.total_cost_usd_limit
         ):
             result.success = False
-            result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+            result.feedback = (
+                f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+            )
             pr_cost: PipelineResult[ContextT] = PipelineResult(
                 step_history=[result],
                 total_cost_usd=result.cost_usd,
@@ -486,7 +533,9 @@ async def _execute_parallel_step_logic(
             and result.token_counts > usage_limits.total_tokens_limit
         ):
             result.success = False
-            result.feedback = f"Token limit of {usage_limits.total_tokens_limit} exceeded"
+            result.feedback = (
+                f"Token limit of {usage_limits.total_tokens_limit} exceeded"
+            )
             pr_tokens: PipelineResult[ContextT] = PipelineResult(
                 step_history=[result],
                 total_cost_usd=result.cost_usd,
@@ -542,7 +591,9 @@ async def _run_step_logic(
             usage_limits=usage_limits,
         )
     if isinstance(step, HumanInTheLoopStep):
-        message = step.message_for_user if step.message_for_user is not None else str(data)
+        message = (
+            step.message_for_user if step.message_for_user is not None else str(data)
+        )
         if isinstance(pipeline_context, PipelineContext):
             pipeline_context.scratchpad["status"] = "paused"
         raise PausedException(message)
@@ -598,7 +649,9 @@ async def _run_step_logic(
                         DeprecationWarning,
                         stacklevel=2,
                     )
-                elif any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+                elif any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                ):
                     # Fallback for agents with **kwargs but no explicit context parameter.
                     # Pass as 'context' for best-effort compatibility.
                     agent_kwargs["context"] = pipeline_context
@@ -607,7 +660,9 @@ async def _run_step_logic(
         if resources is not None:
             if _accepts_param(current_agent.run, "resources"):
                 agent_kwargs["resources"] = resources
-        if step.config.temperature is not None and _accepts_param(current_agent.run, "temperature"):
+        if step.config.temperature is not None and _accepts_param(
+            current_agent.run, "temperature"
+        ):
             agent_kwargs["temperature"] = step.config.temperature
         raw_output = await current_agent.run(data, **agent_kwargs)
         result.latency_s += time.monotonic() - start
@@ -700,7 +755,9 @@ async def _run_step_logic(
                 for validator in step.validators
             ]
             try:
-                validation_results = await asyncio.gather(*validation_tasks, return_exceptions=True)
+                validation_results = await asyncio.gather(
+                    *validation_tasks, return_exceptions=True
+                )
             except Exception as e:  # pragma: no cover - defensive
                 validation_results = [e]
 
@@ -709,7 +766,9 @@ async def _run_step_logic(
             for validator, res in zip(step.validators, validation_results):
                 if isinstance(res, Exception):
                     vname = getattr(
-                        validator, "name", getattr(validator, "__class__", type(validator)).__name__
+                        validator,
+                        "name",
+                        getattr(validator, "__class__", type(validator)).__name__,
                     )
                     failed_checks_feedback.append(f"Validator '{vname}' crashed: {res}")
                     continue
@@ -717,11 +776,15 @@ async def _run_step_logic(
                 collected_results.append(vres)
                 if not vres.is_valid:
                     fb = vres.feedback or "No details provided."
-                    failed_checks_feedback.append(f"Check '{vres.validator_name}' failed: {fb}")
+                    failed_checks_feedback.append(
+                        f"Check '{vres.validator_name}' failed: {fb}"
+                    )
 
             if step.persist_validation_results_to and pipeline_context is not None:
                 if hasattr(pipeline_context, step.persist_validation_results_to):
-                    history_list = getattr(pipeline_context, step.persist_validation_results_to)
+                    history_list = getattr(
+                        pipeline_context, step.persist_validation_results_to
+                    )
                     if isinstance(history_list, list):
                         history_list.extend(collected_results)
 
@@ -746,7 +809,9 @@ async def _run_step_logic(
         if redirect_to:
             if hasattr(redirect_to, "__hash__") and redirect_to.__hash__ is not None:
                 if redirect_to in visited:
-                    raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
+                    raise InfiniteRedirectError(
+                        f"Redirect loop detected in step {step.name}"
+                    )
                 visited.add(redirect_to)
             current_agent = redirect_to
         else:
@@ -763,10 +828,14 @@ async def _run_step_logic(
     result.success = False
     result.feedback = last_feedback
     result.token_counts += (
-        getattr(last_raw_output, "token_counts", 1) if last_raw_output is not None else 0
+        getattr(last_raw_output, "token_counts", 1)
+        if last_raw_output is not None
+        else 0
     )
     result.cost_usd += (
-        getattr(last_raw_output, "cost_usd", 0.0) if last_raw_output is not None else 0.0
+        getattr(last_raw_output, "cost_usd", 0.0)
+        if last_raw_output is not None
+        else 0.0
     )
     if not result.success and step.persist_feedback_to_context:
         if pipeline_context is not None and hasattr(
@@ -839,7 +908,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         if ann is not inspect.Signature.empty:
                             origin = get_origin(ann)
                             if origin is Union:
-                                if not any(isinstance(payload, t) for t in get_args(ann)):
+                                if not any(
+                                    isinstance(payload, t) for t in get_args(ann)
+                                ):
                                     should_call = False
                             elif isinstance(ann, type):
                                 if not isinstance(payload, ann):
@@ -890,14 +961,14 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     for key, value in update_data.items():
                         setattr(pipeline_context, key, value)
 
-                    validated = self.context_model.model_validate(pipeline_context.model_dump())
+                    validated = self.context_model.model_validate(
+                        pipeline_context.model_dump()
+                    )
                     pipeline_context.__dict__.update(validated.__dict__)
                 except ValidationError as e:
                     for key, value in original_data.items():
                         setattr(pipeline_context, key, value)
-                    error_msg = (
-                        f"Context update by step '{step.name}' failed Pydantic validation: {e}"
-                    )
+                    error_msg = f"Context update by step '{step.name}' failed Pydantic validation: {e}"
                     logfire.error(error_msg)
                     result.success = False
                     result.feedback = error_msg
@@ -928,7 +999,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 except Exception as e:
                     # Defensive: log and ignore errors setting span attributes
                     logfire.error(f"Error setting span attribute: {e}")
-                logfire.warn(f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded")
+                logfire.warn(
+                    f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded"
+                )
                 raise UsageLimitExceededError(
                     f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded",
                     pipeline_result,
@@ -944,14 +1017,18 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 except Exception as e:
                     # Defensive: log and ignore errors setting span attributes
                     logfire.error(f"Error setting span attribute: {e}")
-                logfire.warn(f"Token limit of {self.usage_limits.total_tokens_limit} exceeded")
+                logfire.warn(
+                    f"Token limit of {self.usage_limits.total_tokens_limit} exceeded"
+                )
                 raise UsageLimitExceededError(
                     f"Token limit of {self.usage_limits.total_tokens_limit} exceeded",
                     pipeline_result,
                 )
 
     @staticmethod
-    def _set_final_context(result: PipelineResult[ContextT], ctx: Optional[ContextT]) -> None:
+    def _set_final_context(
+        result: PipelineResult[ContextT], ctx: Optional[ContextT]
+    ) -> None:
         if ctx is not None:
             result.final_pipeline_context = ctx
 
@@ -1013,13 +1090,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 with logfire.span(step.name) as span:
                     try:
                         is_last = idx == len(self.pipeline.steps) - 1
-                        if is_last and step.agent is not None and hasattr(step.agent, "stream"):
+                        if (
+                            is_last
+                            and step.agent is not None
+                            and hasattr(step.agent, "stream")
+                        ):
                             agent_kwargs: Dict[str, Any] = {}
                             target = getattr(step.agent, "_agent", step.agent)
-                            if current_pipeline_context_instance is not None and _accepts_param(
-                                target.stream, "pipeline_context"
+                            if (
+                                current_pipeline_context_instance is not None
+                                and _accepts_param(target.stream, "pipeline_context")
                             ):
-                                agent_kwargs["pipeline_context"] = current_pipeline_context_instance
+                                agent_kwargs["pipeline_context"] = (
+                                    current_pipeline_context_instance
+                                )
                             if self.resources is not None and _accepts_param(
                                 target.stream, "resources"
                             ):
@@ -1031,7 +1115,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                             chunks: list[Any] = []
                             start = time.monotonic()
                             try:
-                                async for chunk in step.agent.stream(data, **agent_kwargs):
+                                async for chunk in step.agent.stream(
+                                    data, **agent_kwargs
+                                ):
                                     chunks.append(chunk)
                                     yield chunk
                                 latency = time.monotonic() - start
@@ -1066,19 +1152,28 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                             step_result = await self._run_step(
                                 step,
                                 data,
-                                pipeline_context=current_pipeline_context_instance,
+                                pipeline_context=cast(
+                                    Optional[ContextT],
+                                    current_pipeline_context_instance,
+                                ),
                                 resources=self.resources,
                             )
                     except PausedException as e:
-                        if isinstance(current_pipeline_context_instance, PipelineContext):
-                            current_pipeline_context_instance.scratchpad["status"] = "paused"
-                            current_pipeline_context_instance.scratchpad["pause_message"] = str(e)
+                        if isinstance(
+                            current_pipeline_context_instance, PipelineContext
+                        ):
+                            current_pipeline_context_instance.scratchpad["status"] = (
+                                "paused"
+                            )
+                            current_pipeline_context_instance.scratchpad[
+                                "pause_message"
+                            ] = str(e)
                             scratch = current_pipeline_context_instance.scratchpad
                             if "paused_step_input" not in scratch:
                                 scratch["paused_step_input"] = data
                         self._set_final_context(
                             pipeline_result_obj,
-                            current_pipeline_context_instance,
+                            cast(Optional[ContextT], current_pipeline_context_instance),
                         )
                         break
                     if step_result.metadata_:
@@ -1105,7 +1200,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         pipeline_context=current_pipeline_context_instance,
                         resources=self.resources,
                     )
-                    logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
+                    logfire.warn(
+                        f"Step '{step.name}' failed. Halting pipeline execution."
+                    )
                     break
                 step_output: Optional[RunnerInT] = step_result.output
                 data = step_output
@@ -1119,17 +1216,20 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             if current_pipeline_context_instance is not None:
                 self._set_final_context(
                     pipeline_result_obj,
-                    current_pipeline_context_instance,
+                    cast(Optional[ContextT], current_pipeline_context_instance),
                 )
             raise e
         finally:
             if current_pipeline_context_instance is not None:
                 self._set_final_context(
                     pipeline_result_obj,
-                    current_pipeline_context_instance,
+                    cast(Optional[ContextT], current_pipeline_context_instance),
                 )
                 if isinstance(current_pipeline_context_instance, PipelineContext):
-                    if current_pipeline_context_instance.scratchpad.get("status") != "paused":
+                    if (
+                        current_pipeline_context_instance.scratchpad.get("status")
+                        != "paused"
+                    ):
                         status = (
                             "completed"
                             if all(s.success for s in pipeline_result_obj.step_history)
@@ -1155,7 +1255,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         *,
         initial_context_data: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[Any]:
-        async for item in self.run_async(initial_input, initial_context_data=initial_context_data):
+        async for item in self.run_async(
+            initial_input, initial_context_data=initial_context_data
+        ):
             yield item
 
     def run(
@@ -1208,7 +1310,10 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             raise OrchestratorError("No steps remaining to resume")
         paused_step = self.pipeline.steps[start_idx]
 
-        if isinstance(paused_step, HumanInTheLoopStep) and paused_step.input_schema is not None:
+        if (
+            isinstance(paused_step, HumanInTheLoopStep)
+            and paused_step.input_schema is not None
+        ):
             human_input = paused_step.input_schema.model_validate(human_input)
 
         if isinstance(ctx, PipelineContext):
@@ -1256,14 +1361,16 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     step_result = await self._run_step(
                         step,
                         data,
-                        pipeline_context=ctx,
+                        pipeline_context=cast(Optional[ContextT], ctx),
                         resources=self.resources,
                     )
                 except PausedException as e:
                     if isinstance(ctx, PipelineContext):
                         ctx.scratchpad["status"] = "paused"
                         ctx.scratchpad["pause_message"] = str(e)
-                    self._set_final_context(paused_result, ctx)
+                    self._set_final_context(
+                        paused_result, cast(Optional[ContextT], ctx)
+                    )
                     break
                 if step_result.metadata_:
                     for key, value in step_result.metadata_.items():
@@ -1296,9 +1403,11 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         if isinstance(ctx, PipelineContext):
             if ctx.scratchpad.get("status") != "paused":
                 status = (
-                    "completed" if all(s.success for s in paused_result.step_history) else "failed"
+                    "completed"
+                    if all(s.success for s in paused_result.step_history)
+                    else "failed"
                 )
                 ctx.scratchpad["status"] = status
 
-        self._set_final_context(paused_result, ctx)
+        self._set_final_context(paused_result, cast(Optional[ContextT], ctx))
         return paused_result

--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -33,14 +33,19 @@ class ConsoleTracer:
         self.log_inputs = log_inputs
         self.log_outputs = log_outputs
         self.console = (
-            Console(highlight=False) if colorized else Console(no_color=True, highlight=False)
+            Console(highlight=False)
+            if colorized
+            else Console(no_color=True, highlight=False)
         )
+        self._depth = 0
         self.event_handlers: Dict[str, Callable[[HookPayload], Any]] = {
             "pre_run": cast(Callable[[HookPayload], Any], self._handle_pre_run),
             "post_run": cast(Callable[[HookPayload], Any], self._handle_post_run),
             "pre_step": cast(Callable[[HookPayload], Any], self._handle_pre_step),
             "post_step": cast(Callable[[HookPayload], Any], self._handle_post_step),
-            "on_step_failure": cast(Callable[[HookPayload], Any], self._handle_on_step_failure),
+            "on_step_failure": cast(
+                Callable[[HookPayload], Any], self._handle_on_step_failure
+            ),
         }
 
     def _handle_pre_run(self, payload: PreRunPayload) -> None:
@@ -48,6 +53,7 @@ class ConsoleTracer:
         title = "Pipeline Start"
         details = Text(f"Input: {initial_input!r}")
         self.console.print(Panel(details, title=title, border_style="bold blue"))
+        self._depth = 0
 
     def _handle_post_run(self, payload: PostRunPayload) -> None:
         pipeline_result = payload.pipeline_result
@@ -64,16 +70,20 @@ class ConsoleTracer:
     def _handle_pre_step(self, payload: PreStepPayload) -> None:
         step = payload.step
         step_input = payload.step_input
-        title = f"Step Start: {step.name if step else ''}"
+        indent = "  " * self._depth
+        title = f"{indent}Step Start: {step.name if step else ''}"
         if self.level == "debug" and self.log_inputs:
             body = Text(repr(step_input))
         else:
             body = Text("running")
         self.console.print(Panel(body, title=title))
+        self._depth += 1
 
     def _handle_post_step(self, payload: PostStepPayload) -> None:
         step_result = payload.step_result
-        title = f"Step End: {step_result.name}"
+        self._depth = max(0, self._depth - 1)
+        indent = "  " * self._depth
+        title = f"{indent}Step End: {step_result.name}"
         status = "SUCCESS" if step_result.success else "FAILED"
         color = "green" if step_result.success else "red"
         body_text = Text(f"Status: {status}", style=f"bold {color}")
@@ -83,7 +93,9 @@ class ConsoleTracer:
 
     def _handle_on_step_failure(self, payload: OnStepFailurePayload) -> None:
         step_result = payload.step_result
-        title = f"Step Failure: {step_result.name}"
+        self._depth = max(0, self._depth - 1)
+        indent = "  " * self._depth
+        title = f"{indent}Step Failure: {step_result.name}"
         details = Text(
             f"Status: FAILED\nFeedback: {step_result.feedback}",
             style="red",
@@ -100,4 +112,6 @@ class ConsoleTracer:
             else:
                 handler(payload)
         else:
-            self.console.print(Panel(Text(str(payload.event_name)), title="Unknown tracer event"))
+            self.console.print(
+                Panel(Text(str(payload.event_name)), title="Unknown tracer event")
+            )

--- a/tests/integration/test_console_tracer_depth.py
+++ b/tests/integration/test_console_tracer_depth.py
@@ -1,0 +1,64 @@
+import pytest
+from flujo.tracing import ConsoleTracer
+from flujo.domain.events import PreStepPayload, PostStepPayload, OnStepFailurePayload
+from flujo.domain.pipeline_dsl import Step
+from flujo.domain.models import StepResult
+
+
+@pytest.mark.asyncio
+async def test_console_tracer_indentation(monkeypatch):
+    tracer = ConsoleTracer(level="info", colorized=False)
+    titles: list[str] = []
+    monkeypatch.setattr(
+        tracer.console, "print", lambda panel: titles.append(panel.title)
+    )
+
+    outer_step = Step("outer")
+    inner_step = Step("inner")
+
+    await tracer.hook(
+        PreStepPayload(event_name="pre_step", step=outer_step, step_input=None)
+    )
+    await tracer.hook(
+        PreStepPayload(event_name="pre_step", step=inner_step, step_input=None)
+    )
+    await tracer.hook(
+        PostStepPayload(event_name="post_step", step_result=StepResult(name="inner"))
+    )
+    await tracer.hook(
+        PostStepPayload(event_name="post_step", step_result=StepResult(name="outer"))
+    )
+
+    assert titles[0] == "Step Start: outer"
+    assert titles[1].startswith("  Step Start: inner")
+    assert titles[2].startswith("  Step End: inner")
+    assert titles[3] == "Step End: outer"
+
+
+@pytest.mark.asyncio
+async def test_console_tracer_indentation_reset_on_failure(monkeypatch):
+    tracer = ConsoleTracer(level="info", colorized=False)
+    titles: list[str] = []
+    monkeypatch.setattr(
+        tracer.console, "print", lambda panel: titles.append(panel.title)
+    )
+
+    fail_step = Step("fail")
+    next_step = Step("next")
+
+    await tracer.hook(
+        PreStepPayload(event_name="pre_step", step=fail_step, step_input=None)
+    )
+    await tracer.hook(
+        OnStepFailurePayload(
+            event_name="on_step_failure",
+            step_result=StepResult(name="fail", success=False, feedback="bad"),
+        )
+    )
+    await tracer.hook(
+        PreStepPayload(event_name="pre_step", step=next_step, step_input=None)
+    )
+
+    assert titles[0] == "Step Start: fail"
+    assert titles[1] == "Step Failure: fail"
+    assert titles[2] == "Step Start: next"

--- a/tests/integration/test_loop_step_execution.py
+++ b/tests/integration/test_loop_step_execution.py
@@ -402,8 +402,8 @@ async def test_loop_step_iteration_spans_and_logging(monkeypatch) -> None:
     assert "LoopStep 'loop_log': Starting Iteration 1/2" in infos
     assert "LoopStep 'loop_log': Starting Iteration 2/2" in infos
     assert "LoopStep 'loop_log' exit condition met at iteration 2." in infos
-    assert "LoopStep 'loop_log' Iteration 1 - Body Step 'inc'" in spans
-    assert "LoopStep 'loop_log' Iteration 2 - Body Step 'inc'" in spans
+    assert spans.count("Loop 'loop_log' - Iteration 1") == 1
+    assert spans.count("Loop 'loop_log' - Iteration 2") == 1
     assert not warns
 
 
@@ -450,4 +450,7 @@ async def test_loop_step_error_logging_in_callables(monkeypatch) -> None:
     )
     runner = Flujo(loop, context_model=Ctx)
     await gather_result(runner, 0)
-    assert any("Error in iteration_input_mapper for LoopStep 'loop_err_log'" in m for m in errors)
+    assert any(
+        "Error in iteration_input_mapper for LoopStep 'loop_err_log'" in m
+        for m in errors
+    )


### PR DESCRIPTION
## Summary
- rename loop iteration spans to `Loop '<name>' - Iteration i`
- record executed branch key directly on conditional branch spans
- track depth in `ConsoleTracer` and indent step titles
- add regression tests for span naming and tracer indentation
- ensure only one iteration span per loop
- fix depth decrement on step failure
- document fix in changelog

## Testing
- `pre-commit run ruff --files flujo/tracing.py tests/integration/test_console_tracer_depth.py`
- `pre-commit run black --files flujo/tracing.py tests/integration/test_console_tracer_depth.py`
- `pre-commit run detect-secrets --files flujo/tracing.py tests/integration/test_console_tracer_depth.py`
- `pre-commit run mypy --files tests/mypy_success.py`
- `pytest -q tests/integration/test_console_tracer_depth.py`
- `pytest -q`
- `hatch run cov`

------
https://chatgpt.com/codex/tasks/task_e_685e082ae760832c880fdac6458367cf