### PR TITLE
Fix runtime type compatibility checks

### DIFF
--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -63,6 +63,9 @@ from .exceptions import (
     ConfigurationError,
     SettingsError,
     UsageLimitExceededError,
+    ImproperStepInvocationError,
+    MissingAgentError,
+    TypeMismatchError,
     PipelineAbortSignal,
 )
 
@@ -114,6 +117,9 @@ __all__ = [
     "ConfigurationError",
     "SettingsError",
     "UsageLimitExceededError",
+    "ImproperStepInvocationError",
+    "MissingAgentError",
+    "TypeMismatchError",
     "StubAgent",
     "DummyPlugin",
     "SQLSyntaxValidator",

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -33,6 +33,8 @@ from ..exceptions import (
     UsageLimitExceededError,
     PipelineAbortSignal,
     PausedException,
+    MissingAgentError,
+    TypeMismatchError,
 )
 from ..domain.pipeline_dsl import (
     Pipeline,
@@ -109,6 +111,39 @@ def _accepts_param(func: Callable[..., Any], param: str) -> Optional[bool]:
 
     cache[param] = result
     return result
+
+
+def _types_compatible(a: Any, b: Any) -> bool:
+    """Return ``True`` if type ``a`` is compatible with type ``b``."""
+    if a is Any or b is Any:
+        return True
+    try:
+        return issubclass(a, b)
+    except Exception:
+        pass
+
+    origin_a, origin_b = get_origin(a), get_origin(b)
+
+    if origin_a is None and origin_b is None:
+        return False
+    if origin_a is None:
+        try:
+            return issubclass(a, origin_b)
+        except Exception:
+            return False
+    if origin_b is None:
+        try:
+            return issubclass(origin_a, b)
+        except Exception:
+            return False
+
+    if origin_a is not origin_b:
+        return False
+
+    args_a, args_b = get_args(a), get_args(b)
+    if len(args_a) != len(args_b):
+        return False
+    return all(_types_compatible(x, y) for x, y in zip(args_a, args_b))
 
 
 RunnerInT = TypeVar("RunnerInT")
@@ -558,7 +593,10 @@ async def _run_step_logic(
     for attempt in range(1, step.config.max_retries + 1):
         result.attempts = attempt
         if current_agent is None:
-            raise OrchestratorError(f"Step {step.name} has no agent")
+            raise MissingAgentError(
+                f"Step '{step.name}' is missing an agent. Assign one via `Step('name', agent=...)` "
+                "or by using a step factory like `@step` or `Step.from_callable()`."
+            )
 
         start = time.monotonic()
         agent_kwargs: Dict[str, Any] = {}
@@ -1115,6 +1153,18 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     logfire.warn(f"Step '{step.name}' failed. Halting pipeline execution.")
                     break
                 step_output: Optional[RunnerInT] = step_result.output
+                if idx < len(self.pipeline.steps) - 1:
+                    next_step = self.pipeline.steps[idx + 1]
+                    expected = getattr(next_step, "__step_input_type__", Any)
+                    actual_type = type(step_output)
+                    if step_output is None:
+                        actual_type = type(None)
+                    if not _types_compatible(actual_type, expected):
+                        raise TypeMismatchError(
+                            f"Type mismatch: Output of '{step.name}' (returns `{actual_type}`) "
+                            f"is not compatible with '{next_step.name}' (expects `{expected}`). "
+                            "For best results, use a static type checker like mypy to catch these issues before runtime."
+                        )
                 data = step_output
         except asyncio.CancelledError:
             logfire.info("Pipeline cancelled")

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -123,6 +123,27 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             meta=meta or {},
         )
 
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - behavior
+        """Disallow direct invocation of a Step."""
+        from ..exceptions import ImproperStepInvocationError
+
+        raise ImproperStepInvocationError(
+            f"Step '{self.name}' cannot be invoked directly. "
+            "Steps are configuration objects and must be run within a Pipeline. "
+            "For unit testing, use `step.arun()`."
+        )
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - behavior
+        if item in {"run", "stream"}:
+            from ..exceptions import ImproperStepInvocationError
+
+            raise ImproperStepInvocationError(
+                f"Step '{self.name}' cannot be invoked directly. "
+                "Steps are configuration objects and must be run within a Pipeline. "
+                "For unit testing, use `step.arun()`."
+            )
+        raise AttributeError(item)
+
     def __rshift__(
         self, other: "Step[StepOutT, NewOutT]" | "Pipeline[StepOutT, NewOutT]"
     ) -> "Pipeline[StepInT, NewOutT]":
@@ -842,6 +863,61 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
             new_steps = list(self.steps) + list(other.steps)
             return Pipeline.model_construct(steps=new_steps)
         raise TypeError("Can only chain Pipeline with Step or Pipeline")
+
+    def validate(self) -> None:
+        """Validate that all steps have agents and compatible types."""
+        from ..exceptions import MissingAgentError, TypeMismatchError
+        from typing import Any, get_origin
+
+        def _compatible(a: Any, b: Any) -> bool:
+            if a is Any or b is Any:
+                return True
+            try:
+                return issubclass(a, b)
+            except Exception:
+                pass
+
+            origin_a, origin_b = get_origin(a), get_origin(b)
+
+            if origin_a is None and origin_b is None:
+                return False
+            if origin_a is None:
+                try:
+                    return issubclass(a, origin_b)
+                except Exception:
+                    return False
+            if origin_b is None:
+                try:
+                    return issubclass(origin_a, b)
+                except Exception:
+                    return False
+
+            if origin_a is not origin_b:
+                return False
+
+            args_a, args_b = get_args(a), get_args(b)
+            if len(args_a) != len(args_b):
+                return False
+            return all(_compatible(x, y) for x, y in zip(args_a, args_b))
+
+        prev_step = None
+        prev_out_type: Any = None
+        for step in self.steps:
+            if step.agent is None:
+                raise MissingAgentError(
+                    f"Step '{step.name}' is missing an agent. Assign one via `Step('name', agent=...)` "
+                    "or by using a step factory like `@step` or `Step.from_callable()`."
+                )
+            in_type = getattr(step, "__step_input_type__", Any)
+            if prev_step is not None and prev_out_type is not None:
+                if not _compatible(prev_out_type, in_type):
+                    raise TypeMismatchError(
+                        f"Type mismatch: Output of '{prev_step.name}' (returns `{prev_out_type}`) "
+                        f"is not compatible with '{step.name}' (expects `{in_type}`). "
+                        "For best results, use a static type checker like mypy to catch these issues before runtime."
+                    )
+            prev_step = step
+            prev_out_type = getattr(step, "__step_output_type__", Any)
 
     def iter_steps(self) -> Iterator[Step[Any, Any]]:
         return iter(self.steps)

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -76,3 +76,21 @@ class PausedException(OrchestratorError):
 
     def __init__(self, message: str = "Pipeline paused for human input.") -> None:
         super().__init__(message)
+
+
+class ImproperStepInvocationError(OrchestratorError):
+    """Raised when a ``Step`` object is invoked directly."""
+
+    pass
+
+
+class MissingAgentError(ConfigurationError):
+    """Raised when a pipeline step is missing its agent."""
+
+    pass
+
+
+class TypeMismatchError(ConfigurationError):
+    """Raised when consecutive steps have incompatible types."""
+
+    pass

--- a/tests/unit/test_error_messages.py
+++ b/tests/unit/test_error_messages.py
@@ -1,0 +1,49 @@
+import pytest
+
+from flujo import Step, Pipeline, Flujo, step
+from flujo.exceptions import (
+    ImproperStepInvocationError,
+    MissingAgentError,
+    TypeMismatchError,
+)
+
+
+@step
+async def echo(x: str) -> str:
+    return x
+
+
+def test_improper_step_call() -> None:
+    with pytest.raises(ImproperStepInvocationError):
+        echo("hi")
+    with pytest.raises(ImproperStepInvocationError):
+        echo.run("hi")  # type: ignore[attr-defined]
+
+
+def test_missing_agent_errors() -> None:
+    blank = Step("blank")
+    pipeline = Pipeline.from_step(blank)
+    with pytest.raises(MissingAgentError):
+        pipeline.validate()
+    runner = Flujo(blank)
+    with pytest.raises(MissingAgentError):
+        runner.run(None)
+
+
+@step
+async def make_int(x: str) -> int:
+    return len(x)
+
+
+@step
+async def need_str(x: str) -> str:
+    return x
+
+
+def test_type_mismatch_errors() -> None:
+    pipeline = make_int >> need_str
+    with pytest.raises(TypeMismatchError):
+        pipeline.validate()
+    runner = Flujo(pipeline)
+    with pytest.raises(TypeMismatchError):
+        runner.run("abc")


### PR DESCRIPTION
## Summary
- improve `_types_compatible` helper to compare generic types correctly
- tighten Pipeline.validate compatibility logic

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_685eeb3983bc832c97a691b8b7db36ee