### PR TITLE
Add Step.refine_until iterative refinement factory

### DIFF
--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -13,6 +13,7 @@ from .pipeline_dsl import (
     adapter_step,
     mapper,
 )
+from .models import RefinementCheck
 from .plugins import PluginOutcome, ValidationPlugin
 from .validation import Validator, ValidationResult
 from .pipeline_validation import ValidationFinding, ValidationReport
@@ -44,4 +45,5 @@ __all__ = [
     "ExecutionBackend",
     "StepExecutionRequest",
     "AgentProcessors",
+    "RefinementCheck",
 ]

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -120,6 +120,13 @@ class PipelineResult(BaseModel, Generic[ContextT]):
     model_config: ClassVar[ConfigDict] = {"arbitrary_types_allowed": True}
 
 
+class RefinementCheck(BaseModel):
+    """Standardized output from a critic pipeline in a refinement loop."""
+
+    is_complete: bool
+    feedback: Optional[Any] = None
+
+
 class UsageLimits(BaseModel):
     """Defines resource consumption limits for a pipeline run."""
 

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -27,7 +27,7 @@ import contextvars
 import inspect
 
 from .pipeline_validation import ValidationFinding, ValidationReport
-from flujo.domain.models import BaseModel
+from flujo.domain.models import BaseModel, PipelineContext, RefinementCheck  # noqa: F401
 from flujo.domain.resources import AppResources
 from pydantic import Field, ConfigDict
 from .agent_protocol import AsyncAgentProtocol
@@ -448,6 +448,82 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             initial_input_to_loop_body_mapper=initial_input_to_loop_body_mapper,
             iteration_input_mapper=iteration_input_mapper,
             loop_output_mapper=loop_output_mapper,
+            **config_kwargs,
+        )
+
+    @classmethod
+    def refine_until(
+        cls,
+        name: str,
+        generator_pipeline: "Pipeline[Any, Any]",
+        critic_pipeline: "Pipeline[Any, RefinementCheck]",
+        max_refinements: int = 5,
+        feedback_mapper: Optional[Callable[[Any, RefinementCheck], Any]] = None,
+        **config_kwargs: Any,
+    ) -> "LoopStep[ContextT]":
+        """Factory for a Generator-Critic refinement loop."""
+        artifact_key = f"__{name}_artifact"
+        original_var: contextvars.ContextVar[Any | None] = contextvars.ContextVar(
+            f"{name}_orig", default=None
+        )
+        artifact_var: contextvars.ContextVar[Any | None] = contextvars.ContextVar(
+            f"{name}_artifact", default=None
+        )
+
+        async def _store_artifact(
+            artifact: Any, *, pipeline_context: BaseModel | None = None
+        ) -> Any:
+            artifact_var.set(artifact)
+            if pipeline_context is not None and hasattr(pipeline_context, "scratchpad"):
+                pipeline_context.scratchpad[artifact_key] = artifact
+            return artifact
+
+        saver_step = cls.from_callable(_store_artifact, name=f"_{name}_store")
+
+        loop_body = generator_pipeline >> saver_step >> critic_pipeline
+
+        def _exit_condition(out: Any, _ctx: BaseModel | None) -> bool:
+            if isinstance(out, RefinementCheck):
+                return out.is_complete
+            return True
+
+        def _initial_mapper(inp: Any, ctx: BaseModel | None) -> dict[str, Any]:
+            original_var.set(inp)
+            if ctx is not None and hasattr(ctx, "scratchpad"):
+                ctx.scratchpad.setdefault(artifact_key + "__orig", inp)
+            return {"original_input": inp, "feedback": None}
+
+        def _iteration_mapper(out: Any, ctx: BaseModel | None, _i: int) -> dict[str, Any]:
+            if isinstance(out, RefinementCheck):
+                feedback = out.feedback
+            else:
+                feedback = None
+            if ctx is not None and hasattr(ctx, "scratchpad"):
+                original = ctx.scratchpad.get(artifact_key + "__orig")
+            else:
+                original = original_var.get(None)
+            if feedback_mapper is None:
+                return {"original_input": original, "feedback": feedback}
+            return feedback_mapper(
+                original,
+                out
+                if isinstance(out, RefinementCheck)
+                else RefinementCheck(is_complete=False, feedback=feedback),
+            )
+
+        def _output_mapper(_out: Any, ctx: BaseModel | None) -> Any:
+            if ctx is not None and hasattr(ctx, "scratchpad") and artifact_key in ctx.scratchpad:
+                return ctx.scratchpad.get(artifact_key)
+            return artifact_var.get(None)
+
+        return cls.loop_until(
+            name=name,
+            loop_body_pipeline=loop_body,
+            exit_condition_callable=_exit_condition,
+            max_loops=max_refinements,
+            initial_input_to_loop_body_mapper=_initial_mapper,
+            iteration_input_mapper=_iteration_mapper,
+            loop_output_mapper=_output_mapper,
             **config_kwargs,
         )
 

