### PR TITLE
Implement robust context inheritance for pipeline steps

### DIFF
--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -35,6 +35,7 @@ from ..exceptions import (
     PausedException,
     MissingAgentError,
     TypeMismatchError,
+    ContextInheritanceError,
 )
 from ..domain.pipeline_dsl import (
     Pipeline,
@@ -111,6 +112,20 @@ def _accepts_param(func: Callable[..., Any], param: str) -> Optional[bool]:
 
     cache[param] = result
     return result
+
+
+def _extract_missing_fields(cause: Any) -> list[str]:
+    """Return list of missing field names from a Pydantic ValidationError."""
+    missing_fields: list[str] = []
+    if cause is not None and hasattr(cause, "errors"):
+        for err in cause.errors():
+            if err.get("type") == "missing":
+                loc = err.get("loc") or []
+                if isinstance(loc, (list, tuple)) and loc:
+                    field = loc[0]
+                    if isinstance(field, str):
+                        missing_fields.append(field)
+    return missing_fields
 
 
 def _types_compatible(a: Any, b: Any) -> bool:
@@ -1028,13 +1043,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 logfire.error(
                     f"Pipeline context initialization failed for model {self.context_model.__name__}: {e}"
                 )
-                msg = (
-                    f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data."
-                )
+                msg = f"Failed to initialize pipeline context with model {self.context_model.__name__} and initial data."
                 if any(err.get("loc") == ("initial_prompt",) for err in e.errors()):
-                    msg += (
-                        " `initial_prompt` field required. Your custom context model must inherit from flujo.domain.models.PipelineContext."
-                    )
+                    msg += " `initial_prompt` field required. Your custom context model must inherit from flujo.domain.models.PipelineContext."
                 msg += f" Validation errors:\n{e}"
                 raise PipelineContextInitializationError(msg) from e
 
@@ -1374,7 +1385,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         self._set_final_context(paused_result, cast(Optional[ContextT], ctx))
         return paused_result
 
-    def as_step(self, name: str, **kwargs: Any) -> Step[RunnerInT, PipelineResult[ContextT]]:
+    def as_step(
+        self, name: str, *, inherit_context: bool = True, **kwargs: Any
+    ) -> Step[RunnerInT, PipelineResult[ContextT]]:
         """Return this ``Flujo`` runner as a composable :class:`Step`.
 
         Parameters
@@ -1396,24 +1409,54 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             context: BaseModel | None = None,
             resources: AppResources | None = None,
         ) -> PipelineResult[ContextT]:
-            init_ctx = context.model_dump() if context is not None else self.initial_context_data
-            sub_runner = Flujo(
-                self.pipeline,
-                context_model=self.context_model,
-                initial_context_data=init_ctx,
-                resources=resources or self.resources,
-                usage_limits=self.usage_limits,
-                hooks=self.hooks,
-                backend=self.backend,
-            )
+            initial_sub_context_data: Dict[str, Any] = {}
+            if inherit_context and context is not None:
+                initial_sub_context_data = context.model_dump()
+            else:
+                initial_sub_context_data = copy.deepcopy(self.initial_context_data)
+
+            if "initial_prompt" not in initial_sub_context_data:
+                initial_sub_context_data["initial_prompt"] = str(initial_input)
+
+            try:
+                sub_runner = Flujo(
+                    self.pipeline,
+                    context_model=self.context_model,
+                    initial_context_data=initial_sub_context_data,
+                    resources=resources or self.resources,
+                    usage_limits=self.usage_limits,
+                    hooks=self.hooks,
+                    backend=self.backend,
+                )
+            except PipelineContextInitializationError as e:
+                cause = getattr(e, "__cause__", None)
+                missing_fields = _extract_missing_fields(cause)
+                raise ContextInheritanceError(
+                    missing_fields=missing_fields,
+                    parent_context_keys=list(context.model_dump().keys()) if context else [],
+                    child_model_name=self.context_model.__name__
+                    if self.context_model
+                    else "Unknown",
+                ) from e
             final_result: PipelineResult[ContextT] | None = None
-            async for item in sub_runner.run_async(initial_input):
-                final_result = item
+            try:
+                async for item in sub_runner.run_async(initial_input):
+                    final_result = item
+            except PipelineContextInitializationError as e:
+                cause = getattr(e, "__cause__", None)
+                missing_fields = _extract_missing_fields(cause)
+                raise ContextInheritanceError(
+                    missing_fields=missing_fields,
+                    parent_context_keys=list(context.model_dump().keys()) if context else [],
+                    child_model_name=self.context_model.__name__
+                    if self.context_model
+                    else "Unknown",
+                ) from e
             if final_result is None:
                 raise OrchestratorError(
                     "Final result is None. The pipeline did not produce a valid result."
                 )
-            if context is not None:
+            if inherit_context and context is not None and final_result.final_pipeline_context:
                 context.__dict__.update(final_result.final_pipeline_context.__dict__)
             return final_result
 

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -56,6 +56,22 @@ class PipelineContextInitializationError(OrchestratorError):
     pass
 
 
+class ContextInheritanceError(OrchestratorError):
+    """Raised when inheriting context for a nested pipeline fails."""
+
+    def __init__(
+        self, missing_fields: list[str], parent_context_keys: list[str], child_model_name: str
+    ) -> None:
+        msg = (
+            f"Failed to inherit context for {child_model_name}. Missing required fields: "
+            f"{', '.join(missing_fields)}. Parent context provided: {', '.join(parent_context_keys)}."
+        )
+        super().__init__(msg)
+        self.missing_fields = missing_fields
+        self.parent_context_keys = parent_context_keys
+        self.child_model_name = child_model_name
+
+
 class UsageLimitExceededError(OrchestratorError):
     """Raised when a pipeline run exceeds its defined usage limits."""
 

--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -13,10 +13,14 @@ from ..domain.commands import (
     FinishCommand,
     ExecutedCommandLog,
 )
-from ..exceptions import PausedException
+from ..exceptions import (
+    PausedException,
+    PipelineContextInitializationError,
+    ContextInheritanceError,
+)
 from ..domain.models import PipelineResult, PipelineContext
 from ..domain.pipeline_dsl import Step, LoopStep
-from ..application.flujo_engine import Flujo, _accepts_param
+from ..application.flujo_engine import Flujo, _accepts_param, _extract_missing_fields
 
 _command_adapter: TypeAdapter[AgentCommand] = TypeAdapter(AgentCommand)
 
@@ -92,7 +96,9 @@ class AgenticLoop:
         runner = Flujo(self._pipeline, context_model=PipelineContext)
         return await runner.resume_async(paused_result, human_input)
 
-    def as_step(self, name: str, **kwargs: Any) -> Step[str, PipelineResult[PipelineContext]]:
+    def as_step(
+        self, name: str, *, inherit_context: bool = True, **kwargs: Any
+    ) -> Step[str, PipelineResult[PipelineContext]]:
         """Return this loop as a composable :class:`Step`.
 
         Parameters
@@ -115,26 +121,47 @@ class AgenticLoop:
             context: PipelineContext | None = None,
             resources: AppResources | None = None,
         ) -> PipelineResult[PipelineContext]:
