### PR TITLE
Add loop strategy guide and context tips

### DIFF
--- a/docs/guides/choosing_your_loop.md
+++ b/docs/guides/choosing_your_loop.md
@@ -1,0 +1,85 @@
+# Guide: Choosing Your Looping Strategy
+
+Flujo offers two looping patterns for different kinds of tasks:
+
+- **`Step.loop_until`** for deterministic iteration of a fixed pipeline body.
+- **`AgenticLoop`** for explorative workflows where a planner decides what to do next.
+
+This guide explains when to use each and shows how to migrate from one to the other.
+
+## When to Use `Step.loop_until` (The State Machine)
+
+`Step.loop_until` is ideal when you repeatedly run the same sub-pipeline until a
+condition is met. Think of it like a `while` loop. The loop body is constant and
+you decide when to exit based on the last output (and optionally the pipeline
+context).
+
+Typical use cases include iterative refinement of a single artifact or polling
+for a result.
+
+```python
+loop_step = Step.loop_until(
+    name="IterativeRefinement",
+    loop_body_pipeline=refine_pipeline,
+    exit_condition_callable=lambda last, ctx: last.is_done,
+)
+```
+
+You have full control over how iteration inputs are mapped and can inspect or
+update the shared context on each turn.
+
+## When to Use `AgenticLoop` (The Explorer)
+
+`AgenticLoop` shines when your workflow requires dynamic decision making or tool
+use. A planner agent determines which command to run next, such as calling a
+helper agent, running Python code, asking a human, or finishing the loop.
+
+This pattern is great for research or data gathering tasks where the exact steps
+aren't known ahead of time.
+
+```python
+agentic_loop = AgenticLoop(planner_agent=planner, agent_registry={"tool": tool})
+result = agentic_loop.run("Find information about Python")
+```
+
+The loop continues until the planner issues a `FinishCommand`. Every command is
+logged to `PipelineContext.command_log` for traceability.
+
+## Migration Guide: Refactoring a `LoopStep` to an `AgenticLoop`
+
+The snippet below shows a simplified before/after comparison.
+
+### Before: Manual `LoopStep`
+
+```python
+# --- Build the loop body ---
+body = Step("Decide", planner_agent) >> Step("Execute", execute_command)
+
+# --- Manual exit condition ---
+loop_step = Step.loop_until(
+    name="ExplorationLoop",
+    loop_body_pipeline=body,
+    exit_condition_callable=lambda last, ctx: isinstance(last, FinishCommand),
+    iteration_input_mapper=lambda result, ctx, i: {
+        "last_command_result": result,
+        "goal": ctx.initial_prompt if ctx else "",
+    },
+)
+```
+
+### After: `AgenticLoop.as_step()`
+
+```python
+loop = AgenticLoop(
+    planner_agent=planner_agent,
+    agent_registry={"execute": execute_command},
+).as_step(name="ExplorationLoop")
+
+pipeline = loop
+runner = Flujo(pipeline)
+result = runner.run("Explore this topic")
+```
+
+`AgenticLoop` removes boilerplate and automatically handles the planner/executor
+interaction. The context keeps a command log so you can inspect the agent's
+decisions.

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -5,3 +5,34 @@
 A context instance is created for every call to `run()` and is available to steps, agents, and plugins that declare either a `context` or `pipeline_context` parameter. If both are present, `context` is prioritized for backward compatibility. This ensures compatibility with both legacy and modern code.
 
 For complete details on implementing context aware components see the [Stateful Pipelines](typing_guide.md#stateful-pipelines-the-contextaware-protocols) section of the Typing Guide.
+
+## Best Practices for Custom Context Models
+
+To create your own context model, **inherit from `flujo.domain.models.PipelineContext`**.
+This base class provides important built-in fields managed by the engine:
+
+- `initial_prompt: str` – automatically populated with the first input of each `run()` call.
+- `scratchpad: Dict[str, Any]` – a general-purpose dictionary for transient state.
+- `hitl_history: List[HumanInteraction]` – records all human-in-the-loop interactions.
+- `command_log: List[ExecutedCommandLog]` – tracks commands issued by an `AgenticLoop`.
+
+A minimal custom context looks like this:
+
+```python
+from flujo.domain.models import PipelineContext
+from pydantic import Field
+
+class MyDiscoveryContext(PipelineContext):
+    frontier: list[int] = Field(default_factory=list)
+    seen_ids: set[int] = Field(default_factory=set)
+
+runner = Flujo(
+    my_pipeline,
+    context_model=MyDiscoveryContext,
+    initial_context_data={"frontier": [123]},
+)
+runner.run("My first input")
+```
+
+The runner automatically fills `initial_prompt` when you call `run()`. You only
+pass data for your custom fields.

--- a/examples/15_agentic_loop_migration.py
+++ b/examples/15_agentic_loop_migration.py
@@ -1,0 +1,61 @@
+"""Refactoring a LoopStep workflow to AgenticLoop.as_step().
+
+This script reworks the text refinement example from ``07_loop_step.py``
+using ``AgenticLoop``. The planner decides whether to run the ``editor``
+agent again or finish based on the latest result.
+"""
+
+import asyncio
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+from flujo import Flujo, Pipeline, Step
+from flujo.recipes import AgenticLoop
+from flujo.domain.commands import FinishCommand, RunAgentCommand, AgentCommand
+from flujo.domain.models import PipelineContext
+
+
+class TextEdit(BaseModel):
+    text: str
+    is_good_enough: bool = False
+
+
+async def editor_agent(text: str) -> TextEdit:
+    """Simple editing agent that lengthens short text."""
+    if len(text) < 30:
+        text += " It is known for its simple syntax."
+    return TextEdit(text=text, is_good_enough=len(text) >= 30)
+
+
+async def planner_agent(data: Dict[str, Any]) -> AgentCommand:
+    """Planner that decides whether to keep editing or finish."""
+    last: TextEdit | None = data.get("last_command_result")
+    goal: str = data.get("goal", "")
+    if last is None or not last.is_good_enough:
+        return RunAgentCommand(agent_name="editor", input_data=goal if last is None else last.text)
+    return FinishCommand(final_answer=last.text)
+
+
+loop_step = AgenticLoop(
+    planner_agent=planner_agent,
+    agent_registry={"editor": editor_agent},
+).as_step(name="RefineText")
+
+pipeline = Pipeline.from_step(loop_step)
+runner = Flujo(pipeline, context_model=PipelineContext)
+
+
+async def main() -> None:
+    print("🚀 Running AgenticLoop refinement...\n")
+    result = None
+    async for item in runner.run_async("Python is a language."):
+        result = item
+    assert result is not None
+    final_ctx = result.final_pipeline_context
+    assert final_ctx is not None
+    print("\n✅ Final answer:", final_ctx.command_log[-1].execution_result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@
 | **11_stateful_hitl.py** | Multi-turn correction loop with simulated HITL. |
 | **12_using_resources.py** | Dependency injection via AppResources. |
 | **13_lifecycle_hooks.py** | Observing pipeline events with hooks. |
+| **15_agentic_loop_migration.py** | Refactoring a LoopStep workflow using AgenticLoop. |
 
 Each script is standalone – activate your virtualenv, set `OPENAI_API_KEY`, then:
 

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -1028,9 +1028,15 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 logfire.error(
                     f"Pipeline context initialization failed for model {self.context_model.__name__}: {e}"
                 )
-                raise PipelineContextInitializationError(
-                    f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data. Validation errors:\n{e}"
-                ) from e
+                msg = (
+                    f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data."
+                )
+                if any(err.get("loc") == ("initial_prompt",) for err in e.errors()):
+                    msg += (
+                        " `initial_prompt` field required. Your custom context model must inherit from flujo.domain.models.PipelineContext."
+                    )
+                msg += f" Validation errors:\n{e}"
+                raise PipelineContextInitializationError(msg) from e
 
         else:
             current_pipeline_context_instance = cast(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ nav:
     - 'Adapter Step': cookbook/adapter_step.md
     - 'Serialize Pydantic': cookbook/serialize_pydantic.md
     - 'Agentic Loop': recipes/agentic_loop.md
+  - Guides:
+    - 'Choosing Your Loop': guides/choosing_your_loop.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
     - 'v0.3.8': migration/v0.3.8.md


### PR DESCRIPTION
## Summary
- document how to choose between `LoopStep` and `AgenticLoop`
- describe best practices for custom pipeline context models
- add example demonstrating a migration from `LoopStep` to `AgenticLoop`
- improve context initialization error message
- include new guide in navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686171f23ba0832cab81a9dfe5c273a0