### PR TITLE
Add durability and versioning docs

### DIFF
--- a/docs/custom_state_backend.md
+++ b/docs/custom_state_backend.md
@@ -1,0 +1,42 @@
+# How to Create a Custom StateBackend
+
+Sometimes you need to store workflow state in a system that `flujo` does not provide out of the box. The `StateBackend` interface lets you plug in any storage layer.
+
+## The StateBackend Contract
+Each backend implements three async methods:
+
+```python
+class StateBackend(ABC):
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None: ...
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]: ...
+    async def delete_state(self, run_id: str) -> None: ...
+```
+`state` is a dictionary created from `WorkflowState.model_dump()`.
+Make sure writes are atomic to avoid corrupted data.
+
+## Step-by-Step Tutorial: Redis Example
+Below is a simplified backend using `redis-py`.
+```python
+import orjson
+import redis.asyncio as redis
+from flujo.state.backends.base import StateBackend
+
+class RedisBackend(StateBackend):
+    def __init__(self, url: str) -> None:
+        self.client = redis.from_url(url)
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        await self.client.set(run_id, orjson.dumps(state))
+
+    async def load_state(self, run_id: str) -> dict | None:
+        data = await self.client.get(run_id)
+        return orjson.loads(data) if data else None
+
+    async def delete_state(self, run_id: str) -> None:
+        await self.client.delete(run_id)
+```
+Use it with `Flujo` just like the built-in backends:
+```python
+backend = RedisBackend("redis://localhost:6379/0")
+runner = Flujo(registry=my_registry, pipeline_name="demo", state_backend=backend)
+```

--- a/docs/durable_workflows.md
+++ b/docs/durable_workflows.md
@@ -1,0 +1,70 @@
+# Durable and Resumable Workflows
+
+Long-running or mission critical tasks should be able to survive a crash or restart. Think of it like a video game that lets you **save your progress**. Flujo solves this with a pluggable *StateBackend* that stores the workflow state after each step.
+
+## Conceptual Overview
+
+### The `StateBackend` Interface
+```python
+class StateBackend(ABC):
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None: ...
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]: ...
+    async def delete_state(self, run_id: str) -> None: ...
+```
+A backend can persist to memory, files, databases, or any other system.
+
+### The `WorkflowState` Model
+Flujo stores a serialized `WorkflowState` containing the `run_id`, pipeline version, current step index and the JSON-serializable pipeline context.
+
+### The Execution Lifecycle
+1. A unique `run_id` is attached to the `PipelineContext`.
+2. After each successful step Flujo saves the state via the backend.
+3. On startup Flujo checks for an existing state and resumes from the saved step.
+
+## Getting Started: A Simple Durable Run
+
+Below is a minimal example using the `SQLiteBackend`.
+```python
+from pathlib import Path
+from flujo import Flujo, PipelineRegistry, step, Step
+from flujo.state.backends.sqlite import SQLiteBackend
+
+@step
+async def to_upper(text: str) -> str:
+    return text.upper()
+
+pipeline = to_upper >> Step.human_in_the_loop("approve", message_for_user="Approve?")
+
+registry = PipelineRegistry()
+registry.register(pipeline, name="demo", version="1.0.0")
+backend = SQLiteBackend(Path("workflow_state.db"))
+
+# First run will pause for approval and persist state
+runner = Flujo(
+    registry=registry,
+    pipeline_name="demo",
+    pipeline_version="1.0.0",
+    state_backend=backend,
+)
+paused = runner.run("hello", initial_context_data={"run_id": "example"})
+
+# Later we create a new runner with the same run_id and resume
+resumer = Flujo(
+    registry=registry,
+    pipeline_name="demo",
+    pipeline_version="1.0.0",
+    state_backend=backend,
+)
+final = resumer.resume_async(paused, "yes")
+```
+
+## Built-in Backends
+
+### `InMemoryBackend`
+For testing and demos. Data lives only in memory and is lost when the process exits.
+
+### `FileBackend`
+Persists state as JSON files. Good for simple serverless environments. Concurrency is limited.
+
+### `SQLiteBackend`
+Stores state in a robust SQLite database. Suitable for many production setups with a single file.

