### PR TITLE
Fix validation for persisted step index

### DIFF
--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -5,6 +5,7 @@ import inspect
 import time
 import weakref
 import copy
+from datetime import datetime
 from typing import (
     Any,
     Callable,
@@ -51,6 +52,7 @@ from ..domain.resources import AppResources
 from ..domain.types import HookCallable
 from ..domain.backends import ExecutionBackend, StepExecutionRequest
 from ..tracing import ConsoleTracer
+from ..state import StateBackend, WorkflowState
 
 from .context_manager import (
     _accepts_param,
@@ -169,6 +171,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         usage_limits: Optional[UsageLimits] = None,
         hooks: Optional[list[HookCallable]] = None,
         backend: Optional[ExecutionBackend] = None,
+        state_backend: Optional[StateBackend] = None,
+        delete_on_completion: bool = False,
+        pipeline_version: str = "0",
         local_tracer: Union[str, "ConsoleTracer", None] = None,
     ) -> None:
         if isinstance(pipeline, Step):
@@ -191,6 +196,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
 
             backend = LocalBackend()
         self.backend = backend
+        self.state_backend = state_backend
+        self.delete_on_completion = delete_on_completion
+        self.pipeline_version = pipeline_version
 
     async def _dispatch_hook(
         self,
@@ -341,6 +349,38 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         if ctx is not None:
             result.final_pipeline_context = ctx
 
+    async def _persist_workflow_state(
+        self,
+        *,
+        run_id: str | None,
+        context: Optional[ContextT],
+        current_step_index: int,
+        last_step_output: Any | None,
+        status: Literal["running", "paused", "completed", "failed", "cancelled"],
+        state_created_at: datetime | None,
+        state_backend: StateBackend | None = None,
+    ) -> None:
+        """Persist workflow state if a backend is configured."""
+
+        backend = state_backend or self.state_backend
+        if backend is None or not run_id or context is None:
+            return
+
+        wf_state = WorkflowState(
+            run_id=run_id,
+            pipeline_id=str(id(self.pipeline)),
+            pipeline_version=self.pipeline_version,
+            current_step_index=current_step_index,
+            pipeline_context=context.model_dump(),
+            last_step_output=last_step_output,
+            status=status,
+            created_at=state_created_at or datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        await backend.save_state(run_id, wf_state.model_dump())
+        if self.delete_on_completion and status in {"completed", "failed"}:
+            await backend.delete_state(run_id)
+
     async def _execute_steps(
         self,
         start_idx: int,
@@ -349,6 +389,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         result: PipelineResult[ContextT],
         *,
         stream_last: bool = False,
+        run_id: str | None = None,
+        state_backend: StateBackend | None = None,
+        state_created_at: datetime | None = None,
     ) -> AsyncIterator[Any]:
         """Iterate over pipeline steps yielding streaming output.
 
@@ -475,6 +518,16 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     context=context,
                     resources=self.resources,
                 )
+                if state_backend is not None and context is not None and run_id is not None:
+                    await self._persist_workflow_state(
+                        run_id=run_id,
+                        context=context,
+                        current_step_index=idx + 1,
+                        last_step_output=step_result.output,
+                        status="running",
+                        state_created_at=state_created_at,
+                        state_backend=state_backend,
+                    )
             else:
                 await self._dispatch_hook(
                     "on_step_failure",
@@ -543,8 +596,42 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         if isinstance(current_context_instance, PipelineContext):
             current_context_instance.scratchpad["status"] = "running"
 
-        data: Optional[RunnerInT] = initial_input
+        data: Any = initial_input
         pipeline_result_obj: PipelineResult[ContextT] = PipelineResult()
+        start_idx = 0
+        state_created_at: datetime | None = None
+        run_id_for_state = getattr(current_context_instance, "run_id", None)
+        if self.state_backend is not None and run_id_for_state:
+            loaded = await self.state_backend.load_state(run_id_for_state)
+            if loaded is not None:
+                wf_state = WorkflowState.model_validate(loaded)
+                start_idx = wf_state.current_step_index
+                state_created_at = wf_state.created_at
+                if start_idx > len(self.pipeline.steps):
+                    raise OrchestratorError(
+                        f"Invalid persisted step index {start_idx} for pipeline with {len(self.pipeline.steps)} steps"
+                    )
+                if wf_state.pipeline_context is not None:
+                    if self.context_model is not None:
+                        current_context_instance = self.context_model.model_validate(
+                            wf_state.pipeline_context
+                        )
+                    else:
+                        current_context_instance = cast(
+                            ContextT, PipelineContext.model_validate(wf_state.pipeline_context)
+                        )
+                if start_idx > 0:
+                    data = wf_state.last_step_output
+            await self._persist_workflow_state(
+                run_id=run_id_for_state,
+                context=current_context_instance,
+                current_step_index=start_idx,
+                last_step_output=data,
+                status="running",
+                state_created_at=state_created_at,
+                state_backend=self.state_backend,
+            )
+        cancelled = False
         try:
             await self._dispatch_hook(
                 "pre_run",
@@ -553,15 +640,19 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                 resources=self.resources,
             )
             async for chunk in self._execute_steps(
-                0,
+                start_idx,
                 data,
                 cast(Optional[ContextT], current_context_instance),
                 pipeline_result_obj,
                 stream_last=True,
+                run_id=run_id_for_state,
+                state_backend=self.state_backend,
+                state_created_at=state_created_at,
             ):
                 yield chunk
         except asyncio.CancelledError:
             telemetry.logfire.info("Pipeline cancelled")
+            cancelled = True
             yield pipeline_result_obj
             return
         except PipelineAbortSignal as e:
@@ -579,14 +670,39 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     pipeline_result_obj,
                     cast(Optional[ContextT], current_context_instance),
                 )
+                final_status: Literal[
+                    "running",
+                    "paused",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                ]
+                if cancelled:
+                    final_status = "cancelled"
+                elif pipeline_result_obj.step_history:
+                    final_status = (
+                        "completed"
+                        if all(s.success for s in pipeline_result_obj.step_history)
+                        else "failed"
+                    )
+                else:
+                    final_status = "failed"
                 if isinstance(current_context_instance, PipelineContext):
-                    if current_context_instance.scratchpad.get("status") != "paused":
-                        status = (
-                            "completed"
-                            if all(s.success for s in pipeline_result_obj.step_history)
-                            else "failed"
-                        )
-                        current_context_instance.scratchpad["status"] = status
+                    if current_context_instance.scratchpad.get("status") == "paused":
+                        final_status = "paused"
+                    current_context_instance.scratchpad["status"] = final_status
+                await self._persist_workflow_state(
+                    run_id=getattr(current_context_instance, "run_id", None),
+                    context=current_context_instance,
+                    current_step_index=start_idx + len(pipeline_result_obj.step_history),
+                    last_step_output=(
+                        pipeline_result_obj.step_history[-1].output
+                        if pipeline_result_obj.step_history
+                        else None
+                    ),
+                    status=final_status,
+                    state_created_at=state_created_at,
+                )
             try:
                 await self._dispatch_hook(
                     "post_run",
@@ -697,21 +813,53 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         paused_result.step_history.append(paused_step_result)
 
         data = human_input
+        run_id_for_state = getattr(ctx, "run_id", None)
+        state_created_at: datetime | None = None
+        if self.state_backend is not None and run_id_for_state is not None:
+            loaded = await self.state_backend.load_state(run_id_for_state)
+            if loaded is not None:
+                wf_state_loaded = WorkflowState.model_validate(loaded)
+                state_created_at = wf_state_loaded.created_at
         async for _ in self._execute_steps(
             start_idx + 1,
             data,
             cast(Optional[ContextT], ctx),
             paused_result,
             stream_last=False,
+            run_id=run_id_for_state,
+            state_backend=self.state_backend,
+            state_created_at=state_created_at,
         ):
             pass
 
+        final_status: Literal[
+            "running",
+            "paused",
+            "completed",
+            "failed",
+            "cancelled",
+        ]
+        if paused_result.step_history:
+            final_status = (
+                "completed" if all(s.success for s in paused_result.step_history) else "failed"
+            )
+        else:
+            final_status = "failed"
         if isinstance(ctx, PipelineContext):
-            if ctx.scratchpad.get("status") != "paused":
-                status = (
-                    "completed" if all(s.success for s in paused_result.step_history) else "failed"
-                )
-                ctx.scratchpad["status"] = status
+            if ctx.scratchpad.get("status") == "paused":
+                final_status = "paused"
+            ctx.scratchpad["status"] = final_status
+
+        await self._persist_workflow_state(
+            run_id=run_id_for_state,
+            context=ctx,
+            current_step_index=len(paused_result.step_history),
+            last_step_output=(
+                paused_result.step_history[-1].output if paused_result.step_history else None
+            ),
+            status=final_status,
+            state_created_at=state_created_at,
+        )
 
         self._set_final_context(paused_result, cast(Optional[ContextT], ctx))
         return paused_result

--- a/flujo/state/__init__.py
+++ b/flujo/state/__init__.py
@@ -1,0 +1,9 @@
+from .models import WorkflowState
+from .backends.base import StateBackend
+from .backends.memory import InMemoryBackend
+
+__all__ = [
+    "WorkflowState",
+    "StateBackend",
+    "InMemoryBackend",
+]

--- a/flujo/state/backends/__init__.py
+++ b/flujo/state/backends/__init__.py
@@ -1,0 +1,4 @@
+from .base import StateBackend
+from .memory import InMemoryBackend
+
+__all__ = ["StateBackend", "InMemoryBackend"]

--- a/flujo/state/backends/base.py
+++ b/flujo/state/backends/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class StateBackend(ABC):
+    """Abstract interface for workflow state persistence."""
+
+    @abstractmethod
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        """Persist the serialized state for ``run_id``."""
+        ...
+
+    @abstractmethod
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Load and return the serialized state for ``run_id`` if present."""
+        ...
+
+    @abstractmethod
+    async def delete_state(self, run_id: str) -> None:
+        """Remove any persisted state for ``run_id``."""
+        ...

--- a/flujo/state/backends/memory.py
+++ b/flujo/state/backends/memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, Dict, Optional
+
+from .base import StateBackend
+
+
+class InMemoryBackend(StateBackend):
+    """Simple in-memory backend for testing and defaults."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        async with self._lock:
+            self._store[run_id] = copy.deepcopy(state)
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            return copy.deepcopy(self._store.get(run_id))
+
+    async def delete_state(self, run_id: str) -> None:
+        async with self._lock:
+            self._store.pop(run_id, None)

--- a/flujo/state/models.py
+++ b/flujo/state/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from ..domain.models import BaseModel
+from pydantic import Field
+
+
+class WorkflowState(BaseModel):
+    """Serialized snapshot of a running workflow."""
+
+    run_id: str
+    pipeline_id: str
+    pipeline_version: str
+    current_step_index: int
+    pipeline_context: Dict[str, Any]
+    last_step_output: Any | None = None
+    status: Literal["running", "paused", "completed", "failed", "cancelled"]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["WorkflowState"]

--- a/tests/integration/test_stateful_runner.py
+++ b/tests/integration/test_stateful_runner.py
@@ -1,0 +1,163 @@
+from datetime import datetime
+
+import asyncio
+import pytest
+
+from flujo.exceptions import OrchestratorError
+
+from flujo.application.runner import Flujo
+from flujo.state import WorkflowState
+from flujo.state.backends.memory import InMemoryBackend
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.testing.utils import gather_result
+
+
+class Ctx(PipelineContext):
+    pass
+
+
+async def step_one(data: str) -> str:
+    return "mid"
+
+
+async def step_two(data: str) -> str:
+    return data + " done"
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_state_backend() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=False)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    assert len(result.step_history) == 2
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "completed"
+    assert wf_state.current_step_index == 2
+    assert wf_state.last_step_output == "mid done"
+
+
+@pytest.mark.asyncio
+async def test_resume_from_saved_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "run123"
+    ctx_after_first = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1 >> s2)),
+        pipeline_version="0",
+        current_step_index=1,
+        pipeline_context=ctx_after_first.model_dump(),
+        last_step_output="mid",
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    saved_after = await backend.load_state(run_id)
+    assert saved_after is not None
+    wf_state_after = WorkflowState.model_validate(saved_after)
+    assert wf_state_after.current_step_index == 2
+    assert wf_state_after.last_step_output == "mid done"
+
+
+@pytest.mark.asyncio
+async def test_delete_on_completion_removes_state() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    runner = Flujo(s1 >> s2, context_model=Ctx, state_backend=backend, delete_on_completion=True)
+    result = await gather_result(runner, "x", initial_context_data={"initial_prompt": "x"})
+    saved = await backend.load_state(result.final_pipeline_context.run_id)
+    assert saved is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_step_index_raises() -> None:
+    backend = InMemoryBackend()
+    s1 = Step.from_callable(step_one, name="s1")
+    s2 = Step.from_callable(step_two, name="s2")
+    run_id = "badidx"
+    ctx = Ctx(initial_prompt="x", run_id=run_id)
+    state = WorkflowState(
+        run_id=run_id,
+        pipeline_id=str(id(s1 >> s2)),
+        pipeline_version="0",
+        current_step_index=3,
+        pipeline_context=ctx.model_dump(),
+        last_step_output=None,
+        status="running",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    await backend.save_state(run_id, state.model_dump())
+
+    runner = Flujo(
+        s1 >> s2,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    with pytest.raises(
+        OrchestratorError,
+        match=r"Invalid persisted step index 3 for pipeline with 2 steps",
+    ):
+        async for _ in runner.run_async(
+            "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_cancelled_pipeline_state_saved() -> None:
+    backend = InMemoryBackend()
+
+    async def long_step(data: str) -> str:
+        await asyncio.sleep(1)
+        return data
+
+    s = Step.from_callable(long_step, name="long")
+    run_id = "cancelled_run"
+    runner = Flujo(
+        s,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+
+    async def consume() -> None:
+        async for _ in runner.run_async(
+            "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    await task
+
+    saved = await backend.load_state(run_id)
+    assert saved is not None
+    wf_state = WorkflowState.model_validate(saved)
+    assert wf_state.status == "cancelled"

--- a/tests/unit/test_state_backend.py
+++ b/tests/unit/test_state_backend.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flujo.state.backends.memory import InMemoryBackend
+
+
+@pytest.mark.asyncio
+async def test_inmemory_backend_roundtrip() -> None:
+    backend = InMemoryBackend()
+    await backend.save_state("run1", {"foo": 1})
+    loaded = await backend.load_state("run1")
+    assert loaded == {"foo": 1}
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None


### PR DESCRIPTION
## Summary
- refine persisted step index validation for resume logic
- include more detail in the error message
- adjust test to match updated message

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_686c3b187644832c9ffa445563ec8f0a