### PR TITLE
Fix validation for start index

### DIFF
--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -658,7 +658,7 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         if scratch.get("status") != "paused":
             raise OrchestratorError("Pipeline is not paused")
         start_idx = len(paused_result.step_history)
-        if start_idx >= len(self.pipeline.steps):
+        if start_idx > len(self.pipeline.steps):
             raise OrchestratorError("No steps remaining to resume")
         paused_step = self.pipeline.steps[start_idx]
 


### PR DESCRIPTION
```
---
name: Pull Request
about: Propose a change to Flujo
---

### Description

Fixes a bug in `flujo/application/runner.py` where the `start_idx` validation in the `resume_async` method was too strict. The condition `start_idx >= len(self.pipeline.steps)` incorrectly flagged a completed pipeline (where `start_idx` equals the pipeline length) as an invalid state.

The validation has been updated to `start_idx > len(self.pipeline.steps)` to correctly identify only truly out-of-bounds indices, allowing completed pipelines to be recognized as valid.

### Related Issue

*Closes #issue_number* (No specific issue provided)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring or performance enhancement

### Checklist

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the style guidelines of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.
```