### PR TITLE
Fix make_agent_async to use pydantic-ai structured output

### DIFF
--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -4,23 +4,14 @@ Agent prompt templates and agent factory utilities.
 
 from __future__ import annotations
 
-from typing import (
-    Any,
-    Generic,
-    Optional,
-    Type,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import Any, Generic, Optional, Type
 from pydantic_ai import Agent
 from pydantic import BaseModel as PydanticBaseModel, TypeAdapter
 import os
 from flujo.infra.settings import settings
 from flujo.domain.models import Checklist
 from flujo.domain.processors import AgentProcessors
-from flujo.processors import EnforceJsonResponse, StripMarkdownFences
-from types import UnionType
+
 from flujo.domain.agent_protocol import (
     AsyncAgentProtocol,
     AgentInT,
@@ -201,61 +192,16 @@ def make_agent(
 
     final_processors = processors.copy(deep=True) if processors else AgentProcessors()
 
-    def _contains_pydantic(tp: Any) -> bool:
-        if isinstance(tp, TypeAdapter):
-            tp = tp._type
-        origin = get_origin(tp)
-        if origin in {list, dict, Union, UnionType}:
-            return any(_contains_pydantic(arg) for arg in get_args(tp))
-        if isinstance(tp, type) and issubclass(tp, PydanticBaseModel):
-            return True
-        return False
-
-    is_pydantic_output = _contains_pydantic(output_type)
-    agent: Agent[Any, Any]
-
-    if is_pydantic_output:
-        agent_native_output_type = str
-
-        final_processors.output_processors.insert(0, StripMarkdownFences("json"))
-        final_processors.output_processors.insert(1, EnforceJsonResponse())
-
-        final_processors.output_processors.append(PydanticValidationProcessor(output_type))
-
+    try:
         agent = Agent(
             model=model,
             system_prompt=system_prompt,
-            output_type=agent_native_output_type,
+            output_type=output_type,
             tools=tools or [],
+            **kwargs,
         )
-    else:
-        actual_type = output_type
-        try:
-            if hasattr(output_type, "_type"):
-                actual_type = output_type._type
-            elif hasattr(output_type, "__origin__") and output_type.__origin__ is not None:
-                if hasattr(output_type, "__args__") and output_type.__args__:
-                    if output_type.__origin__.__name__ == "TypeAdapter":
-                        actual_type = output_type.__args__[0]
-
-            if hasattr(actual_type, "__name__"):
-                pass
-            elif hasattr(actual_type, "__bases__") and PydanticBaseModel in actual_type.__bases__:
-                pass
-            else:
-                from pydantic import create_model
-
-                create_model("TestModel", value=(actual_type, ...))
-
-        except Exception as e:
-            raise ValueError(f"Error processing output_type '{output_type}': {e}") from e
-
-        agent = Agent(
-            model=model,
-            system_prompt=system_prompt,
-            output_type=actual_type,
-            tools=tools or [],
-        )
+    except Exception as e:  # pragma: no cover - defensive
+        raise ConfigurationError(f"Failed to create pydantic-ai agent: {e}") from e
 
     return agent, final_processors
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -15,7 +15,6 @@ from flujo.domain.models import Checklist, ChecklistItem
 from flujo.exceptions import OrchestratorRetryError
 from flujo.infra.settings import settings
 from flujo.domain.processors import AgentProcessors
-from flujo.testing.utils import StubAgent
 
 
 @pytest.fixture
@@ -335,17 +334,15 @@ async def test_async_agent_wrapper_serializes_pydantic_kwarg() -> None:
 
 
 @pytest.mark.asyncio
-async def test_make_agent_async_pydantic_processors_injected(monkeypatch) -> None:
+async def test_make_agent_async_no_extra_processors(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     from flujo.infra import settings as settings_mod
 
     monkeypatch.setattr(settings_mod.settings, "openai_api_key", SecretStr("test-key"))
 
     wrapper = make_agent_async("openai:gpt-4o", "sys", Checklist)
-    names = [p.name for p in wrapper.processors.output_processors]
-    assert names[0] == "StripMarkdownFences"
-    assert names[1] == "EnforceJsonResponse"
-    assert names[-1] == "PydanticValidation"
+    assert wrapper.processors.output_processors == []
+    assert wrapper._agent.output_type is Checklist
 
 
 @pytest.mark.asyncio
@@ -364,24 +361,29 @@ async def test_make_agent_async_custom_processor_order(monkeypatch) -> None:
     procs = AgentProcessors(output_processors=[DummyProc()])
     wrapper = make_agent_async("openai:gpt-4o", "sys", Checklist, processors=procs)
     names = [p.name for p in wrapper.processors.output_processors]
-    assert names == [
-        "StripMarkdownFences",
-        "EnforceJsonResponse",
-        "dummy",
-        "PydanticValidation",
-    ]
+    assert names == ["dummy"]
 
 
 @pytest.mark.asyncio
-async def test_pydantic_output_cleaning(monkeypatch) -> None:
+async def test_pydantic_output_parsed_by_agent(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     from flujo.infra import settings as settings_mod
 
     monkeypatch.setattr(settings_mod.settings, "openai_api_key", SecretStr("test-key"))
 
     raw = 'Here you go:\n```json\n{"items": []}\n```'
+
+    class ParsingStubAgent:
+        output_type = Checklist
+
+        async def run(self, *_args, **_kwargs):
+            import re, json
+
+            m = re.search(r"\{.*\}", raw, re.DOTALL)
+            return Checklist(**json.loads(m.group(0)))
+
     wrapper = make_agent_async("openai:gpt-4o", "sys", Checklist)
-    wrapper._agent = StubAgent([raw])
+    wrapper._agent = ParsingStubAgent()
     result = await wrapper.run_async("prompt")
     assert isinstance(result, Checklist)
     assert result.items == []


### PR DESCRIPTION
## Summary
- simplify `make_agent` so pydantic models are passed directly to `pydantic_ai.Agent`
- drop automatic JSON cleaning/validation processors
- update unit tests for new behaviour

## Testing
- `ruff format flujo/infra/agents.py tests/unit/test_agents.py`
- `ruff check flujo/infra/agents.py tests/unit/test_agents.py`
- `pytest tests/unit/test_agents.py::test_make_agent_async_no_extra_processors -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615587408c832c88b7b5828418ba80