### PR TITLE
Add durable state backend with memory implementation

### DIFF
--- a/flujo/state/__init__.py
+++ b/flujo/state/__init__.py
@@ -1,0 +1,9 @@
+from .models import WorkflowState
+from .backends.base import StateBackend
+from .backends.memory import InMemoryBackend
+
+__all__ = [
+    "WorkflowState",
+    "StateBackend",
+    "InMemoryBackend",
+]

--- a/flujo/state/backends/__init__.py
+++ b/flujo/state/backends/__init__.py
@@ -1,0 +1,4 @@
+from .base import StateBackend
+from .memory import InMemoryBackend
+
+__all__ = ["StateBackend", "InMemoryBackend"]

--- a/flujo/state/backends/base.py
+++ b/flujo/state/backends/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class StateBackend(ABC):
+    """Abstract interface for workflow state persistence."""
+
+    @abstractmethod
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        """Persist the serialized state for ``run_id``."""
+        ...
+
+    @abstractmethod
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Load and return the serialized state for ``run_id`` if present."""
+        ...
+
+    @abstractmethod
+    async def delete_state(self, run_id: str) -> None:
+        """Remove any persisted state for ``run_id``."""
+        ...

--- a/flujo/state/backends/memory.py
+++ b/flujo/state/backends/memory.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import StateBackend
+
+
+class InMemoryBackend(StateBackend):
+    """Simple in-memory backend for testing and defaults."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        self._store[run_id] = state
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        return self._store.get(run_id)
+
+    async def delete_state(self, run_id: str) -> None:
+        self._store.pop(run_id, None)

--- a/flujo/state/models.py
+++ b/flujo/state/models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from ..domain.models import BaseModel
+from pydantic import Field
+
+
+class WorkflowState(BaseModel):
+    """Serialized snapshot of a running workflow."""
+
+    run_id: str
+    pipeline_id: str
+    pipeline_version: str
+    current_step_index: int
+    pipeline_context: Dict[str, Any]
+    status: Literal["running", "paused", "completed", "failed"]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["WorkflowState"]

--- a/tests/integration/test_stateful_runner.py
+++ b/tests/integration/test_stateful_runner.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+import pytest
+
+from flujo.application.runner import Flujo
+from flujo.state import WorkflowState
+from flujo.state.backends.memory import InMemoryBackend
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.testing.utils import gather_result
+
+
+class Ctx(PipelineContext):
+    pass
+
+
+async def step_one(data: str) -> str:
+    return "mid"
+
+
+async def step_two(data: str) -> str:
+    return data + " done"
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_state_backend() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=False)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    assert len(result.step_history) == 2
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "completed"
+    assert wf_state.current_step_index == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_from_saved_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "run123"
+    ctx_after_first = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1)),
+        pipeline_version="0",
+        current_step_index=1,
+        pipeline_context=ctx_after_first.model_dump(),
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    assert (await backend.load_state(run_id)) is not None

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flujo.state.backends.memory import InMemoryBackend
+
+
+@pytest.mark.asyncio
+async def test_inmemory_backend_roundtrip() -> None:
+    backend = InMemoryBackend()
+    await backend.save_state("run1", {"foo": 1})
+    loaded = await backend.load_state("run1")
+    assert loaded == {"foo": 1}
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None


### PR DESCRIPTION
## Summary
- introduce StateBackend interface and WorkflowState model
- implement InMemoryBackend for storing state during pipeline execution
- add state persistence/resume logic to `Flujo` runner
- add unit test for backend and integration tests for runner

## Testing
- `ruff check flujo tests`
- `mypy flujo`
- `pytest -q`
- `pytest --cov=flujo --cov-report=term-missing -q`
- `make quality`

------
https://chatgpt.com/codex/tasks/task_e_686c3b187644832c9ffa445563ec8f0a