-            runner = Flujo(
-                self._pipeline,
-                context_model=PipelineContext,
-                resources=resources,
-            )
+            init_ctx_data: Dict[str, Any] = {}
+            if inherit_context and context is not None:
+                init_ctx_data = context.model_dump()
+            if "initial_prompt" not in init_ctx_data:
+                init_ctx_data["initial_prompt"] = initial_goal
 
-            init_ctx_data = context.model_dump() if context is not None else {}
-            init_ctx_data["initial_prompt"] = initial_goal
+            try:
+                runner = Flujo(
+                    self._pipeline,
+                    context_model=PipelineContext,
+                    resources=resources,
+                    initial_context_data=init_ctx_data,
+                )
+            except PipelineContextInitializationError as e:
+                cause = getattr(e, "__cause__", None)
+                missing_fields = _extract_missing_fields(cause)
+                raise ContextInheritanceError(
+                    missing_fields=missing_fields,
+                    parent_context_keys=list(context.model_dump().keys()) if context else [],
+                    child_model_name=PipelineContext.__name__,
+                ) from e
 
             final_result: PipelineResult[PipelineContext] | None = None
-            async for item in runner.run_async(
-                {"last_command_result": None, "goal": initial_goal},
-                initial_context_data=init_ctx_data,
-            ):
-                final_result = item
+            try:
+                async for item in runner.run_async(
+                    {"last_command_result": None, "goal": initial_goal}
+                ):
+                    final_result = item
+            except PipelineContextInitializationError as e:
+                cause = getattr(e, "__cause__", None)
+                missing_fields = _extract_missing_fields(cause)
+                raise ContextInheritanceError(
+                    missing_fields=missing_fields,
+                    parent_context_keys=list(context.model_dump().keys()) if context else [],
+                    child_model_name=PipelineContext.__name__,
+                ) from e
             if final_result is None:
                 raise ValueError(
                     "The final result of the pipeline execution is None. Ensure the pipeline produces a valid result."
                 )
-            if context is not None:
+            if inherit_context and context is not None:
                 context.__dict__.update(final_result.final_pipeline_context.__dict__)
             return final_result
 


### PR DESCRIPTION
## Summary
- improve `as_step` in `Flujo` and `AgenticLoop` with `inherit_context` option
- ensure `initial_prompt` is inherited or set from input
- merge child context back to parent and expose `ContextInheritanceError`
- test context inheritance behaviour and isolation
- fix parsing of missing fields when context inheritance fails
- deduplicate missing field parsing logic

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_68618850adf8832cb83c3d81dea962a4