### PR TITLE
Implement AgenticLoop.as_step context sync

### DIFF
--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -120,14 +120,20 @@ class AgenticLoop:
                 context_model=PipelineContext,
                 resources=resources,
             )
+
+            init_ctx_data = context.model_dump() if context is not None else {}
+            init_ctx_data["initial_prompt"] = initial_goal
+
             final_result: PipelineResult[PipelineContext] | None = None
             async for item in runner.run_async(
                 {"last_command_result": None, "goal": initial_goal},
-                initial_context_data={"initial_prompt": initial_goal},
+                initial_context_data=init_ctx_data,
             ):
                 final_result = item
             if final_result is None:
-                raise ValueError("The final result of the pipeline execution is None. Ensure the pipeline produces a valid result.")
+                raise ValueError(
+                    "The final result of the pipeline execution is None. Ensure the pipeline produces a valid result."
+                )
             if context is not None:
                 context.__dict__.update(final_result.final_pipeline_context.__dict__)
             return final_result


### PR DESCRIPTION
## Summary
- sync parent context to child when AgenticLoop is used via `.as_step`
- test context propagation in nested pipelines
- test resource propagation into nested pipelines
- ensure initial_prompt in child context matches the step input

## Testing
- `pytest tests/integration/test_as_step_composition.py::test_as_step_context_propagation -q`
- `pytest tests/integration/test_as_step_composition.py::test_as_step_resource_propagation -q`
- `pytest tests/integration/test_as_step_composition.py::test_as_step_initial_prompt_sync -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860f538a0ac832c9bc33ecd7f94799f