### PR TITLE
Disable run_python command

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -387,17 +387,6 @@ command = RunAgentCommand(
 )
 ```
 
-#### `RunPythonCodeCommand`
-
-Executes a snippet of Python code within a secure sandbox environment. The result of the execution is expected to be in a variable named `result`.
-
-```python
-from flujo.domain.commands import RunPythonCodeCommand
-
-command = RunPythonCodeCommand(
-    code="result = 1 + 1"
-)
-```
 
 #### `AskHumanCommand`
 

--- a/docs/recipes/agentic_loop.md
+++ b/docs/recipes/agentic_loop.md
@@ -30,24 +30,7 @@ if paused.status == "paused":
 Your planner agent must emit one of the following commands on each turn:
 
 - `RunAgentCommand(agent_name, input_data)` – delegate work to a registered sub-agent.
-- `RunPythonCodeCommand(code)` – run a Python snippet. The result should be stored in a variable named `result`.
 - `AskHumanCommand(question)` – pause the loop and wait for human input.
 - `FinishCommand(final_answer)` – end the loop with a final answer.
 
-For example, you can run Python code safely:
-
-```python
-planner = StubAgent([
-    RunPythonCodeCommand(code="result = 1 + 1"),
-    FinishCommand(final_answer="done"),
-])
-loop = AgenticLoop(planner, {})
-result = loop.run("goal")
-print(result.final_pipeline_context.command_log[0].execution_result)
-```
-
-## Security Note
-
-`RunPythonCodeCommand` executes Python code with built-ins disabled and will
-reject any `import` statements. It still runs in-process, so you must ensure a
-safe sandbox for untrusted input.
+The previously supported `RunPythonCodeCommand` has been removed due to security concerns.

--- a/flujo/domain/commands.py
+++ b/flujo/domain/commands.py
@@ -16,14 +16,6 @@ class RunAgentCommand(BaseModel):
     input_data: Any = Field(..., description="The input data to pass to the sub-agent.")
 
 
-class RunPythonCodeCommand(BaseModel):
-    """Execute a snippet of Python code. Requires a secure sandbox."""
-
-    type: Literal["run_python"] = "run_python"
-    code: str = Field(..., description="The Python code to execute.")
-    # Result is expected in variable 'result'
-
-
 class AskHumanCommand(BaseModel):
     """Pause execution and ask a human for input."""
 
@@ -38,7 +30,7 @@ class FinishCommand(BaseModel):
     final_answer: Any = Field(..., description="The final result or summary of the task.")
 
 
-AgentCommand = Union[RunAgentCommand, RunPythonCodeCommand, AskHumanCommand, FinishCommand]
+AgentCommand = Union[RunAgentCommand, AskHumanCommand, FinishCommand]
 
 
 class ExecutedCommandLog(BaseModel):

--- a/flujo/recipes/agentic_loop.py
+++ b/flujo/recipes/agentic_loop.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ..domain.resources import AppResources
-import ast
 import asyncio
 from pydantic import TypeAdapter, ValidationError
 
@@ -242,22 +241,7 @@ class _CommandExecutor:
                         agent_kwargs["resources"] = resources
                     exec_result = await agent.run(cmd.input_data, **agent_kwargs)
             elif cmd.type == "run_python":
-                tree = ast.parse(cmd.code, mode="exec")
-                for node in ast.walk(tree):
-                    if isinstance(node, (ast.Import, ast.ImportFrom)):
-                        raise ValueError("Imports are not allowed in run_python")
-                local_scope: Dict[str, Any] = {}
-                # WARNING: The following use of exec is sandboxed with empty __builtins__ for security.
-                # Only trusted code should be executed here. Review all inputs to this exec carefully.
-                import logging
-
-                logging.info(f"Executing trusted user code in agentic_loop: {cmd.code}")
-                exec(  # nosec B102 - Sandboxed exec with empty __builtins__ for trusted user code
-                    compile(tree, filename="<agentic_loop>", mode="exec"),
-                    {"__builtins__": {}},
-                    local_scope,
-                )
-                exec_result = local_scope.get("result", "Python code executed successfully.")
+                exec_result = "Error: run_python command is disabled for security reasons."
             elif cmd.type == "ask_human":
                 if isinstance(context_obj, PipelineContext):
                     context_obj.scratchpad["paused_step_input"] = cmd

--- a/tests/integration/test_agentic_loop_recipe.py
+++ b/tests/integration/test_agentic_loop_recipe.py
@@ -4,7 +4,6 @@ import pytest
 from flujo.recipes.agentic_loop import AgenticLoop
 from flujo.domain.commands import (
     RunAgentCommand,
-    RunPythonCodeCommand,
     AskHumanCommand,
     FinishCommand,
 )
@@ -72,31 +71,3 @@ async def test_max_loops_failure() -> None:
     assert len(ctx.command_log) == 3
     last_step = result.step_history[-1]
     assert last_step.success is False
-
-
-@pytest.mark.asyncio
-async def test_run_python_safe() -> None:
-    planner = StubAgent(
-        [
-            RunPythonCodeCommand(code="result = 1 + 1"),
-            FinishCommand(final_answer="done"),
-        ]
-    )
-    loop = AgenticLoop(planner, {})
-    result = await loop.run_async("goal")
-    ctx = result.final_pipeline_context
-    assert ctx.command_log[0].execution_result == 2
-
-
-@pytest.mark.asyncio
-async def test_run_python_rejects_imports() -> None:
-    planner = StubAgent(
-        [
-            RunPythonCodeCommand(code="import os\nresult = 42"),
-            FinishCommand(final_answer="done"),
-        ]
-    )
-    loop = AgenticLoop(planner, {})
-    result = await loop.run_async("goal")
-    log_entry = result.final_pipeline_context.command_log[0]
-    assert "Imports are not allowed" in str(log_entry.execution_result)


### PR DESCRIPTION
## Summary
- remove insecure run_python execution from AgenticLoop
- drop RunPythonCodeCommand model
- update docs accordingly
- remove run_python tests

## Testing
- `ruff check flujo tests`
- `ruff format flujo tests --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8a298fc0832ca51daaf47c0abb9b