--- a/docs/pipeline_versioning.md
+++ b/docs/pipeline_versioning.md
@@ -1,0 +1,47 @@
+# Managing Pipeline Versions
+
+When you deploy new code while old workflows are still running you risk breaking in-flight runs. The `PipelineRegistry` solves this by tracking multiple versions of each pipeline.
+
+## How It Works
+Register each pipeline with a unique name and version. We recommend [Semantic Versioning](https://semver.org/).
+```python
+from flujo import PipelineRegistry, Step
+
+registry = PipelineRegistry()
+registry.register(Step.from_mapper(str.upper), name="demo", version="1.0.0")
+registry.register(Step.from_mapper(lambda x: x + "!"), name="demo", version="2.0.0")
+```
+
+A `Flujo` runner is created with a registry, a pipeline name and a version:
+```python
+runner = Flujo(registry=registry, pipeline_name="demo", pipeline_version="1.0.0")
+```
+When resuming a durable workflow Flujo always loads the exact version that started the run, ensuring stability.
+
+## Practical Example: A Safe Deployment
+
+```python
+from flujo import PipelineRegistry, Flujo, step
+from flujo.state.backends.sqlite import SQLiteBackend
+
+@step
+async def version_one(text: str) -> str:
+    return text.upper()
+
+@step
+async def version_two(text: str) -> str:
+    return text[::-1]
+
+registry = PipelineRegistry()
+registry.register(version_one, "demo", "1.0.0")
+backend = SQLiteBackend("workflow_state.db")
+runner = Flujo(registry=registry, pipeline_name="demo", pipeline_version="1.0.0", state_backend=backend)
+paused = runner.run("hi", initial_context_data={"run_id": "safe"})
+
+# Deploy new, incompatible version
+registry.register(version_two, "demo", "2.0.0")
+
+resumer = Flujo(registry=registry, pipeline_name="demo", pipeline_version="1.0.0", state_backend=backend)
+final = resumer.resume_async(paused, "continue")
+```
+This run completes using the original `1.0.0` logic even though `2.0.0` is now registered.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,3 @@
+# flujo.registry Module
+
+::: flujo.registry.PipelineRegistry

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,11 @@
+# flujo.state Module
+
+::: flujo.state.models.WorkflowState
+
+::: flujo.state.backends.base.StateBackend
+
+::: flujo.state.backends.memory.InMemoryBackend
+
+::: flujo.state.backends.file.FileBackend
+
+::: flujo.state.backends.sqlite.SQLiteBackend

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -91,7 +91,14 @@ async def add_excitement(text: str) -> str:
     return f"{text}!"
 
 pipeline = to_upper >> add_excitement
-runner = Flujo(pipeline)
+registry = PipelineRegistry()
+registry.register(pipeline, "hello-pipeline", "1.0.0")
+runner = Flujo(
+    registry=registry,
+    pipeline_name="hello-pipeline",
+    pipeline_version="1.0.0",
+    # state_backend=SQLiteBackend(Path("state.db"))  # add for durability
+)
 result: PipelineResult[str] = runner.run("hello")
 print(result.step_history[-1].output)  # HELLO!
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@
 | **06_typed_context.py** | Sharing state with Typed Pipeline Context. |
 | **07_loop_step.py** | Iterative refinement using LoopStep. |
 | **08_branch_step.py** | Dynamic routing with ConditionalStep. |
+| **durable_workflow.py** | Resumable pipeline with the SQLiteBackend. |
 
 Each script is standalone – activate your virtualenv, set `OPENAI_API_KEY`, then:
 

--- a/examples/durable_workflow.py
+++ b/examples/durable_workflow.py
@@ -1,0 +1,40 @@
+"""Demonstrates a resumable workflow using the SQLiteBackend."""
+import asyncio
+from pathlib import Path
+from flujo import Flujo, PipelineRegistry, step, Step
+from flujo.state.backends.sqlite import SQLiteBackend
+
+@step
+async def to_upper(text: str) -> str:
+    return text.upper()
+
+pipeline = to_upper >> Step.human_in_the_loop("approve", message_for_user="Approve?")
+
+registry = PipelineRegistry()
+registry.register(pipeline, "demo", "1.0.0")
+backend = SQLiteBackend(Path("workflow_state.db"))
+
+async def main() -> None:
+    run_id = "demo-run"
+    print("\u25B6\uFE0F Starting workflow...")
+    runner = Flujo(
+        registry=registry,
+        pipeline_name="demo",
+        pipeline_version="1.0.0",
+        state_backend=backend,
+    )
+    paused = await runner.run_async("hello", initial_context_data={"run_id": run_id})
+    print("Paused message:", paused.final_pipeline_context.scratchpad.get("pause_message"))
+
+    print("\n\u23F9 Restarting and resuming...")
+    new_runner = Flujo(
+        registry=registry,
+        pipeline_name="demo",
+        pipeline_version="1.0.0",
+        state_backend=backend,
+    )
+    final = await new_runner.resume_async(paused, "yes")
+    print("Final output:", final.step_history[-1].output)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -161,7 +161,41 @@ ContextT = TypeVar("ContextT", bound=BaseModel)
 
 
 class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
-    """Execute a pipeline sequentially."""
+    """Execute a pipeline sequentially.
+
+    Parameters
+    ----------
+    pipeline:
+        *(Deprecated)* Pipeline object to run directly. Prefer registering
+        pipelines in a :class:`~flujo.registry.PipelineRegistry` and specifying
+        ``registry``, ``pipeline_name`` and ``pipeline_version`` instead.
+    context_model:
+        Optional Pydantic model class for the shared pipeline context.
+    initial_context_data:
+        Initial values used to construct the context model.
+    resources:
+        Optional container of resources passed to each step.
+    usage_limits:
+        Optional :class:`~flujo.domain.models.UsageLimits` for governor checks.
+    hooks:
+        List of lifecycle hook callables.
+    backend:
+        Execution backend used to run steps.
+    state_backend:
+        Optional :class:`~flujo.state.backends.base.StateBackend` for persisting
+        workflow progress. See :doc:`durable_workflows`.
+    delete_on_completion:
+        Delete persisted state when the run finishes successfully.
+    pipeline_version:
+        Version string for the pipeline when using a registry.
+    local_tracer:
+        ``"default"`` to enable console tracing or pass a ``ConsoleTracer``.
+    registry:
+        Optional :class:`~flujo.registry.PipelineRegistry` holding named
+        pipelines. See :doc:`pipeline_versioning`.
+    pipeline_name:
+        Name of the pipeline to load from the registry.
+    """
 
     def __init__(
         self,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,10 +29,15 @@ nav:
     - Quickstart: quickstart.md
     - Concepts: concepts.md
     - Configuration: configuration.md
+  - Core Concepts:
+    - 'Durable and Resumable Workflows': durable_workflows.md
+    - 'Managing Pipeline Versions': pipeline_versioning.md
   - Usage: usage.md
   - Tutorial: tutorial.md
   - 'Intelligent Evals': intelligent_evals.md
-  - Extending: extending.md
+  - Extending:
+    - Overview: extending.md
+    - 'Custom StateBackend': custom_state_backend.md
   - Development:
     - 'Contributing Guide': dev.md
     - 'Documentation Guide': documentation_guide.md
@@ -76,6 +81,8 @@ nav:
     - Tools: tools.md
     - Telemetry: telemetry.md
     - Troubleshooting: troubleshooting.md
+    - State Module: state.md
+    - Registry Module: registry.md
 
 plugins:
   - search

--- a/tests/integration/test_persistence_backends.py
+++ b/tests/integration/test_persistence_backends.py
@@ -71,9 +71,7 @@ async def test_file_backend_resume_after_crash(tmp_path: Path) -> None:
     rc = _run_crashing_process("FileBackend", state_dir, run_id)
     assert rc != 0
     backend = FileBackend(state_dir)
-    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(
-        step_two, name="s2"
-    )
+    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(step_two, name="s2")
     runner = Flujo(
         pipeline,
         context_model=Ctx,
@@ -100,9 +98,7 @@ async def test_sqlite_backend_resume_after_crash(tmp_path: Path) -> None:
     rc = _run_crashing_process("SQLiteBackend", db_path, run_id)
     assert rc != 0
     backend = SQLiteBackend(db_path)
-    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(
-        step_two, name="s2"
-    )
+    pipeline = Step.from_callable(step_one, name="s1") >> Step.from_callable(step_two, name="s2")
     runner = Flujo(
         pipeline,
         context_model=Ctx,
@@ -141,9 +137,7 @@ async def test_file_backend_concurrent(tmp_path: Path) -> None:
             delete_on_completion=False,
             initial_context_data={"run_id": rid},
         )
-        await gather_result(
-            runner, 0, initial_context_data={"initial_prompt": "x", "run_id": rid}
-        )
+        await gather_result(runner, 0, initial_context_data={"initial_prompt": "x", "run_id": rid})
 
     await asyncio.gather(*(run_one(i) for i in range(5)))
 


### PR DESCRIPTION
## Summary
- document durable workflows and pipeline versioning
- document how to create a custom state backend
- expose state and registry API docs
- update tutorial to use PipelineRegistry
- example for resumable workflows
- update Flujo constructor docstring

## Testing
- `make format`
- `make lint`
- `make type-check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c8a0f53a0832cbc58873a1cb01c50