### PR TITLE
Implement automated output repair

### DIFF
--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -5,8 +5,9 @@ Agent prompt templates and agent factory utilities.
 from __future__ import annotations
 
 from typing import Any, Generic, Optional, Type
-from pydantic_ai import Agent
-from pydantic import BaseModel as PydanticBaseModel
+from pydantic_ai import Agent, ModelRetry
+from pydantic import BaseModel as PydanticBaseModel, TypeAdapter, ValidationError
+import json
 import os
 from flujo.infra.settings import settings
 from flujo.domain.models import Checklist
@@ -20,11 +21,26 @@ from flujo.domain.agent_protocol import (
 from flujo.exceptions import (
     OrchestratorRetryError,
     ConfigurationError,
+    OrchestratorError,
 )
 import asyncio
 from flujo.infra.telemetry import logfire
 import traceback
 from tenacity import AsyncRetrying, RetryError, stop_after_attempt, wait_exponential
+from ..processors.repair import DeterministicRepairProcessor
+
+
+def get_raw_output_from_exception(exc: Exception) -> str:
+    """Best-effort extraction of raw output from validation-related exceptions."""
+    if hasattr(exc, "message"):
+        msg = getattr(exc, "message")
+        if isinstance(msg, str):
+            return msg
+    if exc.args:
+        first = exc.args[0]
+        if isinstance(first, str):
+            return first
+    return str(exc)
 
 
 # 1. Prompt Constants
@@ -128,6 +144,36 @@ SELF_IMPROVE_SYS = """You are a debugging assistant specialized in AI pipelines.
     "}\n" \
     """
 
+REPAIR_PROMPT = """
+You are an expert system that corrects malformed JSON to conform to a given Pydantic JSON schema.
+Analyze the original prompt, the failed output, and the validation error. Your goal is to produce a valid JSON object.
+
+If you can fix the JSON, respond with ONLY the corrected raw JSON object.
+If the request or schema is too complex or ambiguous to fix reliably, respond with a JSON object with this exact schema:
+{{"repair_error": true, "reasoning": "A brief explanation of why the original task is difficult."}}
+
+TARGET SCHEMA:
+{json_schema}
+---
+ORIGINAL USER PROMPT:
+{original_prompt}
+---
+FAILED LLM OUTPUT:
+{failed_output}
+---
+PYDANTIC VALIDATION ERROR:
+{validation_error}
+---
+Your response:
+"""
+
+# Short system prompt used for the repair agent. The full instructions are sent
+# as a user message with the relevant context and schema.
+REPAIR_SYS = (
+    "You are an expert system that fixes malformed JSON and returns only the "
+    "corrected JSON or a repair_error object."
+)
+
 
 # 2. Agent Factory
 def make_agent(
@@ -189,6 +235,7 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         timeout: int | None = None,
         model_name: str | None = None,
         processors: Optional[AgentProcessors] = None,
+        auto_repair: bool = True,
     ) -> None:
         if not isinstance(max_retries, int):
             raise TypeError(f"max_retries must be an integer, got {type(max_retries).__name__}.")
@@ -208,6 +255,8 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
         )
         self._model_name: str | None = model_name or getattr(agent, "model", "unknown_model")
         self.processors: AgentProcessors = processors or AgentProcessors()
+        self.auto_repair = auto_repair
+        self.target_output_type = getattr(agent, "output_type", Any)
 
     def _call_agent_with_dynamic_args(self, *args: Any, **kwargs: Any) -> Any:
         return self._agent.run(*args, **kwargs)
