### PR TITLE
Add durable state backend with memory implementation

### DIFF
--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -5,6 +5,7 @@ import inspect
 import time
 import weakref
 import copy
+from datetime import datetime
 from typing import (
     Any,
     Callable,
@@ -51,6 +52,7 @@ from ..domain.resources import AppResources
 from ..domain.types import HookCallable
 from ..domain.backends import ExecutionBackend, StepExecutionRequest
 from ..tracing import ConsoleTracer
+from ..state import StateBackend, WorkflowState
 
 from .context_manager import (
     _accepts_param,
@@ -169,6 +171,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         usage_limits: Optional[UsageLimits] = None,
         hooks: Optional[list[HookCallable]] = None,
         backend: Optional[ExecutionBackend] = None,
+        state_backend: Optional[StateBackend] = None,
+        delete_on_completion: bool = False,
         local_tracer: Union[str, "ConsoleTracer", None] = None,
     ) -> None:
         if isinstance(pipeline, Step):
@@ -191,6 +195,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
 
             backend = LocalBackend()
         self.backend = backend
+        self.state_backend = state_backend
+        self.delete_on_completion = delete_on_completion
 
     async def _dispatch_hook(
         self,
@@ -349,6 +355,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         result: PipelineResult[ContextT],
         *,
         stream_last: bool = False,
+        run_id: str | None = None,
+        state_backend: StateBackend | None = None,
+        state_created_at: datetime | None = None,
     ) -> AsyncIterator[Any]:
         """Iterate over pipeline steps yielding streaming output.
 
@@ -475,6 +484,19 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     context=context,
                     resources=self.resources,
                 )
+                if state_backend is not None and context is not None and run_id is not None:
+                    wf_state = WorkflowState(
+                        run_id=run_id,
+                        pipeline_id=str(id(self.pipeline)),
+                        pipeline_version="0",
+                        current_step_index=idx + 1,
+                        pipeline_context=context.model_dump(),
+                        last_step_output=step_result.output,
+                        status="running",
+                        created_at=state_created_at or datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                    )
+                    await state_backend.save_state(run_id, wf_state.model_dump())
             else:
                 await self._dispatch_hook(
                     "on_step_failure",
@@ -545,6 +567,37 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
 
         data: Optional[RunnerInT] = initial_input
         pipeline_result_obj: PipelineResult[ContextT] = PipelineResult()
+        start_idx = 0
+        state_created_at: datetime | None = None
+        if self.state_backend is not None and hasattr(current_context_instance, "run_id"):
+            loaded = await self.state_backend.load_state(current_context_instance.run_id)
+            if loaded is not None:
+                wf_state = WorkflowState.model_validate(loaded)
+                start_idx = wf_state.current_step_index
+                state_created_at = wf_state.created_at
+                if wf_state.pipeline_context is not None:
+                    if self.context_model is not None:
+                        current_context_instance = self.context_model.model_validate(
+                            wf_state.pipeline_context
+                        )
+                    else:
+                        current_context_instance = cast(
+                            ContextT, PipelineContext.model_validate(wf_state.pipeline_context)
+                        )
+                if start_idx > 0:
+                    data = cast(RunnerInT | None, wf_state.last_step_output)
+            wf_state = WorkflowState(
+                run_id=getattr(current_context_instance, "run_id", ""),
+                pipeline_id=str(id(self.pipeline)),
+                pipeline_version="0",
+                current_step_index=start_idx,
+                pipeline_context=current_context_instance.model_dump(),
+                last_step_output=data,
+                status="running",
+                created_at=state_created_at or datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            )
+            await self.state_backend.save_state(wf_state.run_id, wf_state.model_dump())
         try:
             await self._dispatch_hook(
                 "pre_run",
@@ -553,11 +606,14 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 resources=self.resources,
             )
             async for chunk in self._execute_steps(
-                0,
+                start_idx,
                 data,
                 cast(Optional[ContextT], current_context_instance),
                 pipeline_result_obj,
                 stream_last=True,
+                run_id=getattr(current_context_instance, "run_id", None),
+                state_backend=self.state_backend,
+                state_created_at=state_created_at,
             ):
                 yield chunk
         except asyncio.CancelledError:
@@ -579,14 +635,38 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     pipeline_result_obj,
                     cast(Optional[ContextT], current_context_instance),
                 )
+                final_status: Literal["running", "paused", "completed", "failed"]
+                final_status = (
+                    "completed"
+                    if all(s.success for s in pipeline_result_obj.step_history)
+                    else "failed"
+                )
                 if isinstance(current_context_instance, PipelineContext):
                     if current_context_instance.scratchpad.get("status") != "paused":
-                        status = (
-                            "completed"
-                            if all(s.success for s in pipeline_result_obj.step_history)
-                            else "failed"
-                        )
-                        current_context_instance.scratchpad["status"] = status
+                        current_context_instance.scratchpad["status"] = final_status
+                    else:
+                        final_status = "paused"
+                if self.state_backend is not None and hasattr(current_context_instance, "run_id"):
+                    wf_state = WorkflowState(
+                        run_id=current_context_instance.run_id,
+                        pipeline_id=str(id(self.pipeline)),
+                        pipeline_version="0",
+                        current_step_index=start_idx + len(
+                            pipeline_result_obj.step_history
+                        ),
+                        pipeline_context=current_context_instance.model_dump(),
+                        last_step_output=(
+                            pipeline_result_obj.step_history[-1].output
+                            if pipeline_result_obj.step_history
+                            else None
+                        ),
+                        status=final_status,
+                        created_at=state_created_at or datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                    )
+                    await self.state_backend.save_state(wf_state.run_id, wf_state.model_dump())
+                    if self.delete_on_completion:
+                        await self.state_backend.delete_state(wf_state.run_id)
             try:
                 await self._dispatch_hook(
                     "post_run",
@@ -703,6 +783,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             cast(Optional[ContextT], ctx),
             paused_result,
             stream_last=False,
+            run_id=getattr(ctx, "run_id", None),
+            state_backend=self.state_backend,
+            state_created_at=None,
         ):
             pass
 

--- a/flujo/state/__init__.py
+++ b/flujo/state/__init__.py
@@ -1,0 +1,9 @@
+from .models import WorkflowState
+from .backends.base import StateBackend
+from .backends.memory import InMemoryBackend
+
+__all__ = [
+    "WorkflowState",
+    "StateBackend",
+    "InMemoryBackend",
+]

--- a/flujo/state/backends/__init__.py
+++ b/flujo/state/backends/__init__.py
@@ -1,0 +1,4 @@
+from .base import StateBackend
+from .memory import InMemoryBackend
+
+__all__ = ["StateBackend", "InMemoryBackend"]

--- a/flujo/state/backends/base.py
+++ b/flujo/state/backends/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class StateBackend(ABC):
+    """Abstract interface for workflow state persistence."""
+
+    @abstractmethod
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        """Persist the serialized state for ``run_id``."""
+        ...
+
+    @abstractmethod
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Load and return the serialized state for ``run_id`` if present."""
+        ...
+
+    @abstractmethod
+    async def delete_state(self, run_id: str) -> None:
+        """Remove any persisted state for ``run_id``."""
+        ...

--- a/flujo/state/backends/memory.py
+++ b/flujo/state/backends/memory.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import StateBackend
+
+
+class InMemoryBackend(StateBackend):
+    """Simple in-memory backend for testing and defaults."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        self._store[run_id] = state
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        return self._store.get(run_id)
+
+    async def delete_state(self, run_id: str) -> None:
+        self._store.pop(run_id, None)

--- a/flujo/state/models.py
+++ b/flujo/state/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from ..domain.models import BaseModel
+from pydantic import Field
+
+
+class WorkflowState(BaseModel):
+    """Serialized snapshot of a running workflow."""
+
+    run_id: str
+    pipeline_id: str
+    pipeline_version: str
+    current_step_index: int
+    pipeline_context: Dict[str, Any]
+    last_step_output: Any | None = None
+    status: Literal["running", "paused", "completed", "failed"]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["WorkflowState"]

--- a/tests/integration/test_stateful_runner.py
+++ b/tests/integration/test_stateful_runner.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+
+import pytest
+
+from flujo.application.runner import Flujo
+from flujo.state import WorkflowState
+from flujo.state.backends.memory import InMemoryBackend
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.testing.utils import gather_result
+
+
+class Ctx(PipelineContext):
+    pass
+
+
+async def step_one(data: str) -> str:
+    return "mid"
+
+
+async def step_two(data: str) -> str:
+    return data + " done"
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_state_backend() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=False)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    assert len(result.step_history) == 2
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "completed"
+    assert wf_state.current_step_index == 2
+    assert wf_state.last_step_output == "mid done"
+
+
+@pytest.mark.asyncio
+async def test_resume_from_saved_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "run123"
+    ctx_after_first = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1 >> s2)),
+        pipeline_version="0",
+        current_step_index=1,
+        pipeline_context=ctx_after_first.model_dump(),
+        last_step_output="mid",
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    saved_after = await backend.load_state(run_id)
+    assert saved_after is not None
+    wf_state_after = WorkflowState.model_validate(saved_after)
+    assert wf_state_after.current_step_index == 2
+    assert wf_state_after.last_step_output == "mid done"

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flujo.state.backends.memory import InMemoryBackend
+
+
+@pytest.mark.asyncio
+async def test_inmemory_backend_roundtrip() -> None:
+    backend = InMemoryBackend()
+    await backend.save_state("run1", {"foo": 1})
+    loaded = await backend.load_state("run1")
+    assert loaded == {"foo": 1}
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None


### PR DESCRIPTION
## Summary
- introduce StateBackend interface and WorkflowState model
- implement InMemoryBackend for storing state during pipeline execution
- add state persistence/resume logic to `Flujo` runner
- add unit test for backend and integration tests for runner
- fix resuming from saved state by restoring step output and context when loading

## Testing
- `make quality`
- `make test`
- `make cov`

------
https://chatgpt.com/codex/tasks/task_e_686c3b187644832c9ffa445563ec8f0a