### PR TITLE
Implement SerializePydantic processor

### DIFF
--- a/docs/cookbook/serialize_pydantic.md
+++ b/docs/cookbook/serialize_pydantic.md
@@ -1,0 +1,31 @@
+# Cookbook: Serialize Pydantic Models
+
+`SerializePydantic` converts models produced by one step into plain dictionaries before passing them along. This is handy when the next agent or tool doesn't understand Pydantic models.
+
+```python
+from pydantic import BaseModel
+from flujo import Step, Flujo, AgentProcessors
+from flujo.processors import SerializePydantic
+from flujo.testing.utils import StubAgent
+
+class User(BaseModel):
+    name: str
+    age: int
+
+# First step emits a User model
+producer = Step.solution(
+    StubAgent([User(name="Ada", age=42)]),
+    processors=AgentProcessors(output_processors=[SerializePydantic()]),
+)
+
+# Second step expects a dict
+consumer_agent = StubAgent(["ok"])
+consumer = Step.solution(consumer_agent)
+
+pipeline = producer >> consumer
+runner = Flujo(pipeline)
+runner.run(None)
+print(consumer_agent.inputs[0])
+```
+
+This prints `{"name": "Ada", "age": 42}` showing how the processor bridges a Pydantic model to plain data.

--- a/docs/cookbook/using_processors.md
+++ b/docs/cookbook/using_processors.md
@@ -62,3 +62,9 @@ print(result.step_history[0].output)
 
 This prints `{'count': 1}` because the processor parsed the JSON string.
 
+## Serializing Pydantic Models
+
+`SerializePydantic` turns any object with a `model_dump()` method into a plain dictionary. Use it when a downstream agent doesn't understand Pydantic models.
+
+See [Serialize Pydantic Models](serialize_pydantic.md) for a complete example.
+

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -49,6 +49,7 @@ from .processors import (
     AddContextVariables,
     StripMarkdownFences,
     EnforceJsonResponse,
+    SerializePydantic,
 )
 
 from .infra.agents import (
@@ -92,6 +93,7 @@ __all__ = [
     "AddContextVariables",
     "StripMarkdownFences",
     "EnforceJsonResponse",
+    "SerializePydantic",
     "AppResources",
     "PluginOutcome",
     "ValidationPlugin",

--- a/flujo/processors/__init__.py
+++ b/flujo/processors/__init__.py
@@ -1,9 +1,15 @@
 from .base import Processor
-from .common import AddContextVariables, StripMarkdownFences, EnforceJsonResponse
+from .common import (
+    AddContextVariables,
+    StripMarkdownFences,
+    EnforceJsonResponse,
+    SerializePydantic,
+)
 
 __all__ = [
     "Processor",
     "AddContextVariables",
     "StripMarkdownFences",
     "EnforceJsonResponse",
+    "SerializePydantic",
 ]

--- a/flujo/processors/common.py
+++ b/flujo/processors/common.py
@@ -58,3 +58,16 @@ class EnforceJsonResponse:
             return json.loads(data)
         except Exception:
             return data
+
+
+class SerializePydantic:
+    """Serialize any object with a ``model_dump`` method to a plain ``dict``."""
+
+    def __init__(self) -> None:
+        self.name = "SerializePydantic"
+
+    async def process(self, data: Any, context: Optional[BaseModel] = None) -> Any:
+        dump = getattr(data, "model_dump", None)
+        if callable(dump):
+            return dump()
+        return data

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - 'Real-Time Chatbot': cookbook/realtime_chatbot.md
     - 'Advanced Prompt Formatting': cookbook/advanced_prompting.md
     - 'Adapter Step': cookbook/adapter_step.md
+    - 'Serialize Pydantic': cookbook/serialize_pydantic.md
     - 'Agentic Loop': recipes/agentic_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md


### PR DESCRIPTION
## Summary
- add `SerializePydantic` processor to convert Pydantic models to dicts
- expose processor in package exports
- document processor in the cookbook and link from the processors guide
- add recipe to MkDocs navigation
- test processor behaviour

## Testing
- `pytest tests/integration/test_processors.py::test_serialize_pydantic_output_to_dict tests/integration/test_processors.py::test_serialize_pydantic_is_idempotent -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2609a7e0832c8360f58ac8984551