### PR TITLE
Add strict validation pass-through option

### DIFF
--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -253,9 +253,11 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
         processors: Optional[AgentProcessors] = None,
         persist_feedback_to_context: Optional[str] = None,
         persist_validation_results_to: Optional[str] = None,
+        strict: bool = True,
         **config: Any,
     ) -> "Step[Any, Any]":
         """Construct a validation step using the provided agent."""
+        meta = {"is_validation_step": True, "strict_validation": strict}
         return cls(
             "validate",
             agent,
@@ -263,6 +265,7 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
             processors=processors,
             persist_feedback_to_context=persist_feedback_to_context,
             persist_validation_results_to=persist_validation_results_to,
+            meta=meta,
             **config,
         )
 

--- a/tests/integration/test_strict_validation.py
+++ b/tests/integration/test_strict_validation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from flujo.domain import Step
+from flujo.application.flujo_engine import Flujo
+from flujo.validation import BaseValidator
+from flujo.domain.validation import ValidationResult
+from flujo.testing.utils import StubAgent, gather_result
+
+
+class FailValidator(BaseValidator):
+    async def validate(self, output_to_check: str, *, context=None) -> ValidationResult:
+        return ValidationResult(is_valid=False, feedback="bad", validator_name=self.name)
+
+
+@pytest.mark.asyncio
+async def test_non_strict_validation_pass_through() -> None:
+    agent = StubAgent(["ok"])
+    step = Step.validate_step(agent, validators=[FailValidator()], strict=False)
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    hist = result.step_history[0]
+    assert hist.success is True
+    assert hist.output == "ok"
+    assert hist.metadata_ and hist.metadata_["validation_passed"] is False
+
+
+@pytest.mark.asyncio
+async def test_strict_validation_drops_output() -> None:
+    agent = StubAgent(["bad"])
+    step = Step.validate_step(agent, validators=[FailValidator()], strict=True)
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    hist = result.step_history[0]
+    assert hist.success is False
+    assert hist.output is None
+
+
+@pytest.mark.asyncio
+async def test_regular_step_keeps_output_on_validation_failure() -> None:
+    agent = StubAgent(["value"])
+    step = Step("regular", agent, validators=[FailValidator()])
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    hist = result.step_history[0]
+    assert hist.success is False
+    assert hist.output == "value"


### PR DESCRIPTION
## Summary
- allow non-strict validation in `Step.validate_step`
- preserve original output when strict=False but still flag metadata
- ensure strictness only applies to dedicated validation steps
- add integration tests for strict vs non-strict validation

## Testing
- `make test`
- `make cov`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_6861b0e08858832cb4dd028f69cf2ec4