### PR TITLE
Add durability and versioning docs

### DIFF
--- a/docs/cookbook/hitl_dynamic_clarification.md
+++ b/docs/cookbook/hitl_dynamic_clarification.md
@@ -8,7 +8,9 @@ from flujo.testing.utils import StubAgent
 
 pipeline = Step("ask", StubAgent(["Is this ok?"])) >> Step.human_in_the_loop("clarify")
 runner = Flujo(pipeline)
-result = await runner.run_async("hello")
+result = None
+async for item in runner.run_async("hello"):
+    result = item
 # display pause message from context and resume
 result = await runner.resume_async(result, "sure")
 ```

--- a/docs/cookbook/hitl_simple_approval.md
+++ b/docs/cookbook/hitl_simple_approval.md
@@ -7,8 +7,11 @@ from flujo import Step, Pipeline, Flujo
 from flujo.testing.utils import StubAgent
 
 pipeline = Step("draft", StubAgent(["draft text"])) >> Step.human_in_the_loop("approve", message_for_user="Approve the draft?")
+# "run_async" returns an async iterator, so consume it to get the result
 runner = Flujo(pipeline)
-result = await runner.run_async("start")
+result = None
+async for item in runner.run_async("start"):
+    result = item
 # show result.final_pipeline_context.scratchpad["pause_message"] to the user
 # then resume
 result = await runner.resume_async(result, "yes")

--- a/docs/cookbook/hitl_stateful_correction_loop.md
+++ b/docs/cookbook/hitl_stateful_correction_loop.md
@@ -14,7 +14,10 @@ loop = Step.loop_until(
     max_loops=2,
 )
 runner = Flujo(loop)
-paused = await runner.run_async("start")
+result = None
+async for item in runner.run_async("start"):
+    result = item
+paused = result
 paused = await runner.resume_async(paused, "not ok")
 final = await runner.resume_async(paused, "ok")
 ```

--- a/docs/cookbook/hitl_structured_input.md
+++ b/docs/cookbook/hitl_structured_input.md
@@ -11,9 +11,12 @@ class Answer(BaseModel):
     choice: int
 
 step = Step.human_in_the_loop("pick", input_schema=Answer)
+# Consume run_async to obtain the paused result
 pipeline = Step("start", StubAgent(["Q"])) >> step
 runner = Flujo(pipeline)
-paused = await runner.run_async("x")
+paused = None
+async for item in runner.run_async("x"):
+    paused = item
 # paused.final_pipeline_context.scratchpad["pause_message"] has the question
 resumed = await runner.resume_async(paused, {"choice": 1})
 assert isinstance(resumed.step_history[-1].output, Answer)

--- a/docs/guides/custom_state_backend.md
+++ b/docs/guides/custom_state_backend.md
@@ -1,0 +1,61 @@
+# How to Create a Custom StateBackend
+
+Sometimes you need to store workflow state in a system not supported out of the box. This guide shows how to implement your own backend by walking through a simplified Redis example.
+
+## The StateBackend Contract
+
+Any backend must implement three asynchronous methods:
+
+```python
+class StateBackend(ABC):
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None: ...
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]: ...
+    async def delete_state(self, run_id: str) -> None: ...
+```
+
+`state` is the serialized `WorkflowState` dictionary. Backends are responsible for storing and retrieving this object, handling any serialization and ensuring atomic writes.
+
+## Tutorial: Redis Backend
+
+```python
+import orjson
+import redis.asyncio as redis
+from flujo.state.backends.base import StateBackend
+
+class RedisBackend(StateBackend):
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._client: redis.Redis | None = None
+
+    async def _conn(self) -> redis.Redis:
+        if self._client is None:
+            self._client = await redis.from_url(self._url)
+        return self._client
+
+    async def save_state(self, run_id: str, state: dict) -> None:
+        r = await self._conn()
+        await r.set(run_id, orjson.dumps(state))
+
+    async def load_state(self, run_id: str) -> dict | None:
+        r = await self._conn()
+        data = await r.get(run_id)
+        return orjson.loads(data) if data else None
+
+    async def delete_state(self, run_id: str) -> None:
+        r = await self._conn()
+        await r.delete(run_id)
+```
+
+Use your backend when creating a runner:
+
+```python
+backend = RedisBackend("redis://localhost:6379/0")
+runner = Flujo(
+    registry=registry,
+    pipeline_name="my_pipeline",
+    pipeline_version="1.0.0",
+    state_backend=backend,
+)
+```
+
+This pattern lets you integrate Flujo with any durable storage system.

