### PR TITLE
Remove TypeAdapter usage in docs and example

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -13,12 +13,10 @@ the `PipelineContext`.
 from flujo.recipes import AgenticLoop
 from flujo import make_agent_async
 from flujo.domain.commands import AgentCommand
-from pydantic import TypeAdapter
-
 planner = make_agent_async(
     "openai:gpt-4o",
     "Plan the next command and finish when done.",
-    TypeAdapter(AgentCommand),
+    AgentCommand,
 )
 loop = AgenticLoop(planner_agent=planner, agent_registry={})
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,6 @@ Create a new file `hello_agentic.py`:
 from flujo.recipes import AgenticLoop
 from flujo import make_agent_async, init_telemetry
 from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
-from pydantic import TypeAdapter
 
 init_telemetry()
 
@@ -44,7 +43,7 @@ When you have an answer, respond with `FinishCommand`.
 planner_agent = make_agent_async(
     "openai:gpt-4o",
     PLANNER_PROMPT,
-    TypeAdapter(AgentCommand),
+    AgentCommand,
 )
 
 loop = AgenticLoop(planner_agent=planner_agent, agent_registry={"search_agent": search_agent})

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -39,7 +39,6 @@ We'll begin with the `AgenticLoop` pattern. A planner agent decides which tool a
 from flujo.recipes import AgenticLoop
 from flujo import make_agent_async, init_telemetry
 from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
-from pydantic import TypeAdapter
 
 init_telemetry()
 
@@ -53,7 +52,7 @@ When ready, reply with `FinishCommand` containing the final haiku.
 planner = make_agent_async(
     "openai:gpt-4o",
     PLANNER_PROMPT,
-    TypeAdapter(AgentCommand),
+    AgentCommand,
 )
 
 loop = AgenticLoop(planner_agent=planner, agent_registry={"search_agent": search_agent})

--- a/examples/00_quickstart.py
+++ b/examples/00_quickstart.py
@@ -11,7 +11,6 @@ from flujo.domain.models import PipelineContext
 from flujo import make_agent_async, init_telemetry
 from flujo.recipes import AgenticLoop
 from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
-from pydantic import TypeAdapter
 
 
 # It's good practice to initialize telemetry at the start of your application.
@@ -38,7 +37,7 @@ When you have the answer, use the FinishCommand to provide the final result.
 planner_agent = make_agent_async(
     model="openai:gpt-4o",
     system_prompt=PLANNER_PROMPT,
-    output_type=TypeAdapter(AgentCommand),
+    output_type=AgentCommand,
 )
 
 # --- 2. Assemble and Run the AgenticLoop ---

--- a/tests/mypy_success.py
+++ b/tests/mypy_success.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Callable, Optional
+from typing import Any, cast, Callable, Optional, reveal_type
 import asyncio
 
 from flujo.domain import Step, step, Pipeline


### PR DESCRIPTION
## Summary
- simplify quickstart code by passing `AgentCommand` directly
- update documentation to match the simplified usage
- import `reveal_type` so mypy_success test can run

## Testing
- `hatch run type-check`
- `make test`
- `make cov`
- `make quality`
- `pytest tests/mypy_success.py`


------
https://chatgpt.com/codex/tasks/task_e_686a999c3228832c99cb81ae290a520e