### PR TITLE
Implement pipeline validation report and CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.24] - 2025-06-30
+
+### Added
+- Pre-flight pipeline validation with `Pipeline.validate()` returning a detailed report.
+- New `flujo validate` CLI command to check pipelines from the command line.
+
 ## [0.4.23] - 2025-06-27
 
 ### Fixed

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -28,6 +28,8 @@ from .domain import (
     ValidationPlugin,
     Validator,
     ValidationResult,
+    ValidationFinding,
+    ValidationReport,
     AppResources,
 )
 from .validation import BaseValidator, validator
@@ -95,6 +97,8 @@ __all__ = [
     "ValidationPlugin",
     "Validator",
     "ValidationResult",
+    "ValidationFinding",
+    "ValidationReport",
     "BaseValidator",
     "validator",
     "run_pipeline_async",

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -15,6 +15,7 @@ from .pipeline_dsl import (
 )
 from .plugins import PluginOutcome, ValidationPlugin
 from .validation import Validator, ValidationResult
+from .pipeline_validation import ValidationFinding, ValidationReport
 from .processors import AgentProcessors
 from .resources import AppResources
 from .types import HookCallable
@@ -36,6 +37,8 @@ __all__ = [
     "ValidationPlugin",
     "Validator",
     "ValidationResult",
+    "ValidationFinding",
+    "ValidationReport",
     "AppResources",
     "HookCallable",
     "ExecutionBackend",

--- a/flujo/domain/pipeline_validation.py
+++ b/flujo/domain/pipeline_validation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, List
+
+from pydantic import BaseModel, Field
+
+
+class ValidationFinding(BaseModel):
+    """Represents a single validation finding."""
+
+    rule_id: str
+    severity: Literal["error", "warning"]
+    message: str
+    step_name: Optional[str] = None
+
+
+class ValidationReport(BaseModel):
+    """Aggregated validation results for a pipeline."""
+
+    errors: List[ValidationFinding] = Field(default_factory=list)
+    warnings: List[ValidationFinding] = Field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+__all__ = ["ValidationFinding", "ValidationReport"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -291,6 +291,23 @@ def test_cli_explain(tmp_path) -> None:
     assert "B" in result.stdout
 
 
+def test_cli_validate_success(tmp_path) -> None:
+    file = tmp_path / "pipe.py"
+    file.write_text(
+        "from flujo.domain import Step\nfrom flujo.testing.utils import StubAgent\npipeline = Step('A', StubAgent(['x'])) >> Step('B', StubAgent(['y']))\n"
+    )
+    result = runner.invoke(app, ["validate", str(file)])
+    assert result.exit_code == 0
+    assert "Pipeline is valid" in result.stdout
+
+
+def test_cli_validate_failure(tmp_path) -> None:
+    file = tmp_path / "pipe.py"
+    file.write_text("from flujo.domain import Step\npipeline = Step('A') >> Step('B')\n")
+    result = runner.invoke(app, ["validate", str(file), "--strict"])
+    assert result.exit_code == 1
+
+
 def test_cli_improve_output_formatting(monkeypatch, tmp_path) -> None:
     pipe = tmp_path / "pipe.py"
     pipe.write_text(


### PR DESCRIPTION
## Summary
- add `ValidationFinding` and `ValidationReport` models
- extend `Pipeline.validate` to return a report and handle warnings
- add `flujo validate` command for CLI validation
- update exports and changelog
- adapt tests for new validation API and CLI command

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_685f14f789c8832ca1dff2fed47fc0fc