### PR TITLE
Fix make_agent_async to use pydantic-ai structured output

### DIFF
--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -1404,7 +1404,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             async for item in sub_runner.run_async(initial_input):
                 final_result = item
             if final_result is None:
-                raise OrchestratorError("Final result is None. The pipeline did not produce a valid result.")
+                raise OrchestratorError(
+                    "Final result is None. The pipeline did not produce a valid result."
+                )
             if context is not None:
                 context.__dict__.update(final_result.final_pipeline_context.__dict__)
             return final_result

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -4,23 +4,14 @@ Agent prompt templates and agent factory utilities.
 
 from __future__ import annotations
 
-from typing import (
-    Any,
-    Generic,
-    Optional,
-    Type,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import Any, Generic, Optional, Type
 from pydantic_ai import Agent
-from pydantic import BaseModel as PydanticBaseModel, TypeAdapter
+from pydantic import BaseModel as PydanticBaseModel
 import os
 from flujo.infra.settings import settings
 from flujo.domain.models import Checklist
 from flujo.domain.processors import AgentProcessors
-from flujo.processors import EnforceJsonResponse, StripMarkdownFences
-from types import UnionType
+
 from flujo.domain.agent_protocol import (
     AsyncAgentProtocol,
     AgentInT,
@@ -34,36 +25,6 @@ import asyncio
 from flujo.infra.telemetry import logfire
 import traceback
 from tenacity import AsyncRetrying, RetryError, stop_after_attempt, wait_exponential
-
-
-class PydanticValidationProcessor:
-    """Validate cleaned JSON against the target Pydantic model."""
-
-    def __init__(self, target: Type[Any]):
-        self.target = target
-        self.name = "PydanticValidation"
-
-    async def process(self, data: Any, context: Any | None = None) -> Any:
-        parsed = data
-        if isinstance(data, str):
-            import json
-            import re
-
-            try:
-                parsed = json.loads(data)
-            except Exception:
-                m = re.search(r"\{.*\}|\[.*\]", data, re.DOTALL)
-                if not m:
-                    raise ValueError("No JSON object found in output")
-                parsed = json.loads(m.group(0))
-
-        try:
-            adapter = (
-                self.target if isinstance(self.target, TypeAdapter) else TypeAdapter(self.target)
-            )
-            return adapter.validate_python(parsed)
-        except Exception as e:  # pragma: no cover - defensive
-            raise ValueError(f"Pydantic validation failed: {e}") from e
 
 
 # 1. Prompt Constants
@@ -201,61 +162,16 @@ def make_agent(
 
     final_processors = processors.copy(deep=True) if processors else AgentProcessors()
 
-    def _contains_pydantic(tp: Any) -> bool:
-        if isinstance(tp, TypeAdapter):
-            tp = tp._type
-        origin = get_origin(tp)
-        if origin in {list, dict, Union, UnionType}:
-            return any(_contains_pydantic(arg) for arg in get_args(tp))
-        if isinstance(tp, type) and issubclass(tp, PydanticBaseModel):
-            return True
-        return False
-
-    is_pydantic_output = _contains_pydantic(output_type)
-    agent: Agent[Any, Any]
-
-    if is_pydantic_output:
-        agent_native_output_type = str
-
-        final_processors.output_processors.insert(0, StripMarkdownFences("json"))
-        final_processors.output_processors.insert(1, EnforceJsonResponse())
-
-        final_processors.output_processors.append(PydanticValidationProcessor(output_type))
-
+    try:
         agent = Agent(
             model=model,
             system_prompt=system_prompt,
-            output_type=agent_native_output_type,
+            output_type=output_type,
             tools=tools or [],
+            **kwargs,
         )
-    else:
-        actual_type = output_type
-        try:
-            if hasattr(output_type, "_type"):
-                actual_type = output_type._type
-            elif hasattr(output_type, "__origin__") and output_type.__origin__ is not None:
-                if hasattr(output_type, "__args__") and output_type.__args__:
-                    if output_type.__origin__.__name__ == "TypeAdapter":
-                        actual_type = output_type.__args__[0]
-
-            if hasattr(actual_type, "__name__"):
-                pass
-            elif hasattr(actual_type, "__bases__") and PydanticBaseModel in actual_type.__bases__:
-                pass
-            else:
-                from pydantic import create_model
-
-                create_model("TestModel", value=(actual_type, ...))
-
-        except Exception as e:
-            raise ValueError(f"Error processing output_type '{output_type}': {e}") from e
-
-        agent = Agent(
-            model=model,
-            system_prompt=system_prompt,
-            output_type=actual_type,
-            tools=tools or [],
-        )
+    except (ValueError, TypeError, RuntimeError) as e:  # pragma: no cover - defensive
+        raise ConfigurationError(f"Failed to create pydantic-ai agent: {e}") from e
 
     return agent, final_processors
 

--- a/tests/integration/test_as_step_composition.py
+++ b/tests/integration/test_as_step_composition.py
@@ -66,9 +66,7 @@ async def test_pipeline_of_pipelines_via_as_step() -> None:
 @pytest.mark.asyncio
 async def test_as_step_context_propagation() -> None:
     class Incrementer:
-        async def run(
-            self, data: int, *, pipeline_context: PipelineContext | None = None
-        ) -> dict:
+        async def run(self, data: int, *, pipeline_context: PipelineContext | None = None) -> dict:
             assert pipeline_context is not None
             current = pipeline_context.scratchpad.get("counter", 0)
             return {"scratchpad": {"counter": current + data}}

--- a/tests/unit/test_adapter_step.py
+++ b/tests/unit/test_adapter_step.py
@@ -56,5 +56,6 @@ def example_adapter_step() -> None:
 
 def test_docstring_example() -> None:
     import sys
+
     failures, _ = doctest.testmod(sys.modules[__name__], verbose=False)
     assert failures == 0

--- a/tests/unit/test_dsl.py
+++ b/tests/unit/test_dsl.py
@@ -253,14 +253,8 @@ async def test_step_decorator_matches_from_callable() -> None:
     assert via_decorator.updates_context == via_method.updates_context
     assert via_decorator.config.model_dump() == via_method.config.model_dump()
     assert via_decorator.processors.model_dump() == via_method.processors.model_dump()
-    assert (
-        via_decorator.persist_feedback_to_context
-        == via_method.persist_feedback_to_context
-    )
-    assert (
-        via_decorator.persist_validation_results_to
-        == via_method.persist_validation_results_to
-    )
+    assert via_decorator.persist_feedback_to_context == via_method.persist_feedback_to_context
+    assert via_decorator.persist_validation_results_to == via_method.persist_validation_results_to
     assert await via_decorator.arun(1) == await via_method.arun(1)
 
 


### PR DESCRIPTION
## Summary
- simplify `make_agent` so pydantic models are passed directly to `pydantic_ai.Agent`
- clean up integration tests after formatting
- fix stub agent scoping in tests
- tighten exception handling when creating the agent

## Testing
- `make quality`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_68615587408c832c88b7b5828418ba80