@@ -277,6 +326,44 @@ class AsyncAgentWrapper(Generic[AgentInT, AgentOutT], AsyncAgentProtocol[AgentIn
                     return unpacked_output
         except RetryError as e:
             last_exc = e.last_attempt.exception()
+            if isinstance(last_exc, (ValidationError, ModelRetry)) and self.auto_repair:
+                logfire.warn(
+                    f"Agent validation failed. Initiating automated repair. Error: {last_exc}"
+                )
+                raw_output = get_raw_output_from_exception(last_exc)
+                try:
+                    cleaner = DeterministicRepairProcessor()
+                    cleaned = await cleaner.process(raw_output)
+                    validated = TypeAdapter(self.target_output_type).validate_json(cleaned)
+                    logfire.info("Deterministic repair successful.")
+                    return validated
+                except Exception:
+                    logfire.warn("Deterministic repair failed. Escalating to LLM repair.")
+                try:
+                    schema = TypeAdapter(self.target_output_type).json_schema()
+                    prompt_data = {
+                        "json_schema": json.dumps(schema, ensure_ascii=False),
+                        "original_prompt": str(args[0]) if args else "",
+                        "failed_output": raw_output,
+                        "validation_error": str(last_exc),
+                    }
+                    repaired_str = await get_repair_agent().run(REPAIR_PROMPT.format(**prompt_data))
+                    try:
+                        feedback = json.loads(repaired_str)
+                        if isinstance(feedback, dict) and feedback.get("repair_error"):
+                            reason = feedback.get("reasoning", "No reasoning provided.")
+                            raise OrchestratorError(
+                                f"Repair agent could not fix output. Reasoning: {reason}"
+                            )
+                    except json.JSONDecodeError:
+                        pass
+                    final_obj = TypeAdapter(self.target_output_type).validate_json(repaired_str)
+                    logfire.info("LLM-based repair successful.")
+                    return final_obj
+                except Exception as repair_err:
+                    raise OrchestratorError(
+                        "Agent validation failed and auto-repair also failed."
+                    ) from repair_err
             raise OrchestratorRetryError(
                 f"Agent '{self._model_name}' failed after {self._max_retries} attempts. Last error: {type(last_exc).__name__}({last_exc})"
             ) from last_exc
@@ -301,6 +388,7 @@ def make_agent_async(
     max_retries: int = 3,
     timeout: int | None = None,
     processors: Optional[AgentProcessors] = None,
+    auto_repair: bool = True,
 ) -> AsyncAgentWrapper[Any, Any]:
     """
     Creates a pydantic_ai.Agent and returns an AsyncAgentWrapper exposing .run_async.
@@ -317,6 +405,7 @@ def make_agent_async(
         timeout=timeout,
         model_name=model,
         processors=final_processors,
+        auto_repair=auto_repair,
     )
 
 
@@ -391,6 +480,21 @@ try:
     self_improvement_agent: AsyncAgentProtocol[Any, str] = make_self_improvement_agent()
 except ConfigurationError:  # pragma: no cover - config may be missing in tests
     self_improvement_agent = NoOpReflectionAgent()
+
+_repair_agent: AsyncAgentWrapper[Any, str] | None = None
+
+
+def get_repair_agent() -> AsyncAgentWrapper[Any, str]:
+    """Lazily create the internal repair agent."""
+    global _repair_agent
+    if _repair_agent is None:
+        _repair_agent = make_agent_async(
+            "openai:gpt-4o",
+            REPAIR_SYS,
+            str,
+            auto_repair=False,
+        )
+    return _repair_agent
 
 
 class LoggingReviewAgent(AsyncAgentProtocol[Any, Any]):

--- a/flujo/processors/__init__.py
+++ b/flujo/processors/__init__.py
@@ -5,6 +5,7 @@ from .common import (
     EnforceJsonResponse,
     SerializePydantic,
 )
+from .repair import DeterministicRepairProcessor
 
 __all__ = [
     "Processor",
@@ -12,4 +13,5 @@ __all__ = [
     "StripMarkdownFences",
     "EnforceJsonResponse",
     "SerializePydantic",
+    "DeterministicRepairProcessor",
 ]

--- a/flujo/processors/repair.py
+++ b/flujo/processors/repair.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import ast
+import json
+import re
+from typing import Any, Final
+
+
+class DeterministicRepairProcessor:
+    """Tier-1 deterministic fixer for malformed JSON emitted by LLMs."""
+
+    _RE_CODE_FENCE: Final = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.I | re.M)
+    _RE_LINE_COMMENT: Final = re.compile(r"(^|[^\S\r\n])//.*?$", re.M)
+    _RE_HASH_COMMENT: Final = re.compile(r"(^|[^\S\r\n])#.*?$", re.M)
+    _RE_BLOCK_COMMENT: Final = re.compile(r"/\*.*?\*/", re.S)
+    _RE_TRAILING_COMMA: Final = re.compile(r",\s*([}\]])")
+    _RE_SINGLE_QUOTE: Final = re.compile(r"(?<!\\)'([^'\\]*(?:\\.[^'\\]*)*)'")
+    _RE_PY_LITERALS: Final = re.compile(r"\b(None|True|False)\b")
+    _RE_UNQUOTED_KEY: Final = re.compile(r"([{\[,]\s*)([A-Za-z_][\w\-]*)(\s*:)")
+
+    name: str = "DeterministicRepair"
+
+    async def process(self, raw_output: str | bytes | Any) -> str:
+        if isinstance(raw_output, bytes):
+            raw_output = raw_output.decode()
+        if not isinstance(raw_output, str):
+            raise ValueError("DeterministicRepair expects a str or bytes payload.")
+
+        if self._is_json(raw_output):
+            return self._canonical(raw_output)
+
+        candidate = raw_output.strip()
+
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(candidate)
+            return self._canonical(obj)
+        except json.JSONDecodeError:
+            pass
+
+        candidate = self._RE_CODE_FENCE.sub("", candidate).strip()
+        if self._is_json(candidate):
+            return self._canonical(candidate)
+
+        candidate = self._RE_BLOCK_COMMENT.sub("", candidate)
+        candidate = self._RE_LINE_COMMENT.sub(r"\1", candidate)
+        candidate = self._RE_HASH_COMMENT.sub(r"\1", candidate)
+        if self._is_json(candidate):
+            return self._canonical(candidate)
+
+        candidate = self._RE_TRAILING_COMMA.sub(r"\1", candidate)
+        if self._is_json(candidate):
+            return self._canonical(candidate)
+
+        candidate = self._balance(candidate)
+        if self._is_json(candidate):
+            return self._canonical(candidate)
+
+        candidate = self._repair_literals_and_quotes(candidate)
+        if self._is_json(candidate):
+            return self._canonical(candidate)
+
+        try:
+            obj = ast.literal_eval(candidate)
+            return self._canonical(obj)
+        except Exception:
+            pass
+
+        raise ValueError("DeterministicRepairProcessor: unable to repair payload.")
+
+    @staticmethod
+    def _is_json(text: str) -> bool:
+        try:
+            json.loads(text)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _canonical(data: Any) -> str:
+        obj = data if not isinstance(data, str) else json.loads(data)
+        return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+
+    @classmethod
+    def _balance(cls, text: str) -> str:
+        opens, closes = text.count("{"), text.count("}")
+        if opens > closes:
+            text += "}" * (opens - closes)
+        elif closes > opens:
+            excess = closes - opens
+            while excess > 0 and text.endswith("}"):
+                text = text[:-1]
+                excess -= 1
+        diff = text.count("{") - text.count("}")
+        if diff > 0:
+            text += "}" * diff
+
+        opens, closes = text.count("["), text.count("]")
+        if opens > closes:
+            text += "]" * (opens - closes)
+        elif closes > opens:
+            excess = closes - opens
+            while excess > 0 and text.endswith("]"):
+                text = text[:-1]
+                excess -= 1
+        diff = text.count("[") - text.count("]")
+        if diff > 0:
+            text += "]" * diff
+        return text
+
+    @classmethod
+    def _repair_literals_and_quotes(cls, text: str) -> str:
+        text = cls._RE_PY_LITERALS.sub(
+            lambda m: {"None": "null", "True": "true", "False": "false"}[m.group(1)],
+            text,
+        )
+        text = cls._RE_SINGLE_QUOTE.sub(lambda m: '"' + m.group(1) + '"', text)
+        text = cls._RE_UNQUOTED_KEY.sub(r'\1"\2"\3', text)
+        return text

--- a/tests/unit/test_auto_repair.py
+++ b/tests/unit/test_auto_repair.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import BaseModel, TypeAdapter
+from flujo.processors.repair import DeterministicRepairProcessor
+from flujo.infra.agents import AsyncAgentWrapper
+from flujo.infra import agents as agents_mod
+
+
+class Model(BaseModel):
+    value: int
+
+
+class FailAgent:
+    output_type = Model
+
+    async def run(self, *_args, **_kwargs):
+        TypeAdapter(Model).validate_json('{"value":1} trailing')
+
+
+class FailAgentEscalate:
+    output_type = Model
+
+    async def run(self, *_args, **_kwargs):
+        TypeAdapter(Model).validate_json("bad")
+
+
+@pytest.mark.asyncio
+async def test_deterministic_processor_cleans_trailing_text() -> None:
+    proc = DeterministicRepairProcessor()
+    cleaned = await proc.process('{"a":1} trailing')
+    assert cleaned == '{"a":1}'
+
+
+@pytest.mark.asyncio
+async def test_async_agent_wrapper_deterministic_repair(monkeypatch) -> None:
+    wrapper = AsyncAgentWrapper(FailAgent(), max_retries=1, auto_repair=True)
+    monkeypatch.setattr(
+        agents_mod,
+        "get_raw_output_from_exception",
+        lambda exc: '{"value":1} trailing',
+    )
+    result = await wrapper.run_async("prompt")
+    assert result.value == 1
+
+
+@pytest.mark.asyncio
+async def test_async_agent_wrapper_llm_repair(monkeypatch) -> None:
+    wrapper = AsyncAgentWrapper(FailAgentEscalate(), max_retries=1, auto_repair=True)
+    monkeypatch.setattr(
+        agents_mod,
+        "get_raw_output_from_exception",
+        lambda exc: "bad",
+    )
+
+    async def fail_process(self, _raw):
+        raise ValueError("fail")
+
+    class DummyRepairAgent:
+        async def run(self, *_a, **_k):
+            return '{"value":2}'
+
+    monkeypatch.setattr(DeterministicRepairProcessor, "process", fail_process)
+    monkeypatch.setattr(agents_mod, "get_repair_agent", lambda: DummyRepairAgent())
+
+    result = await wrapper.run_async("prompt")
+    assert result.value == 2


### PR DESCRIPTION
## Summary
- add DeterministicRepairProcessor for cleaning malformed JSON
- expand AsyncAgentWrapper with optional `auto_repair` capability
- implement lazy repair agent via `get_repair_agent`
- provide tests for deterministic and LLM-based repairs
- fix repair agent system prompt and brace balancing

## Testing
- `python -m hatch run quality`
- `python -m hatch run test`
- `python -m hatch run cov`


------
https://chatgpt.com/codex/tasks/task_e_686165108510832ca65c98de0c93899a