### PR TITLE
Add Step.refine_until iterative refinement factory

### DIFF
--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -13,6 +13,7 @@ from .pipeline_dsl import (
     adapter_step,
     mapper,
 )
+from .models import RefinementCheck
 from .plugins import PluginOutcome, ValidationPlugin
 from .validation import Validator, ValidationResult
 from .pipeline_validation import ValidationFinding, ValidationReport
@@ -44,4 +45,5 @@ __all__ = [
     "ExecutionBackend",
     "StepExecutionRequest",
     "AgentProcessors",
+    "RefinementCheck",
 ]

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -120,6 +120,13 @@ class PipelineResult(BaseModel, Generic[ContextT]):
     model_config: ClassVar[ConfigDict] = {"arbitrary_types_allowed": True}
 
 
+class RefinementCheck(BaseModel):
+    """Standardized output from a critic pipeline in a refinement loop."""
+
+    is_complete: bool
+    feedback: Optional[Any] = None
+
+
 class UsageLimits(BaseModel):
     """Defines resource consumption limits for a pipeline run."""
 

--- a/tests/integration/test_refine_until.py
+++ b/tests/integration/test_refine_until.py
@@ -1,0 +1,67 @@
+import pytest
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step, Pipeline, RefinementCheck
+from flujo.testing.utils import StubAgent, gather_result
+
+
+@pytest.mark.asyncio
+async def test_refine_until_basic() -> None:
+    gen_agent = StubAgent(["draft1", "draft2"])
+    gen_pipeline = Pipeline.from_step(Step("gen", gen_agent))
+
+    critic_agent = StubAgent(
+        [
+            RefinementCheck(is_complete=False, feedback="bad"),
+            RefinementCheck(is_complete=True, feedback="good"),
+        ]
+    )
+    critic_pipeline = Pipeline.from_step(Step("crit", critic_agent))
+
+    loop = Step.refine_until(
+        name="refine",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+        max_refinements=3,
+    )
+
+    runner = Flujo(loop)
+    result = await gather_result(runner, "goal")
+    step_result = result.step_history[-1]
+    assert step_result.success is True
+    assert step_result.attempts == 2
+    assert step_result.output == "draft2"
+    assert gen_agent.inputs == [
+        {"original_input": "goal", "feedback": None},
+        {"original_input": "goal", "feedback": "bad"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refine_until_with_feedback_mapper() -> None:
+    gen_agent = StubAgent(["v1", "v2"])
+    gen_pipeline = Pipeline.from_step(Step("gen", gen_agent))
+
+    critic_agent = StubAgent(
+        [
+            RefinementCheck(is_complete=False, feedback="err"),
+            RefinementCheck(is_complete=True, feedback="done"),
+        ]
+    )
+    critic_pipeline = Pipeline.from_step(Step("crit", critic_agent))
+
+    def fmap(original: str | None, check: RefinementCheck) -> dict[str, str | None]:
+        return {"original_input": f"{original}-orig", "feedback": f"fix:{check.feedback}"}
+
+    loop = Step.refine_until(
+        name="refine_map",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+        max_refinements=3,
+        feedback_mapper=fmap,
+    )
+
+    runner = Flujo(loop)
+    result = await gather_result(runner, "goal")
+    step_result = result.step_history[-1]
+    assert step_result.output == "v2"
+    assert gen_agent.inputs[1] == {"original_input": "goal-orig", "feedback": "fix:err"}


### PR DESCRIPTION
## Summary
- add `RefinementCheck` model for critic feedback
- implement `Step.refine_until` factory on DSL for generator/critic loops
- expose `RefinementCheck`
- test the new iterative refinement behaviour

## Testing
- `make test`
- `make quality`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_6860e867c610832cab03f75dc1992726