### PR TITLE
Fix state handling with cancellation and invalid resumes

### DIFF
--- a/flujo/state/__init__.py
+++ b/flujo/state/__init__.py
@@ -1,0 +1,9 @@
+from .models import WorkflowState
+from .backends.base import StateBackend
+from .backends.memory import InMemoryBackend
+
+__all__ = [
+    "WorkflowState",
+    "StateBackend",
+    "InMemoryBackend",
+]

--- a/flujo/state/backends/__init__.py
+++ b/flujo/state/backends/__init__.py
@@ -1,0 +1,4 @@
+from .base import StateBackend
+from .memory import InMemoryBackend
+
+__all__ = ["StateBackend", "InMemoryBackend"]

--- a/flujo/state/backends/base.py
+++ b/flujo/state/backends/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class StateBackend(ABC):
+    """Abstract interface for workflow state persistence."""
+
+    @abstractmethod
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        """Persist the serialized state for ``run_id``."""
+        ...
+
+    @abstractmethod
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Load and return the serialized state for ``run_id`` if present."""
+        ...
+
+    @abstractmethod
+    async def delete_state(self, run_id: str) -> None:
+        """Remove any persisted state for ``run_id``."""
+        ...

--- a/flujo/state/backends/memory.py
+++ b/flujo/state/backends/memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, Dict, Optional
+
+from .base import StateBackend
+
+
+class InMemoryBackend(StateBackend):
+    """Simple in-memory backend for testing and defaults."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        async with self._lock:
+            self._store[run_id] = copy.deepcopy(state)
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            return copy.deepcopy(self._store.get(run_id))
+
+    async def delete_state(self, run_id: str) -> None:
+        async with self._lock:
+            self._store.pop(run_id, None)

--- a/flujo/state/models.py
+++ b/flujo/state/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from ..domain.models import BaseModel
+from pydantic import Field
+
+
+class WorkflowState(BaseModel):
+    """Serialized snapshot of a running workflow."""
+
+    run_id: str
+    pipeline_id: str
+    pipeline_version: str
+    current_step_index: int
+    pipeline_context: Dict[str, Any]
+    last_step_output: Any | None = None
+    status: Literal["running", "paused", "completed", "failed", "cancelled"]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["WorkflowState"]

--- a/tests/integration/test_stateful_runner.py
+++ b/tests/integration/test_stateful_runner.py
@@ -1,0 +1,160 @@
+from datetime import datetime
+
+import asyncio
+import pytest
+
+from flujo.exceptions import OrchestratorError
+
+from flujo.application.runner import Flujo
+from flujo.state import WorkflowState
+from flujo.state.backends.memory import InMemoryBackend
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.testing.utils import gather_result
+
+
+class Ctx(PipelineContext):
+    pass
+
+
+async def step_one(data: str) -> str:
+    return "mid"
+
+
+async def step_two(data: str) -> str:
+    return data + " done"
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_state_backend() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=False)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    assert len(result.step_history) == 2
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "completed"
+    assert wf_state.current_step_index == 2
+    assert wf_state.last_step_output == "mid done"
+
+
+@pytest.mark.asyncio
+async def test_resume_from_saved_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "run123"
+    ctx_after_first = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1 >> s2)),
+        pipeline_version="0",
+        current_step_index=1,
+        pipeline_context=ctx_after_first.model_dump(),
+        last_step_output="mid",
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    saved_after = await backend.load_state(run_id)
+    assert saved_after is not None
+    wf_state_after = WorkflowState.model_validate(saved_after)
+    assert wf_state_after.current_step_index == 2
+    assert wf_state_after.last_step_output == "mid done"
+
+
+@pytest.mark.asyncio
+async def test_delete_on_completion_removes_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=True)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_step_index_raises() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "badidx"
+    ctx = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1 >> s2)),
+        pipeline_version="0",
+        current_step_index=3,
+        pipeline_context=ctx.model_dump(),
+        last_step_output=None,
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    with pytest.raises(OrchestratorError, match="Invalid persisted step index"):
+        async for _ in runner.run_async(
+            "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_cancelled_pipeline_state_saved() -> None:
+    backend = InMemoryBackend()
+
+    async def long_step(data: str) -> str:
+        await asyncio.sleep(1)
+        return data
+
+    s = Step.from_callable(long_step, name="long")
+    run_id = "cancelled_run"
+    runner = Flujo(
+        s,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+
+    async def consume() -> None:
+        async for _ in runner.run_async(
+            "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    await task
+
+    saved = await backend.load_state(run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "cancelled"

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flujo.state.backends.memory import InMemoryBackend
+
+
+@pytest.mark.asyncio
+async def test_inmemory_backend_roundtrip() -> None:
+    backend = InMemoryBackend()
+    await backend.save_state("run1", {"foo": 1})
+    loaded = await backend.load_state("run1")
+    assert loaded == {"foo": 1}
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None


### PR DESCRIPTION
## Summary
- extend `WorkflowState.status` to include `cancelled`
- validate saved step index when resuming and restore step output without casting
- preserve original `created_at` timestamp when resuming a run
- mark cancelled runs correctly and avoid mislabelling empty histories
- add integration tests for invalid step index and cancelled runs

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_686c3b187644832c9ffa445563ec8f0a