### PR TITLE
Refactor pipeline validation typing

### DIFF
--- a/docs/The_flujo_way.md
+++ b/docs/The_flujo_way.md
@@ -327,7 +327,7 @@ Flujo(pipeline, max_retries=2, retry_on_error=True)
 from flujo import Pipeline
 
 # Validate pipeline before running
-validation_report = pipeline.validate()
+validation_report = pipeline.validate_graph()
 if not validation_report.is_valid:
     print("Pipeline validation failed:")
     for finding in validation_report.findings:
@@ -418,7 +418,7 @@ from flujo.testing import StubAgent, gather_result
 | 💵 Cost Limits  | `UsageLimits(total_cost_usd_limit=...)`                       |
 | 📜 Logs         | `ConsoleTracer` for debug visibility                          |
 | 🔧 Tuning       | Use `make_agent_async(...)` and `Step(..., temperature=...)`  |
-| 🔍 Validation   | `pipeline.validate()` and `flujo validate` CLI               |
+| 🔍 Validation   | `pipeline.validate_graph()` and `flujo validate` CLI         |
 | 📦 Composition  | `pipeline1 >> pipeline2` for modular workflows                |
 
 ---

--- a/flujo/cli/main.py
+++ b/flujo/cli/main.py
@@ -489,7 +489,7 @@ def validate(
     if not isinstance(pipeline, Pipeline):
         typer.echo("[red]No 'pipeline' variable of type Pipeline found", err=True)
         raise typer.Exit(1)
-    report = pipeline.validate()
+    report = pipeline.validate_graph()
     if report.errors:
         typer.echo("[red]Validation errors detected:")
         for f in report.errors:

--- a/flujo/domain/dsl/pipeline.py
+++ b/flujo/domain/dsl/pipeline.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# mypy: ignore-errors
-
 from typing import (
     Any,
     ClassVar,
@@ -74,7 +72,7 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
     # Validation helpers
     # ------------------------------------------------------------------
 
-    def validate(self, *, raise_on_error: bool = False) -> ValidationReport:  # noqa: D401
+    def validate_graph(self, *, raise_on_error: bool = False) -> ValidationReport:  # noqa: D401
         """Validate that all steps have agents and compatible types."""
         from typing import Any, get_origin, get_args, Union as TypingUnion
 
@@ -314,7 +312,7 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
             if subgraph_name:
                 lines.append(f'    subgraph "{subgraph_name}"')
 
-            last_node = prev_node
+            last_node: str | None = prev_node
             for st in pipeline.steps:
                 if isinstance(st, LoopStep):
                     last_node = process_loop_step(st, last_node)
@@ -328,6 +326,7 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
             if subgraph_name:
                 lines.append("    end")
 
+            assert last_node is not None
             return last_node
 
         def process_loop_step(step: "LoopStep[Any]", prev_node: Optional[str] = None) -> str:
@@ -456,7 +455,7 @@ class Pipeline(BaseModel, Generic[PipeInT, PipeOutT]):
         simple_group = []
         prev_node = None
 
-        def is_special(step):
+        def is_special(step: Step[Any, Any]) -> bool:
             return isinstance(step, (LoopStep, ConditionalStep, ParallelStep, HumanInTheLoopStep))
 
         steps = list(self.steps)

--- a/flujo/infra/settings.py
+++ b/flujo/infra/settings.py
@@ -1,7 +1,7 @@
 """Settings and configuration for flujo."""
 
 import os
-from typing import ClassVar, Dict, Literal, Optional
+from typing import Callable, ClassVar, Dict, Literal, Optional, cast
 
 import dotenv
 from pydantic import (
@@ -120,8 +120,9 @@ class Settings(BaseSettings):
 
 
 # Singleton instance, fail fast if critical vars missing
+
 try:
-    settings = Settings()  # type: ignore[call-arg]
+    settings = cast(Callable[[], Settings], Settings)()
 except ValidationError as e:
     # Use custom exception for better error handling downstream
     raise SettingsError(f"Invalid or missing environment variables for Settings:\n{e}")

--- a/tests/unit/test_error_messages.py
+++ b/tests/unit/test_error_messages.py
@@ -24,11 +24,11 @@ def test_improper_step_call() -> None:
 def test_missing_agent_errors() -> None:
     blank = Step.model_validate({"name": "blank"})
     pipeline = Pipeline.from_step(blank)
-    report = pipeline.validate()
+    report = pipeline.validate_graph()
     assert not report.is_valid
     assert any(f.rule_id == "V-A1" for f in report.errors)
     with pytest.raises(ConfigurationError):
-        pipeline.validate(raise_on_error=True)
+        pipeline.validate_graph(raise_on_error=True)
     runner = Flujo(blank)
     with pytest.raises(MissingAgentError):
         runner.run(None)
@@ -46,11 +46,11 @@ async def need_str(x: str) -> str:
 
 def test_type_mismatch_errors() -> None:
     pipeline = make_int >> need_str
-    report = pipeline.validate()
+    report = pipeline.validate_graph()
     assert not report.is_valid
     assert any(f.rule_id == "V-A2" for f in report.errors)
     with pytest.raises(ConfigurationError):
-        pipeline.validate(raise_on_error=True)
+        pipeline.validate_graph(raise_on_error=True)
     runner = Flujo(pipeline)
     with pytest.raises(TypeMismatchError):
         runner.run("abc")
@@ -68,17 +68,17 @@ async def expect_optional(x: str | None) -> str:
 
 def test_union_optional_handling() -> None:
     ok_pipeline = echo >> expect_optional
-    report_ok = ok_pipeline.validate()
+    report_ok = ok_pipeline.validate_graph()
     assert report_ok.is_valid
     runner_ok = Flujo(ok_pipeline)
     result_ok = runner_ok.run("hi")
     assert result_ok.step_history[-1].output == "hi"
 
     bad_pipeline = maybe_str >> need_str
-    report_bad = bad_pipeline.validate()
+    report_bad = bad_pipeline.validate_graph()
     assert not report_bad.is_valid
     with pytest.raises(ConfigurationError):
-        bad_pipeline.validate(raise_on_error=True)
+        bad_pipeline.validate_graph(raise_on_error=True)
     runner_bad = Flujo(bad_pipeline)
     with pytest.raises(TypeMismatchError):
         runner_bad.run("")

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -18,11 +18,11 @@ async def modern_step(x: int, *, context: Ctx) -> int:
 
 def test_no_warning_for_context() -> None:
     pipeline = Pipeline.from_step(deprecated_step)
-    report = pipeline.validate()
+    report = pipeline.validate_graph()
     assert not any(f.rule_id == "V-A4" for f in report.warnings)
 
 
 def test_no_warning_for_modern_context() -> None:
     pipeline = Pipeline.from_step(modern_step)
-    report = pipeline.validate()
+    report = pipeline.validate_graph()
     assert not any(f.rule_id == "V-A4" for f in report.warnings)


### PR DESCRIPTION
## Summary
- drop mypy ignore in `pipeline.py`
- remove inline type ignore in settings and load settings via typed cast
- rename validation helper to `validate_graph`
- update CLI, docs and tests for new method name
- clean up imports after feedback

## Testing
- `make type-check`
- `make test`
- `make cov`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_6869b904a5dc832cac36b337ca3cdb2c