### PR TITLE
Implement injection spec

### DIFF
--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -78,9 +78,7 @@ class InfiniteRedirectError(OrchestratorError):
     """Raised when a redirect loop is detected."""
 
 
-_accepts_param_cache_weak: (
-    "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]"
-) = weakref.WeakKeyDictionary()
+_accepts_param_cache_weak: "weakref.WeakKeyDictionary[Callable[..., Any], Dict[str, Optional[bool]]]" = weakref.WeakKeyDictionary()
 _accepts_param_cache_id: weakref.WeakValueDictionary[int, Dict[str, Optional[bool]]] = (
     weakref.WeakValueDictionary()
 )
@@ -103,9 +101,7 @@ def _accepts_param(func: Callable[..., Any], param: str) -> Optional[bool]:
         sig = inspect.signature(func)
         if param in sig.parameters:
             result = True
-        elif any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
-        ):
+        elif any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
             result = True
         else:
             result = False
@@ -149,9 +145,7 @@ async def _execute_loop_step_logic(
                 f"Error in initial_input_to_loop_body_mapper for LoopStep '{loop_step.name}': {e}"
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = (
-                f"Initial input mapper raised an exception: {e}"
-            )
+            loop_overall_result.feedback = f"Initial input mapper raised an exception: {e}"
             return loop_overall_result
     else:
         current_body_input = loop_step_initial_input
@@ -162,9 +156,7 @@ async def _execute_loop_step_logic(
 
     for i in range(1, loop_step.max_loops + 1):
         loop_overall_result.attempts = i
-        logfire.info(
-            f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}"
-        )
+        logfire.info(f"LoopStep '{loop_step.name}': Starting Iteration {i}/{loop_step.max_loops}")
 
         iteration_succeeded_fully = True
         current_iteration_data_for_body_step = current_body_input
@@ -179,24 +171,19 @@ async def _execute_loop_step_logic(
                 )
 
                 loop_overall_result.latency_s += body_step_result_obj.latency_s
-                loop_overall_result.cost_usd += getattr(
-                    body_step_result_obj, "cost_usd", 0.0
-                )
-                loop_overall_result.token_counts += getattr(
-                    body_step_result_obj, "token_counts", 0
-                )
+                loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)
+                loop_overall_result.token_counts += getattr(body_step_result_obj, "token_counts", 0)
 
                 if usage_limits is not None:
                     if (
                         usage_limits.total_cost_usd_limit is not None
-                        and loop_overall_result.cost_usd
-                        > usage_limits.total_cost_usd_limit
+                        and loop_overall_result.cost_usd > usage_limits.total_cost_usd_limit
                     ):
