### PR TITLE
Implement ParallelStep merge strategies

### DIFF
--- a/docs/cookbook/parallel_research_agent.md
+++ b/docs/cookbook/parallel_research_agent.md
@@ -1,0 +1,44 @@
+# Cookbook: Parallel Research Agent
+
+This recipe demonstrates how to fan out multiple research tasks in parallel and
+merge their findings back into a shared context. It uses the new
+`merge_strategy` parameter on `Step.parallel`.
+
+```python
+from flujo import Flujo, Step
+from flujo.domain import MergeStrategy, PipelineContext
+
+
+class ResearchCtx(PipelineContext):
+    pass
+
+
+class ResearchAgent:
+    def __init__(self, topic: str) -> None:
+        self.topic = topic
+
+    async def run(self, data: str, *, context: ResearchCtx | None = None) -> str:
+        # Imagine an API call here
+        context.scratchpad[self.topic] = f"findings about {self.topic}"
+        return f"research_{self.topic}"
+
+
+branches = {
+    "a": Step.model_validate({"name": "a", "agent": ResearchAgent("ai")}),
+    "b": Step.model_validate({"name": "b", "agent": ResearchAgent("ml")}),
+}
+
+parallel = Step.parallel(
+    name="research",
+    branches=branches,
+    merge_strategy=MergeStrategy.MERGE_SCRATCHPAD,
+)
+
+runner = Flujo(parallel, context_model=ResearchCtx)
+result = runner.run("start", initial_context_data={"initial_prompt": "goal"})
+print(result.final_pipeline_context.scratchpad)
+```
+
+Running this pipeline yields a scratchpad dictionary containing the findings
+from both branches.
+