--- a/tests/integration/test_refine_until.py
+++ b/tests/integration/test_refine_until.py
@@ -1,0 +1,143 @@
+import asyncio
+from typing import Any
+
+import pytest
+from flujo.application.flujo_engine import Flujo
+from flujo.domain import Step, Pipeline, RefinementCheck
+from flujo.testing.utils import StubAgent, gather_result
+from pydantic import BaseModel
+
+
+@pytest.mark.asyncio
+async def test_refine_until_basic() -> None:
+    gen_agent = StubAgent(["draft1", "draft2"])
+    gen_pipeline = Pipeline.from_step(Step("gen", gen_agent))
+
+    critic_agent = StubAgent(
+        [
+            RefinementCheck(is_complete=False, feedback="bad"),
+            RefinementCheck(is_complete=True, feedback="good"),
+        ]
+    )
+    critic_pipeline = Pipeline.from_step(Step("crit", critic_agent))
+
+    loop = Step.refine_until(
+        name="refine",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+        max_refinements=3,
+    )
+
+    runner = Flujo(loop)
+    result = await gather_result(runner, "goal")
+    step_result = result.step_history[-1]
+    assert step_result.success is True
+    assert step_result.attempts == 2
+    assert step_result.output == "draft2"
+    assert gen_agent.inputs == [
+        {"original_input": "goal", "feedback": None},
+        {"original_input": "goal", "feedback": "bad"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refine_until_with_feedback_mapper() -> None:
+    gen_agent = StubAgent(["v1", "v2"])
+    gen_pipeline = Pipeline.from_step(Step("gen", gen_agent))
+
+    critic_agent = StubAgent(
+        [
+            RefinementCheck(is_complete=False, feedback="err"),
+            RefinementCheck(is_complete=True, feedback="done"),
+        ]
+    )
+    critic_pipeline = Pipeline.from_step(Step("crit", critic_agent))
+
+    def fmap(original: str | None, check: RefinementCheck) -> dict[str, str | None]:
+        return {"original_input": f"{original}-orig", "feedback": f"fix:{check.feedback}"}
+
+    loop = Step.refine_until(
+        name="refine_map",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+        max_refinements=3,
+        feedback_mapper=fmap,
+    )
+
+    runner = Flujo(loop)
+    result = await gather_result(runner, "goal")
+    step_result = result.step_history[-1]
+    assert step_result.output == "v2"
+    assert gen_agent.inputs[1] == {"original_input": "goal-orig", "feedback": "fix:err"}
+
+
+class SimpleCtx(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_refine_until_with_custom_context() -> None:
+    gen_agent = StubAgent(["one", "two"])
+    gen_pipeline = Pipeline.from_step(Step("gen", gen_agent))
+
+    critic_agent = StubAgent([RefinementCheck(is_complete=True)])
+    critic_pipeline = Pipeline.from_step(Step("crit", critic_agent))
+
+    loop = Step.refine_until(
+        name="refine_ctx",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+    )
+
+    runner = Flujo(loop, context_model=SimpleCtx)
+    result = await gather_result(runner, "start")
+    step_result = result.step_history[-1]
+    assert step_result.output == "one"
+    assert gen_agent.inputs[0] == {"original_input": "start", "feedback": None}
+
+
+@pytest.mark.asyncio
+async def test_refine_until_concurrent_runs_isolated() -> None:
+    class GenAgent:
+        def __init__(self) -> None:
+            self.inputs: list[dict[str, Any]] = []
+
+        async def run(self, data: dict[str, Any], **_: Any) -> str:
+            self.inputs.append(data)
+            await asyncio.sleep(0)
+            fb = data.get("feedback") or "none"
+            return f"{data['original_input']}-{fb}"
+
+    class CriticAgent:
+        async def run(self, artifact: str, **_: Any) -> RefinementCheck:
+            await asyncio.sleep(0)
+            if artifact.endswith("-none"):
+                return RefinementCheck(is_complete=False, feedback="fix")
+            return RefinementCheck(is_complete=True)
+
+    gen_agent = GenAgent()
+    gen_pipeline = Pipeline.from_step(Step("gen_conc", gen_agent))
+    critic_agent = CriticAgent()
+    critic_pipeline = Pipeline.from_step(Step("crit_conc", critic_agent))
+
+    loop = Step.refine_until(
+        name="refine_concurrent",
+        generator_pipeline=gen_pipeline,
+        critic_pipeline=critic_pipeline,
+        max_refinements=2,
+    )
+
+    runner = Flujo(loop)
+
+    async def run_one(val: str) -> Any:
+        return await gather_result(runner, val)
+
+    r1, r2 = await asyncio.gather(run_one("A"), run_one("B"))
+
+    assert r1.step_history[-1].output == "A-fix"
+    assert r2.step_history[-1].output == "B-fix"
+    assert len(gen_agent.inputs) == 4
+    assert {"original_input": "A", "feedback": None} in gen_agent.inputs
+    assert {"original_input": "A", "feedback": "fix"} in gen_agent.inputs
+    assert {"original_input": "B", "feedback": None} in gen_agent.inputs
+    assert {"original_input": "B", "feedback": "fix"} in gen_agent.inputs


### PR DESCRIPTION
## Summary
- add `RefinementCheck` model for critic feedback
- implement `Step.refine_until` factory on DSL for generator/critic loops
- expose `RefinementCheck`
- test the new iterative refinement behaviour
- fix context handling in `refine_until`
- ensure concurrent runs of `refine_until` don't share state

## Testing
- `make test`
- `make quality`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_6860e867c610832cab03f75dc1992726