--- a/docs/guides/durable_workflows.md
+++ b/docs/guides/durable_workflows.md
@@ -1,0 +1,105 @@
+# Durable and Resumable Workflows
+
+Running a long or important workflow can feel a bit like playing an old video game – if the power goes out you lose all your progress. `Flujo` avoids this problem by saving the state of a pipeline after each successful step. When your process restarts, the run can pick up exactly where it left off.
+
+## Why Durability Matters
+
+Servers restart, deployments happen and sometimes a workflow simply has to wait for human input. By persisting the current step index and context, a pipeline can safely resume instead of starting over.
+
+## The StateBackend Interface
+
+Flujo uses a pluggable backend interface for persistence. Every backend implements the same three methods:
+
+```python
+from flujo.state.backends.base import StateBackend
+
+class StateBackend(ABC):
+    """Abstract interface for workflow state persistence."""
+
+    async def save_state(self, run_id: str, state: Dict[str, Any]) -> None:
+        ...
+    async def load_state(self, run_id: str) -> Optional[Dict[str, Any]]:
+        ...
+    async def delete_state(self, run_id: str) -> None:
+        ...
+```
+
+## WorkflowState Model
+
+The runner serializes a `WorkflowState` object which contains the pipeline version, step index and JSON‑serializable context.
+
+```python
+from flujo.state.models import WorkflowState
+
+WorkflowState(
+    run_id: str,
+    pipeline_id: str,
+    pipeline_name: str,
+    pipeline_version: str,
+    current_step_index: int,
+    pipeline_context: Dict[str, Any],
+    last_step_output: Any | None,
+    status: Literal["running", "paused", "completed", "failed", "cancelled"],
+    created_at: datetime,
+    updated_at: datetime,
+)
+```
+
+## Execution Lifecycle
+
+1. A `WorkflowState` is created after the first step completes.
+2. The state is updated after every successful step.
+3. On completion or failure the final status is recorded.
+
+## Getting Started
+
+Here is a minimal example using the `SQLiteBackend`:
+
+```python
+from pathlib import Path
+from flujo import Flujo, Step, PipelineRegistry, step
+from flujo.state import SQLiteBackend
+
+@step
+async def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+pipeline = greet
+registry = PipelineRegistry()
+registry.register(pipeline, "hello", "1.0.0")
+backend = SQLiteBackend(Path("workflow.db"))
+
+runner = Flujo(
+    registry=registry,
+    pipeline_name="hello",
+    pipeline_version="1.0.0",
+    state_backend=backend,
+)
+
+result = runner.run("world", initial_context_data={"run_id": "run1"})
+
+# To resume later just create a new runner with the same run_id
+runner2 = Flujo(
+    registry=registry,
+    pipeline_name="hello",
+    pipeline_version="1.0.0",
+    state_backend=backend,
+)
+resumed = runner2.run("world", initial_context_data={"run_id": "run1"})
+```
+
+## Built-in Backends
+
+### InMemoryBackend
+
+For tests and demos. Data lives only in memory so everything is lost on restart.
+
+### FileBackend
+
+Stores each run as a JSON file in a directory. Great for simple serverless setups but not safe for concurrent writes.
+
+### SQLiteBackend
+
+Persists state in a single SQLite database file. Robust enough for many production scenarios and perfect for local development.
+
+See also: [Managing Pipeline Versions](pipeline_versioning.md).

--- a/docs/guides/pipeline_versioning.md
+++ b/docs/guides/pipeline_versioning.md
@@ -1,0 +1,69 @@
+# Managing Pipeline Versions
+
+Deploying new code while old workflows are still running can lead to inconsistencies. `Flujo` solves this with a simple registry that stores named pipelines and their versions.
+
+## Introduction
+
+Register each pipeline with a unique name and semantic version. When a durable run resumes it will load the exact version it started with, even if newer versions are deployed.
+
+## How It Works
+
+```python
+from flujo import Step, PipelineRegistry, Flujo, step
+
+@step
+async def v1(text: str) -> str:
+    return text.upper()
+
+@step
+async def v2(text: str) -> str:
+    return text.lower()
+
+pipeline_v1 = v1
+pipeline_v2 = v2
+
+registry = PipelineRegistry()
+registry.register(pipeline_v1, "example", "1.0.0")
+registry.register(pipeline_v2, "example", "2.0.0")
+
+runner = Flujo(registry=registry, pipeline_name="example", pipeline_version="1.0.0")
+```
+
+When the runner starts a durable workflow it records the version in the saved `WorkflowState`. If you later register `2.0.0` and resume the run, the registry will still return `1.0.0` for that run.
+
+## Practical Example: A Safe Deployment
+
+```python
+# Start v1
+run_id = "deploy-demo"
+runner = Flujo(
+    registry=registry,
+    pipeline_name="example",
+    pipeline_version="1.0.0",
+    state_backend=SQLiteBackend("state.db"),
+)
+partial = None
+async for item in runner.run_async("DATA", initial_context_data={"run_id": run_id}):
+    partial = item
+    break  # Simulate restart after first step
+
+# Register an incompatible v2
+registry.register(pipeline_v2, "example", "2.0.0")
+
+# Resume the original run
+runner_resume = Flujo(
+    registry=registry,
+    pipeline_name="example",
+    pipeline_version="latest",
+    state_backend=SQLiteBackend("state.db"),
+)
+final = None
+async for item in runner_resume.run_async("DATA", initial_context_data={"run_id": run_id}):
+    final = item
+
+assert final.pipeline_version == "1.0.0"  # Still uses v1
+```
+
+This pattern allows you to deploy new code without interrupting in-flight runs.
+
+See also: [Durable and Resumable Workflows](durable_workflows.md).

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,3 @@
+# Pipeline Registry API
+
+::: flujo.registry.PipelineRegistry

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,11 @@
+# State Backends API
+
+::: flujo.state.models.WorkflowState
+
+::: flujo.state.backends.base.StateBackend
+
+::: flujo.state.backends.memory.InMemoryBackend
+
+::: flujo.state.backends.file.FileBackend
+
+::: flujo.state.backends.sqlite.SQLiteBackend

