### PR TITLE
Fix streaming step execution to reuse normal logic

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -479,9 +479,10 @@ local_backend = LocalBackend(agent_registry={
 # When a step is executed, a StepExecutionRequest is sent to the backend:
 request = StepExecutionRequest(
     step=Step(...),
-    input_data=..., 
+    input_data=...,
     context=PipelineContext(initial_prompt=""),
     resources=None,
+    stream=False,  # Set to True to enable streaming
 )
 
 # The execute_step method handles the actual running of the step's logic

--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, Any, Dict, Optional
+from typing import Protocol, Any, Dict, Optional, Callable, Awaitable
 from dataclasses import dataclass
 from flujo.domain.models import BaseModel
 
@@ -35,6 +35,9 @@ class StepExecutionRequest:
     # Usage limits, propagated so nested executions (e.g., LoopStep) can enforce
     # governor checks mid-execution.
     usage_limits: Optional["UsageLimits"] = None
+    # Streaming support
+    stream: bool = False
+    on_chunk: Optional[Callable[[Any], Awaitable[None]]] = None
 
 
 class ExecutionBackend(Protocol):

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -35,6 +35,8 @@ class LocalBackend(ExecutionBackend):
                 resources=resources,
                 context_model_defined=request.context_model_defined,
                 usage_limits=request.usage_limits,
+                stream=request.stream,
+                on_chunk=request.on_chunk,
             )
             return await self.execute_step(nested_request)
 
@@ -46,4 +48,6 @@ class LocalBackend(ExecutionBackend):
             step_executor=executor,
             context_model_defined=request.context_model_defined,
             usage_limits=request.usage_limits,
+            stream=request.stream,
+            on_chunk=request.on_chunk,
         )

--- a/flujo/testing/utils.py
+++ b/flujo/testing/utils.py
@@ -100,6 +100,7 @@ class DummyRemoteBackend(ExecutionBackend):
             "resources": request.resources,
             "context_model_defined": request.context_model_defined,
             "usage_limits": request.usage_limits,
+            "stream": request.stream,
         }
 
         serialized = orjson.dumps(payload, default=pydantic_default)
@@ -120,6 +121,8 @@ class DummyRemoteBackend(ExecutionBackend):
             resources=reconstruct(request.resources, data.get("resources")),
             context_model_defined=data.get("context_model_defined", False),
             usage_limits=reconstruct(request.usage_limits, data.get("usage_limits")),
+            stream=data.get("stream", False),
+            on_chunk=request.on_chunk,
         )
         roundtrip.step = original_step
         result = await self.local.execute_step(roundtrip)


### PR DESCRIPTION
## Summary
- extend `StepExecutionRequest` with streaming parameters
- support streaming in `_run_step_logic` and Local backend
- refactor runner to yield chunks via `_run_step`
- update docs on streaming backend usage

## Testing
- `ruff format flujo tests docs && ruff check flujo tests docs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8ad6403c832c9edaf6cbdefec769