-                        logfire.warn(
+                        logfire.warn(f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded")
+                        loop_overall_result.success = False
+                        loop_overall_result.feedback = (
                             f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
                         )
-                        loop_overall_result.success = False
-                        loop_overall_result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
                         pr: PipelineResult[ContextT] = PipelineResult(
                             step_history=[loop_overall_result],
                             total_cost_usd=loop_overall_result.cost_usd,
@@ -208,12 +195,9 @@ async def _execute_loop_step_logic(
                         )
                     if (
                         usage_limits.total_tokens_limit is not None
-                        and loop_overall_result.token_counts
-                        > usage_limits.total_tokens_limit
+                        and loop_overall_result.token_counts > usage_limits.total_tokens_limit
                     ):
-                        logfire.warn(
-                            f"Token limit of {usage_limits.total_tokens_limit} exceeded"
-                        )
+                        logfire.warn(f"Token limit of {usage_limits.total_tokens_limit} exceeded")
                         loop_overall_result.success = False
                         loop_overall_result.feedback = (
                             f"Token limit of {usage_limits.total_tokens_limit} exceeded"
@@ -247,19 +231,13 @@ async def _execute_loop_step_logic(
                 final_body_output_of_last_iteration, pipeline_context
             )
         except Exception as e:
-            logfire.error(
-                f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}"
-            )
+            logfire.error(f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}")
             loop_overall_result.success = False
-            loop_overall_result.feedback = (
-                f"Exit condition callable raised an exception: {e}"
-            )
+            loop_overall_result.feedback = f"Exit condition callable raised an exception: {e}"
             break
 
         if should_exit:
-            logfire.info(
-                f"LoopStep '{loop_step.name}' exit condition met at iteration {i}."
-            )
+            logfire.info(f"LoopStep '{loop_step.name}' exit condition met at iteration {i}.")
             loop_overall_result.success = iteration_succeeded_fully
             if not iteration_succeeded_fully:
                 loop_overall_result.feedback = (
@@ -301,20 +279,18 @@ async def _execute_loop_step_logic(
                     last_successful_iteration_body_output, pipeline_context
                 )
             except Exception as e:
-                logfire.error(
-                    f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}"
-                )
+                logfire.error(f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}")
                 loop_overall_result.success = False
-                loop_overall_result.feedback = (
-                    f"Loop output mapper raised an exception: {e}"
-                )
+                loop_overall_result.feedback = f"Loop output mapper raised an exception: {e}"
                 loop_overall_result.output = None
         else:
             loop_overall_result.output = last_successful_iteration_body_output
     else:
         loop_overall_result.output = final_body_output_of_last_iteration
         if not loop_overall_result.feedback:
-            loop_overall_result.feedback = "Loop did not complete successfully or exit condition not met positively."
+            loop_overall_result.feedback = (
+                "Loop did not complete successfully or exit condition not met positively."
+            )
 
     return loop_overall_result
 
@@ -353,9 +329,7 @@ async def _execute_conditional_step_logic(
                 conditional_overall_result.success = False
                 conditional_overall_result.feedback = err_msg
                 return conditional_overall_result
-            logfire.info(
-                f"ConditionalStep '{conditional_step.name}': Executing default branch."
-            )
+            logfire.info(f"ConditionalStep '{conditional_step.name}': Executing default branch.")
         else:
             logfire.info(
                 f"ConditionalStep '{conditional_step.name}': Executing branch for key '{branch_key_to_execute}'."
@@ -377,9 +351,7 @@ async def _execute_conditional_step_logic(
             ) as span:
                 if executed_branch_key is not None:
                     try:
-                        span.set_attribute(
-                            "executed_branch_key", str(executed_branch_key)
-                        )
+                        span.set_attribute("executed_branch_key", str(executed_branch_key))
                     except Exception as e:  # pragma: no cover - defensive
                         logfire.error(f"Error setting span attribute: {e}")
                 branch_step_result_obj = await step_executor(
@@ -390,9 +362,7 @@ async def _execute_conditional_step_logic(
                 )
 
             conditional_overall_result.latency_s += branch_step_result_obj.latency_s
-            conditional_overall_result.cost_usd += getattr(
-                branch_step_result_obj, "cost_usd", 0.0
-            )
+            conditional_overall_result.cost_usd += getattr(branch_step_result_obj, "cost_usd", 0.0)
             conditional_overall_result.token_counts += getattr(
                 branch_step_result_obj, "token_counts", 0
             )
@@ -418,19 +388,15 @@ async def _execute_conditional_step_logic(
             exc_info=True,
         )
         conditional_overall_result.success = False
-        conditional_overall_result.feedback = (
-            f"Error executing conditional logic or branch: {e}"
-        )
+        conditional_overall_result.feedback = f"Error executing conditional logic or branch: {e}"
         return conditional_overall_result
 
     conditional_overall_result.success = branch_succeeded
     if branch_succeeded:
         if conditional_step.branch_output_mapper:
             try:
-                conditional_overall_result.output = (
-                    conditional_step.branch_output_mapper(
-                        branch_output, executed_branch_key, pipeline_context
-                    )
+                conditional_overall_result.output = conditional_step.branch_output_mapper(
+                    branch_output, executed_branch_key, pipeline_context
                 )
             except Exception as e:
                 logfire.error(
@@ -448,12 +414,8 @@ async def _execute_conditional_step_logic(
 
     conditional_overall_result.attempts = 1
     if executed_branch_key is not None:
-        conditional_overall_result.metadata_ = (
-            conditional_overall_result.metadata_ or {}
-        )
-        conditional_overall_result.metadata_["executed_branch_key"] = str(
-            executed_branch_key
-        )
+        conditional_overall_result.metadata_ = conditional_overall_result.metadata_ or {}
+        conditional_overall_result.metadata_["executed_branch_key"] = str(executed_branch_key)
 
     return conditional_overall_result
 
@@ -475,9 +437,7 @@ async def _execute_parallel_step_logic(
     branch_results: Dict[str, StepResult] = {}
 
     async def run_branch(key: str, branch_pipe: Pipeline[Any, Any]) -> None:
-        ctx_copy = (
-            copy.deepcopy(pipeline_context) if pipeline_context is not None else None
-        )
+        ctx_copy = copy.deepcopy(pipeline_context) if pipeline_context is not None else None
         current = parallel_input
         branch_res = StepResult(name=f"{parallel_step.name}:{key}")
         for s in branch_pipe.steps:
@@ -507,9 +467,7 @@ async def _execute_parallel_step_logic(
         result.cost_usd += br.cost_usd
         result.token_counts += br.token_counts
         if not br.success and result.feedback is None:
-            result.feedback = (
-                f"Branch failed: {br.feedback}" if br.feedback else "Branch failed"
-            )
+            result.feedback = f"Branch failed: {br.feedback}" if br.feedback else "Branch failed"
 
     result.success = all(br.success for br in branch_results.values())
 
@@ -519,9 +477,7 @@ async def _execute_parallel_step_logic(
             and result.cost_usd > usage_limits.total_cost_usd_limit
         ):
             result.success = False
-            result.feedback = (
-                f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
-            )
+            result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
             pr_cost: PipelineResult[ContextT] = PipelineResult(
                 step_history=[result],
                 total_cost_usd=result.cost_usd,
@@ -533,9 +489,7 @@ async def _execute_parallel_step_logic(
             and result.token_counts > usage_limits.total_tokens_limit
         ):
             result.success = False
-            result.feedback = (
-                f"Token limit of {usage_limits.total_tokens_limit} exceeded"
-            )
+            result.feedback = f"Token limit of {usage_limits.total_tokens_limit} exceeded"
             pr_tokens: PipelineResult[ContextT] = PipelineResult(
                 step_history=[result],
                 total_cost_usd=result.cost_usd,
@@ -591,9 +545,7 @@ async def _run_step_logic(
             usage_limits=usage_limits,
         )
     if isinstance(step, HumanInTheLoopStep):
-        message = (
-            step.message_for_user if step.message_for_user is not None else str(data)
-        )
+        message = step.message_for_user if step.message_for_user is not None else str(data)
         if isinstance(pipeline_context, PipelineContext):
             pipeline_context.scratchpad["status"] = "paused"
         raise PausedException(message)
@@ -623,6 +575,13 @@ async def _run_step_logic(
                 except Exception as e:  # pragma: no cover - defensive
                     logfire.error(f"Processor {proc.name} failed: {e}")
             data = processed
+        from ..signature_tools import analyze_signature
+        from ..deprecation import warn_once
+
+        target = getattr(current_agent, "_agent", current_agent)
+        func = getattr(target, "_step_callable", target.run)
+        spec = analyze_signature(func)
+
         if isinstance(current_agent, ContextAwareAgentProtocol) and getattr(
             current_agent, "__context_aware__", False
         ):
@@ -631,38 +590,22 @@ async def _run_step_logic(
                     f"Agent '{current_agent.__class__.__name__}' requires a pipeline context"
                 )
             agent_kwargs["pipeline_context"] = pipeline_context
-        elif pipeline_context is not None:
-            target = getattr(current_agent, "_agent", current_agent)
-            # The logic below is to handle parameter injection for context.
-            # It prioritizes `context`, then `pipeline_context` to support both new and legacy code.
-            # This is more robust than the previous `_accepts_param` which was too greedy with `**kwargs`.
-            try:
-                sig = inspect.signature(target.run)
-                params = sig.parameters
-                if "context" in params:
-                    agent_kwargs["context"] = pipeline_context
-                elif "pipeline_context" in params:
-                    agent_kwargs["pipeline_context"] = pipeline_context
-                    warnings.warn(
-                        f"Agent '{target.__class__.__name__}' uses the deprecated 'pipeline_context' parameter. "
-                        "Update its signature to use 'context: YourContext' for future compatibility.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                elif any(
-                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-                ):
-                    # Fallback for agents with **kwargs but no explicit context parameter.
-                    # Pass as 'context' for best-effort compatibility.
-                    agent_kwargs["context"] = pipeline_context
-            except (ValueError, TypeError):  # Fails on some built-ins
-                pass  # Fallback to empty kwargs if inspection fails
+        elif pipeline_context is not None and spec.needs_context and spec.context_kw:
+            agent_kwargs[spec.context_kw] = pipeline_context
+            if spec.context_kw == "pipeline_context":
+                warn_once(
+                    f"Agent '{target.__class__.__name__}' uses the deprecated 'pipeline_context' parameter. "
+                    "Update its signature to use 'context: YourContext' for future compatibility.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         if resources is not None:
-            if _accepts_param(current_agent.run, "resources"):
+            if spec.needs_resources:
                 agent_kwargs["resources"] = resources
-        if step.config.temperature is not None and _accepts_param(
-            current_agent.run, "temperature"
-        ):
+            elif _accepts_param(current_agent.run, "resources"):
+                agent_kwargs["resources"] = resources
+        if step.config.temperature is not None and _accepts_param(current_agent.run, "temperature"):
             agent_kwargs["temperature"] = step.config.temperature
         raw_output = await current_agent.run(data, **agent_kwargs)
         result.latency_s += time.monotonic() - start
@@ -698,8 +641,12 @@ async def _run_step_logic(
         sorted_plugins = sorted(step.plugins, key=lambda p: p[1], reverse=True)
         for plugin, _ in sorted_plugins:
             try:
+                from ..signature_tools import analyze_signature
+                from ..deprecation import warn_once
+
                 plugin_kwargs: Dict[str, Any] = {}
-                accepts_resources = _accepts_param(plugin.validate, "resources")
+                func = getattr(plugin, "_plugin_callable", plugin.validate)
+                spec = analyze_signature(func)
 
                 if isinstance(plugin, ContextAwarePluginProtocol) and getattr(
                     plugin, "__context_aware__", False
@@ -709,20 +656,21 @@ async def _run_step_logic(
                             f"Plugin '{plugin.__class__.__name__}' requires a pipeline context"
                         )
                     plugin_kwargs["pipeline_context"] = pipeline_context
-                elif pipeline_context is not None:
-                    # Prioritize 'context', fall back to 'pipeline_context' for compatibility
-                    if _accepts_param(plugin.validate, "context"):
-                        plugin_kwargs["context"] = pipeline_context
-                    elif _accepts_param(plugin.validate, "pipeline_context"):
-                        plugin_kwargs["pipeline_context"] = pipeline_context
-                        warnings.warn(
+                elif pipeline_context is not None and spec.needs_context and spec.context_kw:
+                    plugin_kwargs[spec.context_kw] = pipeline_context
+                    if spec.context_kw == "pipeline_context":
+                        warn_once(
                             f"Plugin '{plugin.__class__.__name__}' uses the deprecated 'pipeline_context' parameter. "
                             "Update its signature to use 'context: YourContext' for future compatibility.",
                             DeprecationWarning,
                             stacklevel=2,
                         )
-                if resources is not None and accepts_resources:
-                    plugin_kwargs["resources"] = resources
+
+                if resources is not None:
+                    if spec.needs_resources:
+                        plugin_kwargs["resources"] = resources
+                    elif _accepts_param(plugin.validate, "resources"):
+                        plugin_kwargs["resources"] = resources
                 validated = await asyncio.wait_for(
                     plugin.validate(
                         {"output": last_unpacked_output, "feedback": last_feedback},
@@ -755,9 +703,7 @@ async def _run_step_logic(
                 for validator in step.validators
             ]
             try:
-                validation_results = await asyncio.gather(
-                    *validation_tasks, return_exceptions=True
-                )
+                validation_results = await asyncio.gather(*validation_tasks, return_exceptions=True)
             except Exception as e:  # pragma: no cover - defensive
                 validation_results = [e]
 
@@ -776,15 +722,11 @@ async def _run_step_logic(
                 collected_results.append(vres)
                 if not vres.is_valid:
                     fb = vres.feedback or "No details provided."
-                    failed_checks_feedback.append(
-                        f"Check '{vres.validator_name}' failed: {fb}"
-                    )
+                    failed_checks_feedback.append(f"Check '{vres.validator_name}' failed: {fb}")
 
             if step.persist_validation_results_to and pipeline_context is not None:
                 if hasattr(pipeline_context, step.persist_validation_results_to):
-                    history_list = getattr(
-                        pipeline_context, step.persist_validation_results_to
-                    )
+                    history_list = getattr(pipeline_context, step.persist_validation_results_to)
                     if isinstance(history_list, list):
                         history_list.extend(collected_results)
 
@@ -809,9 +751,7 @@ async def _run_step_logic(
         if redirect_to:
             if hasattr(redirect_to, "__hash__") and redirect_to.__hash__ is not None:
                 if redirect_to in visited:
-                    raise InfiniteRedirectError(
-                        f"Redirect loop detected in step {step.name}"
-                    )
+                    raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
                 visited.add(redirect_to)
             current_agent = redirect_to
         else:
@@ -828,14 +768,10 @@ async def _run_step_logic(
     result.success = False
     result.feedback = last_feedback
     result.token_counts += (
-        getattr(last_raw_output, "token_counts", 1)
-        if last_raw_output is not None
-        else 0
+        getattr(last_raw_output, "token_counts", 1) if last_raw_output is not None else 0
     )
     result.cost_usd += (
-        getattr(last_raw_output, "cost_usd", 0.0)
-        if last_raw_output is not None
-        else 0.0
+        getattr(last_raw_output, "cost_usd", 0.0) if last_raw_output is not None else 0.0
     )
     if not result.success and step.persist_feedback_to_context:
         if pipeline_context is not None and hasattr(
@@ -908,9 +844,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         if ann is not inspect.Signature.empty:
                             origin = get_origin(ann)
                             if origin is Union:
-                                if not any(
-                                    isinstance(payload, t) for t in get_args(ann)
-                                ):
+                                if not any(isinstance(payload, t) for t in get_args(ann)):
                                     should_call = False
                             elif isinstance(ann, type):
                                 if not isinstance(payload, ann):
@@ -961,14 +895,14 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     for key, value in update_data.items():
                         setattr(pipeline_context, key, value)
 
-                    validated = self.context_model.model_validate(
-                        pipeline_context.model_dump()
-                    )
+                    validated = self.context_model.model_validate(pipeline_context.model_dump())
                     pipeline_context.__dict__.update(validated.__dict__)
                 except ValidationError as e:
                     for key, value in original_data.items():
                         setattr(pipeline_context, key, value)
-                    error_msg = f"Context update by step '{step.name}' failed Pydantic validation: {e}"
+                    error_msg = (
+                        f"Context update by step '{step.name}' failed Pydantic validation: {e}"
+                    )
                     logfire.error(error_msg)
                     result.success = False
                     result.feedback = error_msg
@@ -999,9 +933,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 except Exception as e:
                     # Defensive: log and ignore errors setting span attributes
                     logfire.error(f"Error setting span attribute: {e}")
-                logfire.warn(
-                    f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded"
-                )
+                logfire.warn(f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded")
                 raise UsageLimitExceededError(
                     f"Cost limit of ${self.usage_limits.total_cost_usd_limit} exceeded",
                     pipeline_result,
@@ -1017,18 +949,14 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 except Exception as e:
                     # Defensive: log and ignore errors setting span attributes
                     logfire.error(f"Error setting span attribute: {e}")
-                logfire.warn(
-                    f"Token limit of {self.usage_limits.total_tokens_limit} exceeded"
-                )
+                logfire.warn(f"Token limit of {self.usage_limits.total_tokens_limit} exceeded")
                 raise UsageLimitExceededError(
                     f"Token limit of {self.usage_limits.total_tokens_limit} exceeded",
                     pipeline_result,
                 )
 
     @staticmethod
-    def _set_final_context(
-        result: PipelineResult[ContextT], ctx: Optional[ContextT]
-    ) -> None:
+    def _set_final_context(result: PipelineResult[ContextT], ctx: Optional[ContextT]) -> None:
         if ctx is not None:
             result.final_pipeline_context = ctx
 
@@ -1090,20 +1018,13 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 with logfire.span(step.name) as span:
                     try:
                         is_last = idx == len(self.pipeline.steps) - 1
-                        if (
-                            is_last
-                            and step.agent is not None
-                            and hasattr(step.agent, "stream")
-                        ):
+                        if is_last and step.agent is not None and hasattr(step.agent, "stream"):
                             agent_kwargs: Dict[str, Any] = {}
                             target = getattr(step.agent, "_agent", step.agent)
-                            if (
-                                current_pipeline_context_instance is not None
-                                and _accepts_param(target.stream, "pipeline_context")
+                            if current_pipeline_context_instance is not None and _accepts_param(
+                                target.stream, "pipeline_context"
                             ):
-                                agent_kwargs["pipeline_context"] = (
-                                    current_pipeline_context_instance
-                                )
+                                agent_kwargs["pipeline_context"] = current_pipeline_context_instance
                             if self.resources is not None and _accepts_param(
                                 target.stream, "resources"
                             ):
@@ -1115,9 +1036,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                             chunks: list[Any] = []
                             start = time.monotonic()
                             try:
-                                async for chunk in step.agent.stream(
-                                    data, **agent_kwargs
-                                ):
+                                async for chunk in step.agent.stream(data, **agent_kwargs):
                                     chunks.append(chunk)
                                     yield chunk
                                 latency = time.monotonic() - start
@@ -1159,15 +1078,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                                 resources=self.resources,
                             )
                     except PausedException as e:
-                        if isinstance(
-                            current_pipeline_context_instance, PipelineContext
-                        ):
-                            current_pipeline_context_instance.scratchpad["status"] = (
-                                "paused"
-                            )
-                            current_pipeline_context_instance.scratchpad[
-                                "pause_message"
-                            ] = str(e)
+                        if isinstance(current_pipeline_context_instance, PipelineContext):
+                            current_pipeline_context_instance.scratchpad["status"] = "paused"
+                            current_pipeline_context_instance.scratchpad["pause_message"] = str(e)
                             scratch = current_pipeline_context_instance.scratchpad
                             if "paused_step_input" not in scratch:
                                 scratch["paused_step_input"] = data
@@ -1200,9 +1113,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         pipeline_context=current_pipeline_context_instance,
                         resources=self.resources,
                     )
-                    logfire.warn(
-                        f"Step '{step.name}' failed. Halting pipeline execution."
-                    )
+                    logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
                     break
                 step_output: Optional[RunnerInT] = step_result.output
                 data = step_output
@@ -1226,10 +1137,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     cast(Optional[ContextT], current_pipeline_context_instance),
                 )
                 if isinstance(current_pipeline_context_instance, PipelineContext):
-                    if (
-                        current_pipeline_context_instance.scratchpad.get("status")
-                        != "paused"
-                    ):
+                    if current_pipeline_context_instance.scratchpad.get("status") != "paused":
                         status = (
                             "completed"
                             if all(s.success for s in pipeline_result_obj.step_history)
@@ -1255,9 +1163,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         *,
         initial_context_data: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[Any]:
-        async for item in self.run_async(
-            initial_input, initial_context_data=initial_context_data
-        ):
+        async for item in self.run_async(initial_input, initial_context_data=initial_context_data):
             yield item
 
     def run(
@@ -1310,10 +1216,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             raise OrchestratorError("No steps remaining to resume")
         paused_step = self.pipeline.steps[start_idx]
 
-        if (
-            isinstance(paused_step, HumanInTheLoopStep)
-            and paused_step.input_schema is not None
-        ):
+        if isinstance(paused_step, HumanInTheLoopStep) and paused_step.input_schema is not None:
             human_input = paused_step.input_schema.model_validate(human_input)
 
         if isinstance(ctx, PipelineContext):
@@ -1368,9 +1271,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     if isinstance(ctx, PipelineContext):
                         ctx.scratchpad["status"] = "paused"
                         ctx.scratchpad["pause_message"] = str(e)
-                    self._set_final_context(
-                        paused_result, cast(Optional[ContextT], ctx)
-                    )
+                    self._set_final_context(paused_result, cast(Optional[ContextT], ctx))
                     break
                 if step_result.metadata_:
                     for key, value in step_result.metadata_.items():
@@ -1403,9 +1304,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         if isinstance(ctx, PipelineContext):
             if ctx.scratchpad.get("status") != "paused":
                 status = (
-                    "completed"
-                    if all(s.success for s in paused_result.step_history)
-                    else "failed"
+                    "completed" if all(s.success for s in paused_result.step_history) else "failed"
                 )
                 ctx.scratchpad["status"] = status
 

--- a/flujo/deprecation.py
+++ b/flujo/deprecation.py
@@ -1,0 +1,16 @@
+import inspect
+import warnings
+from typing import Any, Type
+
+_warned_locations: set[tuple[str, int]] = set()
+
+
+def warn_once(
+    message: str, category: Type[Warning] = DeprecationWarning, stacklevel: int = 2
+) -> None:
+    frame = inspect.stack()[stacklevel]
+    loc = (frame.filename, frame.lineno)
+    if loc in _warned_locations:
+        return
+    _warned_locations.add(loc)
+    warnings.warn(message, category, stacklevel=stacklevel)

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -276,43 +276,18 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
 
         step_name = name or getattr(func, "__name__", func.__class__.__name__)
 
+        from ..signature_tools import analyze_signature
+
+        spec = analyze_signature(func)
+
         class _CallableAgent:
+            _step_callable = func
+            _injection_spec = spec
+
             async def run(self, data: Any, **kwargs: Any) -> Any:
-                final_kwargs = {}
-                from flujo.application.flujo_engine import _accepts_param
-                import inspect
-
-                # Detect if func is a mock (for test robustness)
-                is_mock = hasattr(func, "assert_called_with") or func.__class__.__name__.startswith(
-                    "AsyncMock"
-                )
-
-                sig = inspect.signature(func)
-                expects_kwonly_pipeline_context = any(
-                    p.name == "pipeline_context" and p.kind == inspect.Parameter.KEYWORD_ONLY
-                    for p in sig.parameters.values()
-                )
-
-                context_value = kwargs.get("context") or kwargs.get("pipeline_context")
-                if context_value is not None:
-                    if is_mock:
-                        final_kwargs["context"] = context_value
-                        final_kwargs["pipeline_context"] = context_value
-                    elif expects_kwonly_pipeline_context:
-                        final_kwargs["pipeline_context"] = context_value
-                    elif _accepts_param(func, "context"):
-                        final_kwargs["context"] = context_value
-                    elif _accepts_param(func, "pipeline_context"):
-                        final_kwargs["pipeline_context"] = context_value
-
-                # Handle other parameters
-                for param in ["resources"]:
-                    if param in kwargs and _accepts_param(func, param):
-                        final_kwargs[param] = kwargs[param]
-
                 if first is None:
-                    return await func(**final_kwargs)
-                return await func(data, **final_kwargs)
+                    return await func(**kwargs)
+                return await func(data, **kwargs)
 
         agent_wrapper = _CallableAgent()
 

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -38,43 +38,34 @@ class Default:
             return await target(data, **kwargs)
 
         class ReviewWrapper:
-            async def run(self, data: Any, **kwargs: Any) -> Any:
-                pipeline_context = kwargs.get("context") or kwargs.get("pipeline_context")
-                if not pipeline_context:
-                    raise KeyError("Could not find 'context' or 'pipeline_context' in kwargs")
-                result = await _invoke(review_agent, data, **kwargs)
+            async def run(self, data: Any, *, context: PipelineContext) -> Any:
+                result = await _invoke(review_agent, data, context=context)
                 checklist = cast(Checklist, getattr(result, "output", result))
-                pipeline_context.scratchpad["checklist"] = checklist
+                context.scratchpad["checklist"] = checklist
                 return cast(str, data)
 
             async def run_async(self, data: Any, **kwargs: Any) -> Any:
                 return await self.run(data, **kwargs)
 
         class SolutionWrapper:
-            async def run(self, data: Any, **kwargs: Any) -> Any:
-                pipeline_context = kwargs.get("context") or kwargs.get("pipeline_context")
-                if not pipeline_context:
-                    raise KeyError("Could not find 'context' or 'pipeline_context' in kwargs")
-                result = await _invoke(solution_agent, data, **kwargs)
+            async def run(self, data: Any, *, context: PipelineContext) -> Any:
+                result = await _invoke(solution_agent, data, context=context)
                 solution = cast(str, getattr(result, "output", result))
-                pipeline_context.scratchpad["solution"] = solution
+                context.scratchpad["solution"] = solution
                 return solution
 
             async def run_async(self, data: Any, **kwargs: Any) -> Any:
                 return await self.run(data, **kwargs)
 
         class ValidatorWrapper:
-            async def run(self, _data: Any, **kwargs: Any) -> Any:
-                pipeline_context = kwargs.get("context") or kwargs.get("pipeline_context")
-                if not pipeline_context:
-                    raise KeyError("Could not find 'context' or 'pipeline_context' in kwargs")
+            async def run(self, _data: Any, *, context: PipelineContext) -> Any:
                 payload = {
-                    "solution": pipeline_context.scratchpad.get("solution"),
-                    "checklist": pipeline_context.scratchpad.get("checklist"),
+                    "solution": context.scratchpad.get("solution"),
+                    "checklist": context.scratchpad.get("checklist"),
                 }
-                result = await _invoke(validator_agent, payload, **kwargs)
+                result = await _invoke(validator_agent, payload, context=context)
                 validated = cast(Checklist, getattr(result, "output", result))
-                pipeline_context.scratchpad["checklist"] = validated
+                context.scratchpad["checklist"] = validated
                 return validated
 
             async def run_async(self, _data: Any, **kwargs: Any) -> Any:

--- a/flujo/signature_tools.py
+++ b/flujo/signature_tools.py
@@ -1,0 +1,93 @@
+import inspect
+import weakref
+import types
+from typing import Any, Callable, NamedTuple, Optional, get_type_hints, get_origin, get_args, Union
+
+from .domain.models import BaseModel
+from .domain.resources import AppResources
+from .exceptions import ConfigurationError
+
+
+class InjectionSpec(NamedTuple):
+    needs_context: bool
+    needs_resources: bool
+    context_kw: Optional[str]
+
+
+_analysis_cache_weak: "weakref.WeakKeyDictionary[Callable[..., Any], InjectionSpec]" = (
+    weakref.WeakKeyDictionary()
+)
+_analysis_cache_id: weakref.WeakValueDictionary[int, InjectionSpec] = weakref.WeakValueDictionary()
+
+
+def _cache_get(func: Callable[..., Any]) -> InjectionSpec | None:
+    try:
+        return _analysis_cache_weak.get(func)
+    except TypeError:
+        return _analysis_cache_id.get(id(func))
+
+
+def _cache_set(func: Callable[..., Any], spec: InjectionSpec) -> None:
+    try:
+        _analysis_cache_weak[func] = spec
+    except TypeError:
+        _analysis_cache_id[id(func)] = spec
+
+
+def analyze_signature(func: Callable[..., Any]) -> InjectionSpec:
+    cached = _cache_get(func)
+    if cached is not None:
+        return cached
+
+    needs_context = False
+    needs_resources = False
+    context_kw: Optional[str] = None
+    try:
+        sig = inspect.signature(func)
+        hints = get_type_hints(func)
+    except Exception:
+        sig = inspect.signature(func)
+        hints = {}
+
+    for p in sig.parameters.values():
+        if p.kind == inspect.Parameter.KEYWORD_ONLY:
+            if p.name == "context" or (p.name == "pipeline_context" and not needs_context):
+                ann = hints.get(p.name, p.annotation)
+                if ann is inspect.Signature.empty:
+                    raise ConfigurationError(
+                        f"Parameter '{p.name}' must be annotated with a BaseModel subclass"
+                    )
+                origin = get_origin(ann)
+                if origin in {Union, getattr(types, "UnionType", Union)}:
+                    args = get_args(ann)
+                    if not any(isinstance(a, type) and issubclass(a, BaseModel) for a in args):
+                        raise ConfigurationError(
+                            f"Parameter '{p.name}' must be annotated with a BaseModel subclass"
+                        )
+                elif not (isinstance(ann, type) and issubclass(ann, BaseModel)):
+                    raise ConfigurationError(
+                        f"Parameter '{p.name}' must be annotated with a BaseModel subclass"
+                    )
+                needs_context = True
+                context_kw = p.name
+            elif p.name == "resources":
+                ann = hints.get(p.name, p.annotation)
+                if ann is inspect.Signature.empty:
+                    raise ConfigurationError(
+                        "Parameter 'resources' must be annotated with an AppResources subclass"
+                    )
+                origin = get_origin(ann)
+                if origin in {Union, getattr(types, "UnionType", Union)}:
+                    args = get_args(ann)
+                    if not any(isinstance(a, type) and issubclass(a, AppResources) for a in args):
+                        raise ConfigurationError(
+                            "Parameter 'resources' must be annotated with an AppResources subclass"
+                        )
+                elif not (isinstance(ann, type) and issubclass(ann, AppResources)):
+                    raise ConfigurationError(
+                        "Parameter 'resources' must be annotated with an AppResources subclass"
+                    )
+                needs_resources = True
+    spec = InjectionSpec(needs_context, needs_resources, context_kw)
+    _cache_set(func, spec)
+    return spec

--- a/flujo/tracing.py
+++ b/flujo/tracing.py
@@ -33,9 +33,7 @@ class ConsoleTracer:
         self.log_inputs = log_inputs
         self.log_outputs = log_outputs
         self.console = (
-            Console(highlight=False)
-            if colorized
-            else Console(no_color=True, highlight=False)
+            Console(highlight=False) if colorized else Console(no_color=True, highlight=False)
         )
         self._depth = 0
         self.event_handlers: Dict[str, Callable[[HookPayload], Any]] = {
@@ -43,9 +41,7 @@ class ConsoleTracer:
             "post_run": cast(Callable[[HookPayload], Any], self._handle_post_run),
             "pre_step": cast(Callable[[HookPayload], Any], self._handle_pre_step),
             "post_step": cast(Callable[[HookPayload], Any], self._handle_post_step),
-            "on_step_failure": cast(
-                Callable[[HookPayload], Any], self._handle_on_step_failure
-            ),
+            "on_step_failure": cast(Callable[[HookPayload], Any], self._handle_on_step_failure),
         }
 
     def _handle_pre_run(self, payload: PreRunPayload) -> None:
@@ -112,6 +108,4 @@ class ConsoleTracer:
             else:
                 handler(payload)
         else:
-            self.console.print(
-                Panel(Text(str(payload.event_name)), title="Unknown tracer event")
-            )
+            self.console.print(Panel(Text(str(payload.event_name)), title="Unknown tracer event"))

--- a/tests/integration/test_console_tracer_depth.py
+++ b/tests/integration/test_console_tracer_depth.py
@@ -9,25 +9,15 @@ from flujo.domain.models import StepResult
 async def test_console_tracer_indentation(monkeypatch):
     tracer = ConsoleTracer(level="info", colorized=False)
     titles: list[str] = []
-    monkeypatch.setattr(
-        tracer.console, "print", lambda panel: titles.append(panel.title)
-    )
+    monkeypatch.setattr(tracer.console, "print", lambda panel: titles.append(panel.title))
 
     outer_step = Step("outer")
     inner_step = Step("inner")
 
-    await tracer.hook(
-        PreStepPayload(event_name="pre_step", step=outer_step, step_input=None)
-    )
-    await tracer.hook(
-        PreStepPayload(event_name="pre_step", step=inner_step, step_input=None)
-    )
-    await tracer.hook(
-        PostStepPayload(event_name="post_step", step_result=StepResult(name="inner"))
-    )
-    await tracer.hook(
-        PostStepPayload(event_name="post_step", step_result=StepResult(name="outer"))
-    )
+    await tracer.hook(PreStepPayload(event_name="pre_step", step=outer_step, step_input=None))
+    await tracer.hook(PreStepPayload(event_name="pre_step", step=inner_step, step_input=None))
+    await tracer.hook(PostStepPayload(event_name="post_step", step_result=StepResult(name="inner")))
+    await tracer.hook(PostStepPayload(event_name="post_step", step_result=StepResult(name="outer")))
 
     assert titles[0] == "Step Start: outer"
     assert titles[1].startswith("  Step Start: inner")
@@ -39,25 +29,19 @@ async def test_console_tracer_indentation(monkeypatch):
 async def test_console_tracer_indentation_reset_on_failure(monkeypatch):
     tracer = ConsoleTracer(level="info", colorized=False)
     titles: list[str] = []
-    monkeypatch.setattr(
-        tracer.console, "print", lambda panel: titles.append(panel.title)
-    )
+    monkeypatch.setattr(tracer.console, "print", lambda panel: titles.append(panel.title))
 
     fail_step = Step("fail")
     next_step = Step("next")
 
-    await tracer.hook(
-        PreStepPayload(event_name="pre_step", step=fail_step, step_input=None)
-    )
+    await tracer.hook(PreStepPayload(event_name="pre_step", step=fail_step, step_input=None))
     await tracer.hook(
         OnStepFailurePayload(
             event_name="on_step_failure",
             step_result=StepResult(name="fail", success=False, feedback="bad"),
         )
     )
-    await tracer.hook(
-        PreStepPayload(event_name="pre_step", step=next_step, step_input=None)
-    )
+    await tracer.hook(PreStepPayload(event_name="pre_step", step=next_step, step_input=None))
 
     assert titles[0] == "Step Start: fail"
     assert titles[1] == "Step Failure: fail"

--- a/tests/integration/test_loop_step_execution.py
+++ b/tests/integration/test_loop_step_execution.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Any
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step, Pipeline
@@ -450,7 +450,4 @@ async def test_loop_step_error_logging_in_callables(monkeypatch) -> None:
     )
     runner = Flujo(loop, context_model=Ctx)
     await gather_result(runner, 0)
-    assert any(
-        "Error in iteration_input_mapper for LoopStep 'loop_err_log'" in m
-        for m in errors
-    )
+    assert any("Error in iteration_input_mapper for LoopStep 'loop_err_log'" in m for m in errors)

--- a/tests/integration/test_map_over_step.py
+++ b/tests/integration/test_map_over_step.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Any
 
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 import pytest
 
 from flujo.application.flujo_engine import Flujo

--- a/tests/integration/test_nested_dsl_constructs.py
+++ b/tests/integration/test_nested_dsl_constructs.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step, Pipeline

--- a/tests/integration/test_parallel_step.py
+++ b/tests/integration/test_parallel_step.py
@@ -1,6 +1,6 @@
 import asyncio
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 from flujo.domain import Step
 from flujo.testing.utils import gather_result
 from flujo.application.flujo_engine import Flujo

--- a/tests/integration/test_pipeline_composition.py
+++ b/tests/integration/test_pipeline_composition.py
@@ -7,7 +7,7 @@ in real-world scenarios, ensuring the FSD requirements are fully met.
 
 import pytest
 from typing import Any, Dict, List
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step, Pipeline

--- a/tests/integration/test_pipeline_context_updates.py
+++ b/tests/integration/test_pipeline_context_updates.py
@@ -1,5 +1,6 @@
 import pytest
-from pydantic import BaseModel, model_validator
+from flujo.domain.models import BaseModel
+from pydantic import model_validator
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step

--- a/tests/integration/test_pipeline_hooks.py
+++ b/tests/integration/test_pipeline_hooks.py
@@ -9,7 +9,7 @@ from flujo import (
 )
 from flujo.exceptions import PipelineAbortSignal, UsageLimitExceededError
 from flujo.domain.models import PipelineResult
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 from typing import Any, List, cast
 from flujo.domain.events import (
     HookPayload,

--- a/tests/integration/test_pipeline_runner_with_context.py
+++ b/tests/integration/test_pipeline_runner_with_context.py
@@ -1,6 +1,6 @@
 import asyncio
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step

--- a/tests/integration/test_pipeline_runner_with_resources.py
+++ b/tests/integration/test_pipeline_runner_with_resources.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo import Flujo, Step, AppResources, PluginOutcome
 from flujo.testing.utils import gather_result

--- a/tests/integration/test_processors.py
+++ b/tests/integration/test_processors.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel, PipelineContext
 
 from flujo import Flujo, Step, AgentProcessors
 from flujo.testing.utils import StubAgent, gather_result
@@ -8,21 +8,21 @@ from flujo.testing.utils import StubAgent, gather_result
 class AddWorld:
     name = "AddWorld"
 
-    async def process(self, data: str, context=None) -> str:
+    async def process(self, data: str, context: PipelineContext | None = None) -> str:
         return data + " world"
 
 
 class DoubleOutput:
     name = "DoubleOutput"
 
-    async def process(self, data: str, context=None) -> str:
+    async def process(self, data: str, context: PipelineContext | None = None) -> str:
         return data * 2
 
 
 class ContextPrefix:
     name = "CtxPrefix"
 
-    async def process(self, data: str, context=None) -> str:
+    async def process(self, data: str, context: PipelineContext | None = None) -> str:
         prefix = getattr(context, "prefix", "") if context else ""
         return f"{prefix}:{data}"
 
@@ -30,7 +30,7 @@ class ContextPrefix:
 class FailingProc:
     name = "Fail"
 
-    async def process(self, data, context=None):
+    async def process(self, data, context: PipelineContext | None = None):
         raise RuntimeError("boom")
 
 

--- a/tests/integration/test_pydantic_ai_compatibility.py
+++ b/tests/integration/test_pydantic_ai_compatibility.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
@@ -15,9 +15,10 @@ class TypeCheckingAgent:
 
 
 class KwargCheckingAgent:
-    async def run(self, data, *, pipeline_context):
-        assert isinstance(pipeline_context, dict)
-        return pipeline_context.get("foo")
+    async def run(self, data, *, pipeline_context: "SimpleContext") -> str:
+        if isinstance(pipeline_context, dict):
+            return pipeline_context.get("foo", "")
+        return pipeline_context.foo
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_streaming_pipeline.py
+++ b/tests/integration/test_streaming_pipeline.py
@@ -8,7 +8,7 @@ from flujo.domain import Step
 from flujo.domain.models import PipelineResult
 from flujo.domain.resources import AppResources
 from flujo.testing.utils import StubAgent, FailingStreamAgent
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 
 class MockStreamingAgent:

--- a/tests/integration/test_usage_governor.py
+++ b/tests/integration/test_usage_governor.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo import Flujo, Step, Pipeline, UsageLimits, UsageLimitExceededError
 from flujo.testing.utils import gather_result

--- a/tests/integration/test_validation_persistence.py
+++ b/tests/integration/test_validation_persistence.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel, Field
+from flujo.domain.models import BaseModel, Field
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step

--- a/tests/unit/test_context_aware_protocol.py
+++ b/tests/unit/test_context_aware_protocol.py
@@ -2,7 +2,7 @@ import warnings
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo import Flujo, Step
 from flujo.domain.agent_protocol import ContextAwareAgentProtocol, AsyncAgentProtocol
@@ -47,6 +47,9 @@ async def test_context_aware_agent_no_warning() -> None:
 
 @pytest.mark.asyncio
 async def test_legacy_agent_triggers_warning() -> None:
+    from flujo.deprecation import _warned_locations
+
+    _warned_locations.clear()
     step = Step("s", LegacyAgent())
     runner = Flujo(step, context_model=Ctx)
     with pytest.warns(DeprecationWarning):

--- a/tests/unit/test_dummy_remote_backend.py
+++ b/tests/unit/test_dummy_remote_backend.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo import Flujo, Step
 from flujo.testing.utils import DummyRemoteBackend, gather_result

--- a/tests/unit/test_pipeline_context.py
+++ b/tests/unit/test_pipeline_context.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 
 from flujo.application.flujo_engine import Flujo
 from flujo.domain import Step
@@ -112,8 +112,7 @@ async def test_plugin_receives_context_and_strict_plugin_errors() -> None:
     # Verify that the run succeeded and plugins received context correctly.
     assert result.step_history[0].success
     assert isinstance(ctx_plugin.ctx, Ctx)
-    assert kwargs_plugin.kwargs is not None
-    assert kwargs_plugin.kwargs.get("context") is not None
+    assert kwargs_plugin.kwargs == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_prompt_formatter.py
+++ b/tests/unit/test_prompt_formatter.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from flujo.domain.models import BaseModel
 from flujo import format_prompt
 
 

--- a/tests/unit/test_signature_injection.py
+++ b/tests/unit/test_signature_injection.py
@@ -1,0 +1,57 @@
+import warnings
+import pytest
+from flujo.domain.models import BaseModel
+
+from flujo import Flujo, step
+from flujo.domain.resources import AppResources
+from flujo.testing.utils import gather_result
+from flujo.deprecation import _warned_locations
+
+
+class Ctx(BaseModel):
+    num: int = 0
+
+
+class MyRes(AppResources):
+    tag: str = "ok"
+
+
+@step
+async def add(x: int, *, context: Ctx) -> int:
+    context.num += x
+    return context.num
+
+
+@step
+async def res_step(_: int, *, resources: MyRes) -> str:
+    return resources.tag
+
+
+@step
+async def legacy(_: int, *, pipeline_context: Ctx) -> int:
+    return pipeline_context.num
+
+
+@pytest.mark.asyncio
+async def test_context_injected() -> None:
+    runner = Flujo(add, context_model=Ctx)
+    result = await gather_result(runner, 1)
+    assert result.final_pipeline_context.num == 1
+    assert result.step_history[-1].output == 1
+
+
+@pytest.mark.asyncio
+async def test_resources_injected() -> None:
+    runner = Flujo(res_step, context_model=Ctx, resources=MyRes(tag="X"))
+    result = await gather_result(runner, 0)
+    assert result.step_history[-1].output == "X"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_context_deprecated_warning() -> None:
+    _warned_locations.clear()
+    runner = Flujo(legacy, context_model=Ctx)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        await gather_result(runner, 0)
+    assert any(isinstance(w.message, DeprecationWarning) for w in rec)


### PR DESCRIPTION
## Summary
- add `signature_tools` for analyzing callable signatures
- add `deprecation.warn_once` utility
- inject context/resources using `InjectionSpec`
- update default and agentic loop recipes for new injection
- adjust tests for BaseModel subclasses and new warnings

## Testing
- `ruff format flujo tests`
- `ruff check flujo tests`
- `mypy flujo`
- `bandit -c pyproject.toml -r flujo -s B101,B404,B603 --exit-zero`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec8658fe4832c841c992ae2e24dcf