--- a/examples/durable_workflow.py
+++ b/examples/durable_workflow.py
@@ -1,0 +1,58 @@
+"""Durable workflow example using the SQLiteBackend.
+
+Run once to pause the pipeline and again to resume. The run is identified by a
+custom ``run_id`` stored in the context.
+"""
+
+import asyncio
+from pathlib import Path
+
+from flujo import Flujo, PipelineRegistry, Step, step
+from flujo.state import SQLiteBackend
+from flujo.testing import StubAgent
+
+@step
+async def draft(text: str) -> str:
+    print("Generating draft...")
+    return "A short draft"
+
+pipeline = (
+    Step.solution(StubAgent(["ignored"]))
+    >> Step.solution(draft)
+    >> Step.human_in_the_loop(name="approval", message_for_user="Approve the draft?")
+    >> Step.solution(StubAgent(["Final answer"]))
+)
+
+registry = PipelineRegistry()
+registry.register(pipeline, "durable_demo", "1.0.0")
+backend = SQLiteBackend(Path("workflow_state.db"))
+
+async def main() -> None:
+    run_id = "example-run"
+    runner = Flujo(
+        registry=registry,
+        pipeline_name="durable_demo",
+        pipeline_version="1.0.0",
+        state_backend=backend,
+        delete_on_completion=False,
+    )
+
+    result = None
+    async for item in runner.run_async("start", initial_context_data={"run_id": run_id}):
+        result = item
+    if result and result.final_pipeline_context.scratchpad.get("status") == "paused":
+        print("Pipeline paused. Resuming...")
+        runner2 = Flujo(
+            registry=registry,
+            pipeline_name="durable_demo",
+            pipeline_version="1.0.0",
+            state_backend=backend,
+            delete_on_completion=False,
+        )
+        resumed = await runner2.resume_async(result, "yes")
+        print("Final output:", resumed.step_history[-1].output)
+    else:
+        print("Run completed without pause.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -161,7 +161,23 @@ ContextT = TypeVar("ContextT", bound=BaseModel)
 
 
 class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
-    """Execute a pipeline sequentially."""
+    """Execute a pipeline sequentially.
+
+    Parameters
+    ----------
+    pipeline : Pipeline | Step | None, optional
+        Pipeline object to run directly. Deprecated when using ``registry``.
+    registry : PipelineRegistry, optional
+        Registry holding named pipelines.
+    pipeline_name : str, optional
+        Name of the pipeline registered in ``registry``.
+    pipeline_version : str, default "latest"
+        Version to load from the registry when the run starts.
+    state_backend : StateBackend, optional
+        Backend used to persist :class:`WorkflowState` for durable execution.
+    delete_on_completion : bool, default False
+        If ``True`` remove persisted state once the run finishes.
+    """
 
     def __init__(
         self,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,9 @@ nav:
     - 'Agentic Loop': recipes/agentic_loop.md
   - Guides:
     - 'Choosing Your Loop': guides/choosing_your_loop.md
+    - 'Durable Workflows': guides/durable_workflows.md
+    - 'Managing Pipeline Versions': guides/pipeline_versioning.md
+    - 'Custom StateBackend': guides/custom_state_backend.md
   - Migration:
     - 'v0.3.7': migration/v0.3.7.md
     - 'v0.3.8': migration/v0.3.8.md
@@ -75,6 +78,8 @@ nav:
     - Scoring: scoring.md
     - Tools: tools.md
     - Telemetry: telemetry.md
+    - State Backends: state.md
+    - Pipeline Registry: registry.md
     - Troubleshooting: troubleshooting.md
 
 plugins:


### PR DESCRIPTION
## Summary
- document durable workflows and pipeline versioning
- add guide on implementing custom state backends
- update API docs with state backend and registry modules
- show registry-based initialization in tutorial and API reference
- add runnable durable workflow example
- update Flujo docstring
- fix async usage examples in docs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c8a0f53a0832cbc58873a1cb01c50