### PR TITLE
Add persistent file/sqlite backends

### DIFF
--- a/flujo/state/__init__.py
+++ b/flujo/state/__init__.py
@@ -1,9 +1,13 @@
 from .models import WorkflowState
 from .backends.base import StateBackend
 from .backends.memory import InMemoryBackend
+from .backends.file import FileBackend
+from .backends.sqlite import SQLiteBackend
 
 __all__ = [
     "WorkflowState",
     "StateBackend",
     "InMemoryBackend",
+    "FileBackend",
+    "SQLiteBackend",
 ]

--- a/flujo/state/backends/__init__.py
+++ b/flujo/state/backends/__init__.py
@@ -1,4 +1,11 @@
 from .base import StateBackend
 from .memory import InMemoryBackend
+from .file import FileBackend
+from .sqlite import SQLiteBackend
 
-__all__ = ["StateBackend", "InMemoryBackend"]
+__all__ = [
+    "StateBackend",
+    "InMemoryBackend",
+    "FileBackend",
+    "SQLiteBackend",
+]

--- a/flujo/state/backends/file.py
+++ b/flujo/state/backends/file.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, cast
+
+import orjson
+
+from .base import StateBackend
+
+
+class FileBackend(StateBackend):
+    """Persist workflow state to JSON files."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        file_path = self.path / f"{run_id}.json"
+        data = orjson.dumps(state)
+        async with self._lock:
+            await asyncio.to_thread(self._atomic_write, file_path, data)
+
+    def _atomic_write(self, file_path: Path, data: bytes) -> None:
+        tmp = file_path.with_suffix(file_path.suffix + ".tmp")
+        with open(tmp, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, file_path)
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        file_path = self.path / f"{run_id}.json"
+        async with self._lock:
+            if not file_path.exists():
+                return None
+            return await asyncio.to_thread(self._read_json, file_path)
+
+    def _read_json(self, file_path: Path) -> Dict[str, Any]:
+        with open(file_path, "rb") as f:
+            data = orjson.loads(f.read())
+        return cast(Dict[str, Any], data)
+
+    async def delete_state(self, run_id: str) -> None:
+        file_path = self.path / f"{run_id}.json"
+        async with self._lock:
+            if file_path.exists():
+                await asyncio.to_thread(file_path.unlink)

--- a/flujo/state/backends/sqlite.py
+++ b/flujo/state/backends/sqlite.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import orjson
+import aiosqlite
+
+from .base import StateBackend
+
+
+class SQLiteBackend(StateBackend):
+    """SQLite-backed persistent storage for workflow state."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+        self._initialized = False
+
+    async def _init_db(self) -> None:
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_state (
+                    run_id TEXT PRIMARY KEY,
+                    pipeline_id TEXT,
+                    pipeline_version TEXT,
+                    current_step_index INTEGER,
+                    pipeline_context TEXT,
+                    last_step_output TEXT,
+                    status TEXT,
+                    created_at TEXT,
+                    updated_at TEXT
+                )
+                """
+            )
+            await db.commit()
+
+    async def _ensure_init(self) -> None:
+        if not self._initialized:
+            async with self._lock:
+                if not self._initialized:
+                    await self._init_db()
+                    self._initialized = True
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        await self._ensure_init()
+        async with self._lock:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute(
+                    """
+                    INSERT OR REPLACE INTO workflow_state (
+                        run_id,
+                        pipeline_id,
+                        pipeline_version,
+                        current_step_index,
+                        pipeline_context,
+                        last_step_output,
+                        status,
+                        created_at,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        state["pipeline_id"],
+                        state["pipeline_version"],
+                        state["current_step_index"],
+                        orjson.dumps(state["pipeline_context"]).decode(),
+                        (
+                            orjson.dumps(state["last_step_output"]).decode()
+                            if state.get("last_step_output") is not None
+                            else None
+                        ),
+                        state["status"],
+                        state["created_at"].isoformat(),
+                        state["updated_at"].isoformat(),
+                    ),
+                )
+                await db.commit()
+
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        await self._ensure_init()
+        async with self._lock:
+            async with aiosqlite.connect(self.db_path) as db:
+                cursor = await db.execute(
+                    """
+                    SELECT run_id, pipeline_id, pipeline_version, current_step_index,
+                           pipeline_context, last_step_output, status, created_at,
+                           updated_at
+                    FROM workflow_state WHERE run_id = ?
+                    """,
+                    (run_id,),
+                )
+                row = await cursor.fetchone()
+                await cursor.close()
+        if row is None:
+            return None
+        pipeline_context = orjson.loads(row[4]) if row[4] is not None else {}
+        last_step_output = orjson.loads(row[5]) if row[5] is not None else None
+        return {
+            "run_id": row[0],
+            "pipeline_id": row[1],
+            "pipeline_version": row[2],
+            "current_step_index": row[3],
+            "pipeline_context": pipeline_context,
+            "last_step_output": last_step_output,
+            "status": row[6],
+            "created_at": datetime.fromisoformat(row[7]),
+            "updated_at": datetime.fromisoformat(row[8]),
+        }
+
+    async def delete_state(self, run_id: str) -> None:
+        await self._ensure_init()
+        async with self._lock:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute(
+                    "DELETE FROM workflow_state WHERE run_id = ?",
+                    (run_id,),
+                )
+                await db.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "rich>=13.7",
   "pydantic-evals>=0.0.47", # Added for Intelligent Evals
   "orjson>=3.9.0",
