### PR TITLE
Implement AgenticLoop.as_step context sync

### DIFF
--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -120,14 +120,21 @@ class AgenticLoop:
                 context_model=PipelineContext,
                 resources=resources,
             )
+
+            init_ctx_data = (
+                context.model_dump() if context is not None else {"initial_prompt": initial_goal}
+            )
+
             final_result: PipelineResult[PipelineContext] | None = None
             async for item in runner.run_async(
                 {"last_command_result": None, "goal": initial_goal},
-                initial_context_data={"initial_prompt": initial_goal},
+                initial_context_data=init_ctx_data,
             ):
                 final_result = item
             if final_result is None:
-                raise ValueError("The final result of the pipeline execution is None. Ensure the pipeline produces a valid result.")
+                raise ValueError(
+                    "The final result of the pipeline execution is None. Ensure the pipeline produces a valid result."
+                )
             if context is not None:
                 context.__dict__.update(final_result.final_pipeline_context.__dict__)
             return final_result

--- a/tests/integration/test_as_step_composition.py
+++ b/tests/integration/test_as_step_composition.py
@@ -5,6 +5,7 @@ from flujo.recipes.agentic_loop import AgenticLoop
 from flujo.testing.utils import StubAgent, gather_result
 from flujo.domain.commands import FinishCommand, RunAgentCommand
 from flujo.domain.models import PipelineContext, PipelineResult
+from flujo.domain.resources import AppResources
 
 
 @pytest.mark.asyncio
@@ -60,3 +61,58 @@ async def test_pipeline_of_pipelines_via_as_step() -> None:
     inner_result = result.step_history[2].output
     assert isinstance(inner_result, PipelineResult)
     assert inner_result.step_history[-1].output == 2
+
+
+@pytest.mark.asyncio
+async def test_as_step_context_propagation() -> None:
+    class Incrementer:
+        async def run(
+            self, data: int, *, pipeline_context: PipelineContext | None = None
+        ) -> dict:
+            assert pipeline_context is not None
+            current = pipeline_context.scratchpad.get("counter", 0)
+            return {"scratchpad": {"counter": current + data}}
+
+    inner_runner = Flujo(
+        Step("inc", Incrementer(), updates_context=True),
+        context_model=PipelineContext,
+    )
+
+    pipeline = inner_runner.as_step(name="inner")
+    runner = Flujo(pipeline, context_model=PipelineContext)
+
+    result = await gather_result(
+        runner,
+        2,
+        initial_context_data={"initial_prompt": "goal", "scratchpad": {"counter": 1}},
+    )
+
+    assert result.final_pipeline_context.scratchpad["counter"] == 3
+
+
+@pytest.mark.asyncio
+async def test_as_step_resource_propagation() -> None:
+    class Res(AppResources):
+        counter: int = 0
+
+    class UseRes:
+        async def run(self, data: int, *, resources: Res) -> int:
+            resources.counter += data
+            return resources.counter
+
+    inner_runner = Flujo(
+        Step("res", UseRes()),
+        context_model=PipelineContext,
+    )
+
+    pipeline = inner_runner.as_step(name="inner")
+    res = Res()
+    runner = Flujo(pipeline, context_model=PipelineContext, resources=res)
+
+    await gather_result(
+        runner,
+        5,
+        initial_context_data={"initial_prompt": "goal"},
+    )
+
+    assert res.counter == 5


### PR DESCRIPTION
## Summary
- sync parent context to child when AgenticLoop is used via `.as_step`
- test context propagation in nested pipelines
- test resource propagation into nested pipelines

## Testing
- `pytest tests/integration/test_as_step_composition.py::test_as_step_context_propagation -q`
- `pytest tests/integration/test_as_step_composition.py::test_as_step_resource_propagation -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f538a0ac832c9bc33ecd7f94799f