--- a/docs/modular_workflows.md
+++ b/docs/modular_workflows.md
@@ -76,4 +76,8 @@ print(result.step_history[-1].output)  # {"a": 1, "b": 2}
 print(result.final_pipeline_context.val)  # 0
 ```
 
+`Step.parallel` also supports merging branch contexts and flexible failure
+handling via the `merge_strategy` and `on_branch_failure` parameters. See
+[`pipeline_dsl.md`](pipeline_dsl.md) for details.
+
 See [pipeline_dsl.md](pipeline_dsl.md) for general DSL usage.

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -649,6 +649,34 @@ This feature provides significant performance improvements when:
 - You have many parallel branches
 - Each branch only needs a subset of the context data
 
+### Context Merging and Failure Handling
+
+`Step.parallel` can merge context updates from its branches back into the main
+pipeline context. Use the `merge_strategy` parameter to control how merging is
+performed and `on_branch_failure` to define failure behavior.
+
+```python
+from flujo import Step
+from flujo.domain import MergeStrategy, BranchFailureStrategy
+
+parallel = Step.parallel(
+    name="parallel_merge",
+    branches={"a": Pipeline.from_step(Step("a", a_agent)), "b": Pipeline.from_step(Step("b", b_agent))},
+    merge_strategy=MergeStrategy.MERGE_SCRATCHPAD,
+    on_branch_failure=BranchFailureStrategy.IGNORE,
+)
+```
+
+Available `MergeStrategy` values:
+
+- `NO_MERGE` (default) – discard branch context modifications.
+- `OVERWRITE` – last successful branch context wins.
+- `MERGE_SCRATCHPAD` – merge `scratchpad` dictionaries from all successful branches.
+
+`on_branch_failure` accepts `PROPAGATE` (default) or `IGNORE`. When set to
+`IGNORE`, the parallel step succeeds as long as one branch succeeds and the
+output dictionary includes the failed `StepResult` objects for inspection.
+
 ### Proactive Governor Cancellation
 
 Parallel steps now support proactive cancellation when usage limits are breached. When any branch exceeds cost or token limits, sibling branches are immediately cancelled to prevent unnecessary resource consumption:

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -43,6 +43,8 @@ from ..domain.pipeline_dsl import (
     LoopStep,
     ConditionalStep,
     ParallelStep,
+    MergeStrategy,
+    BranchFailureStrategy,
     HumanInTheLoopStep,
     BranchKey,
 )
@@ -582,6 +584,8 @@ async def _execute_parallel_step_logic(
             branch_res.feedback = f"Branch execution error: {e}"
             branch_res.output = None
 
+        branch_res.branch_context = ctx_copy
+
         outputs[key] = branch_res.output
         branch_results[key] = branch_res
 
@@ -622,14 +626,57 @@ async def _execute_parallel_step_logic(
 
     result.latency_s = time.monotonic() - start
 
-    # Aggregate results from all branches
+    # Aggregate usage metrics
     for br in branch_results.values():
         result.cost_usd += br.cost_usd
         result.token_counts += br.token_counts
-        if not br.success and result.feedback is None:
-            result.feedback = f"Branch failed: {br.feedback}" if br.feedback else "Branch failed"
 
-    result.success = all(br.success for br in branch_results.values())
+    succeeded_branches: Dict[str, StepResult] = {}
+    failed_branches: Dict[str, StepResult] = {}
+    for name, br in branch_results.items():
+        if br.success:
+            succeeded_branches[name] = br
+        else:
+            failed_branches[name] = br
+
+    # --- 1. Handle Failures ---
+    if failed_branches and parallel_step.on_branch_failure == BranchFailureStrategy.PROPAGATE:
+        result.success = False
+        fail_name = next(iter(failed_branches))
+        result.feedback = f"Branch '{fail_name}' failed. Propagating failure."
+        result.output = {
+            **{k: v.output for k, v in succeeded_branches.items()},
+            **{k: v for k, v in failed_branches.items()},
+        }
+        result.attempts = 1
+        return result
+
+    # --- 2. Handle Merging for Successful Branches ---
+    if parallel_step.merge_strategy != MergeStrategy.NO_MERGE and context is not None:
+        if callable(parallel_step.merge_strategy):
+            for res in succeeded_branches.values():
+                if res.branch_context is not None:
+                    parallel_step.merge_strategy(context, res.branch_context)
+        elif parallel_step.merge_strategy == MergeStrategy.OVERWRITE:
+            if succeeded_branches:
+                last_ctx = list(succeeded_branches.values())[-1].branch_context
+                if last_ctx is not None:
+                    context.__dict__.update(last_ctx.__dict__)
+        elif parallel_step.merge_strategy == MergeStrategy.MERGE_SCRATCHPAD:
+            if hasattr(context, "scratchpad"):
+                for res in succeeded_branches.values():
+                    bc = res.branch_context
+                    if bc is not None and hasattr(bc, "scratchpad"):
+                        context.scratchpad.update(bc.scratchpad)
+
+    # --- 3. Finalize the Result ---
+    result.success = True
+    final_output = {k: v.output for k, v in succeeded_branches.items()}
+    if parallel_step.on_branch_failure == BranchFailureStrategy.IGNORE:
+        final_output.update(failed_branches)
+
+    result.output = final_output
+    result.attempts = 1
 
     # Final usage limit check (for backward compatibility and safety)
     if usage_limits is not None:
@@ -658,8 +705,6 @@ async def _execute_parallel_step_logic(
             Flujo._set_final_context(pr_tokens, context)
             raise UsageLimitExceededError(result.feedback, pr_tokens)
 
-    result.output = outputs
-    result.attempts = 1
     return result
 
 

--- a/flujo/domain/__init__.py
+++ b/flujo/domain/__init__.py
@@ -11,6 +11,8 @@ from .pipeline_dsl import (
     StepConfig,
     MapStep,
     ParallelStep,
+    MergeStrategy,
+    BranchFailureStrategy,
 )
 from .models import (
     Task,
@@ -40,6 +42,8 @@ __all__ = [
     "StepConfig",
     "MapStep",
     "ParallelStep",
+    "MergeStrategy",
+    "BranchFailureStrategy",
     # Models
     "Task",
     "Candidate",

--- a/flujo/domain/models.py
+++ b/flujo/domain/models.py
@@ -101,6 +101,10 @@ class StepResult(BaseModel):
     token_counts: int = 0
     cost_usd: float = 0.0
     feedback: str | None = None
+    branch_context: Any | None = Field(
+        default=None,
+        description="Final context object for a branch in ParallelStep.",
+    )
     metadata_: dict[str, Any] | None = Field(
         default=None,
         description="Optional metadata about the step execution.",

--- a/tests/integration/test_parallel_step.py
+++ b/tests/integration/test_parallel_step.py
@@ -1,7 +1,11 @@
+import os
 import asyncio
+from typing import Any
 import pytest
-from flujo.domain.models import BaseModel
-from flujo.domain import Step
+from flujo.domain.models import BaseModel, PipelineContext, StepResult
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+from flujo.domain import Step, MergeStrategy, BranchFailureStrategy, UsageLimits
+from flujo.exceptions import UsageLimitExceededError
 from flujo.testing.utils import gather_result
 from flujo.application.flujo_engine import Flujo
 
@@ -48,3 +52,117 @@ async def test_parallel_step_result_structure() -> None:
     assert isinstance(step_result.output, dict)
     assert set(step_result.output.keys()) == {"x", "y"}
     assert step_result.success is True
+
+
+class ScratchCtx(PipelineContext):
+    val: int = 0
+
+
+class ScratchAgent:
+    def __init__(self, key: str, val: int, fail: bool = False, delay: float = 0.0) -> None:
+        self.key = key
+        self.val = val
+        self.fail = fail
+        self.delay = delay
+
+    async def run(self, data: int, *, context: ScratchCtx | None = None) -> int:
+        if self.fail:
+            raise RuntimeError("boom")
+        await asyncio.sleep(self.delay)
+        if context is not None:
+            context.scratchpad[self.key] = self.val
+        return data + self.val
+
+
+class CostlyAgent:
+    def __init__(self, cost: float = 0.1, delay: float = 0.0) -> None:
+        self.cost = cost
+        self.delay = delay
+
+    async def run(self, data: int) -> Any:
+        await asyncio.sleep(self.delay)
+
+        class Output(BaseModel):
+            value: int
+            cost_usd: float = self.cost
+            token_counts: int = 0
+
+        return Output(value=data)
+
+
+@pytest.mark.asyncio
+async def test_parallel_merge_scratchpad() -> None:
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("a", 1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("b", 2)}),
+    }
+    parallel = Step.parallel(
+        "merge_sp",
+        branches,
+        merge_strategy=MergeStrategy.MERGE_SCRATCHPAD,
+    )
+    runner = Flujo(parallel, context_model=ScratchCtx)
+    result = await gather_result(runner, 0, initial_context_data={"initial_prompt": "x"})
+    assert result.final_pipeline_context.scratchpad["a"] == 1
+    assert result.final_pipeline_context.scratchpad["b"] == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_overwrite_conflict() -> None:
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("v", 1, delay=0.1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("v", 2, delay=0.2)}),
+    }
+    parallel = Step.parallel("overwrite", branches, merge_strategy=MergeStrategy.OVERWRITE)
+    runner = Flujo(parallel, context_model=ScratchCtx)
+    result = await gather_result(runner, 0, initial_context_data={"initial_prompt": "x"})
+    assert result.final_pipeline_context.scratchpad["v"] == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_propagate_failure() -> None:
+    branches = {
+        "good": Step.model_validate({"name": "good", "agent": ScratchAgent("a", 1)}),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
+    }
+    parallel = Step.parallel(
+        "fail_prop", branches, on_branch_failure=BranchFailureStrategy.PROPAGATE
+    )
+    runner = Flujo(parallel, context_model=ScratchCtx)
+    result = await gather_result(runner, 0, initial_context_data={"initial_prompt": "x"})
+    step_result = result.step_history[-1]
+    assert not step_result.success
+    assert isinstance(step_result.output["bad"], StepResult)
+
+
+@pytest.mark.asyncio
+async def test_parallel_ignore_failure() -> None:
+    branches = {
+        "good": Step.model_validate({"name": "good", "agent": ScratchAgent("a", 1)}),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
+    }
+    parallel = Step.parallel(
+        "fail_ignore", branches, on_branch_failure=BranchFailureStrategy.IGNORE
+    )
+    runner = Flujo(parallel, context_model=ScratchCtx)
+    result = await gather_result(runner, 0, initial_context_data={"initial_prompt": "x"})
+    step_result = result.step_history[-1]
+    assert step_result.success
+    assert isinstance(step_result.output["bad"], StepResult)
+
+
+@pytest.mark.asyncio
+async def test_governor_precedence_over_failure_strategy() -> None:
+    branches = {
+        "costly": Step.model_validate({"name": "costly", "agent": CostlyAgent(cost=0.2, delay=0.0)}),
+        "slow": Step.model_validate({"name": "slow", "agent": CostlyAgent(cost=0.0, delay=0.5)}),
+    }
+    parallel = Step.parallel(
+        "gov_precedence",
+        branches,
+        on_branch_failure=BranchFailureStrategy.IGNORE,
+    )
+    limits = UsageLimits(total_cost_usd_limit=0.1)
+    runner = Flujo(parallel, usage_limits=limits, context_model=ScratchCtx)
+    with pytest.raises(UsageLimitExceededError):
+        await gather_result(runner, 0, initial_context_data={"initial_prompt": "x"})

--- a/tests/integration/test_parallel_step_enhancements.py
+++ b/tests/integration/test_parallel_step_enhancements.py
@@ -361,4 +361,4 @@ async def test_proactive_cancellation_error_handling() -> None:
 
     # Verify that the parallel step handles the error gracefully
     assert not result.step_history[-1].success
-    assert "Branch failed" in result.step_history[-1].feedback
+    assert "failed" in result.step_history[-1].feedback

--- a/tests/unit/test_parallel_step_strategies.py
+++ b/tests/unit/test_parallel_step_strategies.py
@@ -1,0 +1,112 @@
+import os
+import asyncio
+from typing import Any, Dict
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+from flujo import Flujo, Step
+from flujo.domain import MergeStrategy, BranchFailureStrategy
+from flujo.testing.utils import gather_result
+from flujo.domain.models import StepResult, PipelineContext
+
+
+class Ctx(PipelineContext):
+    value: int = 0
+
+
+class ScratchAgent:
+    def __init__(self, key: str, val: Any, delay: float = 0.0, fail: bool = False) -> None:
+        self.key = key
+        self.val = val
+        self.delay = delay
+        self.fail = fail
+
+    async def run(self, data: Any, *, context: Ctx | None = None) -> Any:
+        if self.fail:
+            raise RuntimeError("boom")
+        await asyncio.sleep(self.delay)
+        if context is not None:
+            context.scratchpad[self.key] = self.val
+        return data
+
+
+@pytest.mark.asyncio
+async def test_merge_strategy_no_merge() -> None:
+    branches: Dict[str, Step] = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("x", 1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("y", 2)}),
+    }
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.NO_MERGE)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    assert "x" not in result.final_pipeline_context.scratchpad
+    assert "y" not in result.final_pipeline_context.scratchpad
+
+
+@pytest.mark.asyncio
+async def test_merge_strategy_overwrite() -> None:
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("v", 1, delay=0.1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("v", 2, delay=0.2)}),
+    }
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.OVERWRITE)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    assert result.final_pipeline_context.scratchpad["v"] == 2
+
+
+@pytest.mark.asyncio
+async def test_merge_strategy_merge_scratchpad() -> None:
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("x", 1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("y", 2)}),
+    }
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    assert result.final_pipeline_context.scratchpad["x"] == 1
+    assert result.final_pipeline_context.scratchpad["y"] == 2
+
+
+def custom_merge(main: Ctx, branch: Ctx) -> None:
+    main.scratchpad.setdefault("vals", []).append(branch.scratchpad["val"])
+
+
+@pytest.mark.asyncio
+async def test_merge_strategy_callable() -> None:
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("val", 1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("val", 2)}),
+    }
+    parallel = Step.parallel("par", branches, merge_strategy=custom_merge)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    assert sorted(result.final_pipeline_context.scratchpad["vals"]) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_branch_failure_propagate() -> None:
+    branches = {
+        "ok": Step.model_validate({"name": "ok", "agent": ScratchAgent("a", 1)}),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
+    }
+    parallel = Step.parallel("par", branches, on_branch_failure=BranchFailureStrategy.PROPAGATE)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    assert not result.step_history[-1].success
+    assert isinstance(result.step_history[-1].output["bad"], StepResult)
+
+
+@pytest.mark.asyncio
+async def test_branch_failure_ignore() -> None:
+    branches = {
+        "ok": Step.model_validate({"name": "ok", "agent": ScratchAgent("a", 1)}),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
+    }
+    parallel = Step.parallel("par", branches, on_branch_failure=BranchFailureStrategy.IGNORE)
+    runner = Flujo(parallel, context_model=Ctx)
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
+    step_result = result.step_history[-1]
+    assert step_result.success
+    assert isinstance(step_result.output["bad"], StepResult)


### PR DESCRIPTION
## Summary
- add MergeStrategy and BranchFailureStrategy enums
- support context merging and failure policies in `ParallelStep`
- carry branch contexts in `StepResult`
- document new parallel execution features
- add cookbook example for parallel research
- add extensive tests for new strategies

## Testing
- `make quality`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866d325e3c0832c935b62c06ef46868