+  "aiosqlite>=0.21.0",
 ]
 
 # Optional dependency groups (install with: `pip install .[dev]`, etc.)

--- a/tests/integration/test_persistence_backends.py
+++ b/tests/integration/test_persistence_backends.py
@@ -1,0 +1,155 @@
+import subprocess
+import sys
+from pathlib import Path
+import asyncio
+
+import pytest
+
+from flujo.application.runner import Flujo
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.state.backends.file import FileBackend
+from flujo.state.backends.sqlite import SQLiteBackend
+from flujo.testing.utils import gather_result
+from flujo.state import WorkflowState
+
+
+class Ctx(PipelineContext):
+    pass
+
+
+async def step_one(data: str) -> str:
+    return "mid"
+
+
+async def step_two(data: str) -> str:
+    return data + " done"
+
+
+def _run_crashing_process(backend_type: str, path: Path, run_id: str) -> int:
+    script = f"""
+import asyncio, os
+from pathlib import Path
+from flujo.application.runner import Flujo
+from flujo.domain import Step
+from flujo.domain.models import PipelineContext
+from flujo.state.backends.{"file" if backend_type == "FileBackend" else "sqlite"} import {backend_type}
+
+class Ctx(PipelineContext):
+    pass
+
+async def s1(data: str) -> str:
+    return 'mid'
+
+class CrashAgent:
+    async def run(self, data: str) -> str:
+        os._exit(1)
+
+async def main():
+    backend = {backend_type}(Path(r'{path}'))
+    runner = Flujo(
+        Step.from_callable(s1, name='s1') >> Step.from_callable(CrashAgent().run, name='crash'),
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={{'run_id': '{run_id}'}}
+    )
+    async for _ in runner.run_async('x', initial_context_data={{'initial_prompt': 'x', 'run_id': '{run_id}'}}):
+        pass
+
+asyncio.run(main())
+"""
+    result = subprocess.run([sys.executable, "-"], input=script, text=True)
+    return result.returncode
+
+
+@pytest.mark.asyncio
+async def test_file_backend_resume_after_crash(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    run_id = "run_file"
+    rc = _run_crashing_process("FileBackend", state_dir, run_id)
+    assert rc != 0
+    backend = FileBackend(state_dir)
+    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(
+        step_two, name="s2"
+    )
+    runner = Flujo(
+        pipeline,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    assert result.step_history[0].output == "mid done"
+    saved = await backend.load_state(run_id)
+    assert saved is not None
+    wf = WorkflowState.model_validate(saved)
+    assert wf.current_step_index == 2
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_resume_after_crash(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    run_id = "run_sqlite"
+    rc = _run_crashing_process("SQLiteBackend", db_path, run_id)
+    assert rc != 0
+    backend = SQLiteBackend(db_path)
+    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(
+        step_two, name="s2"
+    )
+    runner = Flujo(
+        pipeline,
+        context_model=Ctx,
+        state_backend=backend,
+        delete_on_completion=False,
+        initial_context_data={"run_id": run_id},
+    )
+    result = await gather_result(
+        runner, "x", initial_context_data={"initial_prompt": "x", "run_id": run_id}
+    )
+    assert len(result.step_history) == 1
+    assert result.step_history[0].name == "s2"
+    assert result.step_history[0].output == "mid done"
+    saved = await backend.load_state(run_id)
+    assert saved is not None
+    wf = WorkflowState.model_validate(saved)
+    assert wf.current_step_index == 2
+
+
+@pytest.mark.asyncio
+async def test_file_backend_concurrent(tmp_path: Path) -> None:
+    backend = FileBackend(tmp_path)
+
+    async def inc(data: int) -> int:
+        await asyncio.sleep(0.05)
+        return data + 1
+
+    pipeline = Step.from_callable(inc, name="a") >> Step.from_callable(inc, name="b")
+
+    async def run_one(i: int) -> None:
+        rid = f"run{i}"
+        runner = Flujo(
+            pipeline,
+            context_model=Ctx,
+            state_backend=backend,
+            delete_on_completion=False,
+            initial_context_data={"run_id": rid},
+        )
+        await gather_result(
+            runner, 0, initial_context_data={"initial_prompt": "x", "run_id": rid}
+        )
+
+    await asyncio.gather(*(run_one(i) for i in range(5)))
+
+    for i in range(5):
+        loaded = await backend.load_state(f"run{i}")
+        assert loaded is not None
+        wf = WorkflowState.model_validate(loaded)
+        assert wf.current_step_index == 2
+        assert wf.last_step_output == 2

--- a/tests/unit/test_file_sqlite_backends.py
+++ b/tests/unit/test_file_sqlite_backends.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from pathlib import Path
+import asyncio
+
+import pytest
+
+from flujo.state.backends.file import FileBackend
+from flujo.state.backends.sqlite import SQLiteBackend
+
+
+@pytest.mark.asyncio
+async def test_file_backend_roundtrip(tmp_path: Path) -> None:
+    backend = FileBackend(tmp_path)
+    state = {"foo": "bar"}
+    await backend.save_state("run1", state)
+    loaded = await backend.load_state("run1")
+    assert loaded == state
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None
+
+
+@pytest.mark.asyncio
+async def test_file_backend_load_during_delete(tmp_path: Path) -> None:
+    backend = FileBackend(tmp_path)
+    await backend.save_state("run1", {"foo": 1})
+
+    await asyncio.gather(backend.load_state("run1"), backend.delete_state("run1"))
+    # load_state should not raise even if file is deleted concurrently
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_roundtrip(tmp_path: Path) -> None:
+    backend = SQLiteBackend(tmp_path / "state.db")
+    now = datetime.utcnow().replace(microsecond=0)
+    state = {
+        "run_id": "run1",
+        "pipeline_id": "p",
+        "pipeline_version": "0",
+        "current_step_index": 1,
+        "pipeline_context": {"a": 1},
+        "last_step_output": "x",
+        "status": "running",
+        "created_at": now,
+        "updated_at": now,
+    }
+    await backend.save_state("run1", state)
+    loaded = await backend.load_state("run1")
+    assert loaded is not None
+    assert loaded["pipeline_context"] == {"a": 1}
+    assert loaded["last_step_output"] == "x"
+    assert loaded["created_at"] == now
+    assert loaded["updated_at"] == now
+    await backend.delete_state("run1")
+    assert await backend.load_state("run1") is None


### PR DESCRIPTION
## Summary
- add FileBackend and SQLiteBackend implementations
- export the new backends
- include aiosqlite runtime dependency
- test persistence backends for crash recovery and concurrency
- fix SQLiteBackend locking and datetime serialization

## Testing
- `make quality`
- `make test`
- `make cov`
- `make audit`


------
https://chatgpt.com/codex/tasks/task_e_686c5e34af98832c91da6167e693e5db