### PR TITLE
Implement declarative step fallbacks

### DIFF
--- a/docs/cookbook/resilience_and_performance.md
+++ b/docs/cookbook/resilience_and_performance.md
@@ -1,0 +1,21 @@
+# Building Resilient Pipelines with Fallbacks
+
+The `Step.fallback()` method lets you declare a backup step that runs if the primary step fails.
+This is useful for handling transient errors or providing a simpler model when a complex one is unreliable.
+
+```python
+from flujo import Step, Flujo
+from flujo.testing.utils import StubAgent
+
+primary = Step("primary", StubAgent(["fail"]), max_retries=1)
+backup = Step("backup", StubAgent(["ok"]))
+primary.fallback(backup)
+
+runner = Flujo(primary)
+result = runner.run("data")
+print(result.step_history[0].output)  # -> "ok"
+```
+
+When the fallback runs successfully, `StepResult.metadata_['fallback_triggered']` is set to `True` and the pipeline continues normally.
+Resource usage from the fallback is added to the main step result, and circular
+fallbacks raise `InfiniteFallbackError`.

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -560,6 +560,26 @@ Steps can be configured with various options:
 - `timeout_s`: Timeout in seconds (default: None)
 - `temperature`: Temperature for LLM agents (default: None)
 
+### Fallback Steps
+
+Use `.fallback(other_step)` to specify an alternate step to run if the primary
+step fails after exhausting its retries. The fallback receives the same input as
+the original step.
+
+```python
+from flujo import Step
+
+primary = Step("generate", primary_agent, max_retries=2)
+backup = Step("backup", backup_agent)
+primary.fallback(backup)
+```
+
+If the fallback succeeds, the overall step is marked successful and
+`StepResult.metadata_['fallback_triggered']` is set to `True`.
+Metrics like latency, cost, and token counts from the fallback step are merged
+into the primary result. Circular fallback references raise
+`InfiniteFallbackError`.
+
 ## Pipelines
 
 Pipelines are sequences of steps that execute in order.

--- a/flujo/application/flujo_engine.py
+++ b/flujo/application/flujo_engine.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import time
 import weakref
+import contextvars
 import copy
 from unittest.mock import Mock
 from typing import (
@@ -36,6 +37,7 @@ from ..exceptions import (
     MissingAgentError,
     TypeMismatchError,
     ContextInheritanceError,
+    InfiniteFallbackError,
 )
 from ..domain.pipeline_dsl import (
     Pipeline,
@@ -71,6 +73,10 @@ from ..domain.events import (
 )
 from ..domain.backends import ExecutionBackend, StepExecutionRequest
 from ..tracing import ConsoleTracer
+
+_fallback_chain_var: contextvars.ContextVar[list[Step[Any, Any]]] = contextvars.ContextVar(
+    "_fallback_chain", default=[]
+)
 
 _agent_command_adapter: TypeAdapter[AgentCommand] = TypeAdapter(AgentCommand)
 
@@ -949,6 +955,45 @@ async def _run_step_logic(
         is_validation_step=is_validation_step,
         is_strict=is_strict,
     )
+    # If the step failed and a fallback is defined, execute it.
+    if not result.success and step.fallback_step:
+        logfire.info(
+            f"Step '{step.name}' failed. Attempting fallback step '{step.fallback_step.name}'."
+        )
+        original_failure_feedback = result.feedback
+
+        chain = _fallback_chain_var.get()
+        if step in chain:
+            raise InfiniteFallbackError(f"Fallback loop detected in step '{step.name}'")
+        token = _fallback_chain_var.set(chain + [step])
+        try:
+            fallback_result = await step_executor(
+                step.fallback_step,
+                data,
+                context,
+                resources,
+            )
+        finally:
+            _fallback_chain_var.reset(token)
+
+        result.latency_s += fallback_result.latency_s
+        result.cost_usd += fallback_result.cost_usd
+        result.token_counts += fallback_result.token_counts
+
+        if fallback_result.success:
+            result.success = True
+            result.output = fallback_result.output
+            result.feedback = None
+            result.metadata_ = {
+                **(result.metadata_ or {}),
+                "fallback_triggered": True,
+                "original_error": original_failure_feedback,
+            }
+        else:
+            result.feedback = (
+                f"Original error: {original_failure_feedback}\n"
+                f"Fallback error: {fallback_result.feedback}"
+            )
     if not result.success and step.persist_feedback_to_context:
         if context is not None and hasattr(context, step.persist_feedback_to_context):
             history_list = getattr(context, step.persist_feedback_to_context)

--- a/flujo/cli/main.py
+++ b/flujo/cli/main.py
@@ -227,7 +227,7 @@ def bench(prompt: str, rounds: int = 10) -> None:
         KeyboardInterrupt: If the benchmark is interrupted by the user
     """
     import time
-    import numpy as np  # type: ignore[import-not-found]
+    import numpy as np
 
     try:
         review_agent = make_agent_async(settings.default_review_model, REVIEW_SYS, Checklist)

--- a/flujo/domain/pipeline_dsl.py
+++ b/flujo/domain/pipeline_dsl.py
@@ -69,6 +69,7 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
     validators: List[Validator] = Field(default_factory=list)
     failure_handlers: List[Callable[[], None]] = Field(default_factory=list)
     processors: "AgentProcessors" = Field(default_factory=AgentProcessors)
+    fallback_step: Optional[Any] = Field(default=None, exclude=True)
     persist_feedback_to_context: Optional[str] = Field(
         default=None,
         description=("If step fails, append feedback to this context attribute (must be a list)."),
@@ -411,6 +412,11 @@ class Step(BaseModel, Generic[StepInT, StepOutT]):
         self.failure_handlers.append(handler)
         return self
 
+    def fallback(self, step: "Step") -> "Step[StepInT, StepOutT]":
+        """Set a fallback step to execute if this step fails after retries."""
+        self.fallback_step = step
+        return self
+
     @classmethod
     def loop_until(
         cls,
@@ -664,6 +670,9 @@ def step(
 
 # Convenience alias to create mapping steps
 mapper = Step.from_mapper
+
+# Resolve forward references now that ``Step`` is fully defined
+# (handled automatically by Pydantic)
 
 
 def adapter_step(

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -50,6 +50,12 @@ class InfiniteRedirectError(OrchestratorError):
     pass
 
 
+class InfiniteFallbackError(OrchestratorError):
+    """Raised when a fallback loop is detected during execution."""
+
+    pass
+
+
 class PipelineContextInitializationError(OrchestratorError):
     """Raised when a typed pipeline context fails to initialize."""
 

--- a/tests/integration/test_caching_and_fallbacks.py
+++ b/tests/integration/test_caching_and_fallbacks.py
@@ -1,0 +1,86 @@
+from flujo.domain import Step, Pipeline
+from flujo.domain.pipeline_dsl import StepConfig
+from flujo.testing.utils import StubAgent, DummyPlugin, gather_result
+from flujo.domain.plugins import PluginOutcome
+from flujo.application.flujo_engine import Flujo
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_fallback() -> None:
+    s1 = Step.model_validate({"name": "s1", "agent": StubAgent(["a"])})
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")])
+    failing = Step.model_validate(
+        {
+            "name": "s2",
+            "agent": StubAgent(["bad"]),
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    fb = Step.model_validate({"name": "fb", "agent": StubAgent(["good"])})
+    failing.fallback(fb)
+    s3 = Step.model_validate({"name": "s3", "agent": StubAgent(["end"])})
+    pipeline = s1 >> failing >> s3
+    result = await gather_result(Flujo(pipeline), "in")
+    assert result.step_history[1].output == "good"
+    assert result.step_history[1].metadata_["fallback_triggered"] is True
+    assert result.step_history[2].output == "end"
+
+
+@pytest.mark.asyncio
+async def test_loop_step_fallback_continues() -> None:
+    body_agent = StubAgent(["bad", "done"])
+    plugin = DummyPlugin(
+        [PluginOutcome(success=False, feedback="err"), PluginOutcome(success=True)]
+    )
+    body = Step.model_validate(
+        {
+            "name": "body",
+            "agent": body_agent,
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    fb_agent = StubAgent(["recover"])
+    fb = Step.model_validate({"name": "fb", "agent": fb_agent})
+    body.fallback(fb)
+    loop_step = Step.loop_until(
+        name="loop",
+        loop_body_pipeline=Pipeline.from_step(body),
+        exit_condition_callable=lambda out, _ctx: out == "done",
+        max_loops=2,
+    )
+    result = await gather_result(Flujo(loop_step), "start")
+    sr = result.step_history[0]
+    assert sr.success is True
+    assert body_agent.call_count == 2
+    assert fb_agent.call_count == 1
+    assert sr.output == "done"
+
+
+@pytest.mark.asyncio
+async def test_conditional_branch_with_fallback() -> None:
+    branch_agent = StubAgent(["bad"])
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")])
+    branch_step = Step.model_validate(
+        {
+            "name": "branch",
+            "agent": branch_agent,
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    fb_agent = StubAgent(["fix"])
+    branch_step.fallback(Step.model_validate({"name": "branch_fb", "agent": fb_agent}))
+
+    cond = Step.branch_on(
+        name="cond",
+        condition_callable=lambda *_: "a",
+        branches={"a": Pipeline.from_step(branch_step)},
+    )
+    final = Step.model_validate({"name": "final", "agent": StubAgent(["end"])})
+    pipeline = cond >> final
+    result = await gather_result(Flujo(pipeline), "x")
+    assert fb_agent.call_count == 1
+    assert result.step_history[-1].output == "end"

--- a/tests/unit/test_fallback.py
+++ b/tests/unit/test_fallback.py
@@ -1,0 +1,165 @@
+import pytest
+import asyncio
+
+
+from flujo.domain.pipeline_dsl import Step, StepConfig
+from flujo.testing.utils import StubAgent, DummyPlugin, gather_result
+from flujo.domain.plugins import PluginOutcome
+from flujo.application.flujo_engine import Flujo, InfiniteFallbackError
+
+
+@pytest.mark.asyncio
+async def test_fallback_assignment() -> None:
+    primary = Step.model_validate({"name": "p", "agent": StubAgent(["x"])})
+    fb = Step.model_validate({"name": "fb", "agent": StubAgent(["y"])})
+    primary.fallback(fb)
+    assert primary.fallback_step is fb
+
+
+@pytest.mark.asyncio
+async def test_fallback_not_triggered_on_success() -> None:
+    agent = StubAgent(["ok"])
+    primary = Step.model_validate({"name": "p", "agent": agent})
+    fb = Step.model_validate({"name": "fb", "agent": StubAgent(["fb"])})
+    primary.fallback(fb)
+    runner = Flujo(primary)
+    res = await gather_result(runner, "in")
+    sr = res.step_history[0]
+    assert sr.output == "ok"
+    assert agent.call_count == 1
+    assert fb.agent.call_count == getattr(fb.agent, "call_count", 0)
+    assert sr.metadata_ is None
+
+
+@pytest.mark.asyncio
+async def test_fallback_triggered_on_failure() -> None:
+    primary_agent = StubAgent(["bad"])
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")])
+    primary = Step.model_validate(
+        {
+            "name": "p",
+            "agent": primary_agent,
+            "config": StepConfig(max_retries=1),
+            "plugins": [(plugin, 0)],
+        }
+    )
+    fb_agent = StubAgent(["recover"])
+    fb = Step.model_validate({"name": "fb", "agent": fb_agent})
+    primary.fallback(fb)
+    runner = Flujo(primary)
+    res = await gather_result(runner, "data")
+    sr = res.step_history[0]
+    assert sr.success is True
+    assert sr.output == "recover"
+    assert sr.metadata_ and sr.metadata_["fallback_triggered"] is True
+    assert primary_agent.call_count == 1
+    assert fb_agent.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_failure_propagates() -> None:
+    primary_agent = StubAgent(["bad"])
+    plugin_primary = DummyPlugin([PluginOutcome(success=False, feedback="p fail")])
+    primary = Step.model_validate(
+        {"name": "p", "agent": primary_agent, "plugins": [(plugin_primary, 0)]}
+    )
+    fb_agent = StubAgent(["still bad"])
+    plugin_fb = DummyPlugin([PluginOutcome(success=False, feedback="fb fail")])
+    fb = Step.model_validate({"name": "fb", "agent": fb_agent, "plugins": [(plugin_fb, 0)]})
+    primary.fallback(fb)
+    runner = Flujo(primary)
+    res = await gather_result(runner, "data")
+    sr = res.step_history[0]
+    assert sr.success is False
+    assert "p fail" in sr.feedback
+    assert "fb fail" in sr.feedback
+    assert fb_agent.call_count == 1
+
+
+class WrappedResult:
+    def __init__(self, output: str, token_counts: int = 2, cost_usd: float = 0.1) -> None:
+        self.output = output
+        self.token_counts = token_counts
+        self.cost_usd = cost_usd
+
+
+class SlowAgent:
+    async def run(self, data: str) -> WrappedResult:
+        await asyncio.sleep(0.05)
+        return WrappedResult("slow")
+
+
+@pytest.mark.asyncio
+async def test_fallback_latency_accumulated() -> None:
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")])
+    failing = Step.model_validate(
+        {
+            "name": "p",
+            "agent": StubAgent(["bad"]),
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    fb = Step.model_validate({"name": "fb", "agent": SlowAgent()})
+    failing.fallback(fb)
+    runner = Flujo(failing)
+    res = await gather_result(runner, "x")
+    sr = res.step_history[0]
+    assert sr.success is True
+    assert sr.latency_s >= 0.05
+
+
+class CostlyOutput:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.token_counts = 5
+        self.cost_usd = 0.2
+
+
+@pytest.mark.asyncio
+async def test_failed_fallback_accumulates_metrics() -> None:
+    plugin_primary = DummyPlugin([PluginOutcome(success=False, feedback="bad")])
+    primary = Step.model_validate(
+        {
+            "name": "p",
+            "agent": StubAgent(["bad"]),
+            "plugins": [(plugin_primary, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    fb_plugin = DummyPlugin([PluginOutcome(success=False, feedback="worse")])
+    fb_agent = StubAgent([CostlyOutput("oops")])
+    fb = Step.model_validate({"name": "fb", "agent": fb_agent, "plugins": [(fb_plugin, 0)]})
+    primary.fallback(fb)
+    runner = Flujo(primary)
+    res = await gather_result(runner, "in")
+    sr = res.step_history[0]
+    assert sr.success is False
+    assert sr.cost_usd == 0.2
+    assert sr.token_counts == 6
+
+
+@pytest.mark.asyncio
+async def test_infinite_fallback_loop_detected() -> None:
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")])
+    a = Step.model_validate(
+        {
+            "name": "a",
+            "agent": StubAgent(["bad"]),
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    b = Step.model_validate(
+        {
+            "name": "b",
+            "agent": StubAgent(["bad"]),
+            "plugins": [(plugin, 0)],
+            "config": StepConfig(max_retries=1),
+        }
+    )
+    a.fallback(b)
+    b.fallback(a)
+    runner = Flujo(a)
+    with pytest.raises(InfiniteFallbackError):
+        await gather_result(runner, "data")


### PR DESCRIPTION
## Summary
- add fallback chain detection and metrics accumulation
- document fallback metrics and loop errors
- test fallback latency and metric aggregation
- fix duplicate `InfiniteFallbackError` definition

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_6866dc1bc770832cae844120b804f510