### PR TITLE
Fix streaming step execution to reuse normal logic

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -479,9 +479,11 @@ local_backend = LocalBackend(agent_registry={
 # When a step is executed, a StepExecutionRequest is sent to the backend:
 request = StepExecutionRequest(
     step=Step(...),
-    input_data=..., 
+    input_data=...,
     context=PipelineContext(initial_prompt=""),
     resources=None,
+    stream=False,  # Set to True to enable streaming
+    on_chunk=None,  # Optional callback for streamed chunks
 )
 
 # The execute_step method handles the actual running of the step's logic

--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -613,6 +613,8 @@ async def _run_step_logic(
     context_model_defined: bool,
     usage_limits: UsageLimits | None = None,
     context_setter: Callable[[PipelineResult[TContext], Optional[TContext]], None] | None = None,
+    stream: bool = False,
+    on_chunk: Callable[[Any], Awaitable[None]] | None = None,
 ) -> StepResult:
     """Core logic for executing a single step without engine coupling."""
     if context_setter is None:
@@ -717,7 +719,12 @@ async def _run_step_logic(
         from ...signature_tools import analyze_signature
 
         target = getattr(current_agent, "_agent", current_agent)
-        func = getattr(target, "_step_callable", target.run)
+        func = getattr(target, "_step_callable", None)
+        if func is None:
+            if stream and hasattr(target, "stream"):
+                func = target.stream
+            else:
+                func = target.run
         spec = analyze_signature(func)
 
         if spec.needs_context:
@@ -734,9 +741,39 @@ async def _run_step_logic(
                 agent_kwargs["resources"] = resources
         if step.config.temperature is not None and _accepts_param(func, "temperature"):
             agent_kwargs["temperature"] = step.config.temperature
-        raw_output = await current_agent.run(data, **agent_kwargs)
-        result.latency_s += time.monotonic() - start
-        last_raw_output = raw_output
+        stream_failed = False
+        if stream and hasattr(current_agent, "stream"):
+            chunks: list[Any] = []
+            try:
+                async for chunk in current_agent.stream(data, **agent_kwargs):
+                    if on_chunk is not None:
+                        await on_chunk(chunk)
+                    chunks.append(chunk)
+                result.latency_s += time.monotonic() - start
+                raw_output = (
+                    "".join(chunks)
+                    if chunks and all(isinstance(c, str) for c in chunks)
+                    else chunks
+                )
+                last_raw_output = raw_output
+            except Exception as e:
+                stream_failed = True
+                result.latency_s += time.monotonic() - start
+                partial = (
+                    "".join(chunks)
+                    if chunks and all(isinstance(c, str) for c in chunks)
+                    else chunks
+                )
+                raw_output = partial
+                last_raw_output = raw_output
+                result.output = partial
+                result.feedback = str(e)
+                feedbacks.append(str(e))
+                last_feedback = str(e)
+        else:
+            raw_output = await current_agent.run(data, **agent_kwargs)
+            result.latency_s += time.monotonic() - start
+            last_raw_output = raw_output
 
         if isinstance(raw_output, Mock):
             raise TypeError(
@@ -760,7 +797,7 @@ async def _run_step_logic(
                 unpacked_output = processed
         last_unpacked_output = unpacked_output
 
-        success = True
+        success = not stream_failed
         redirect_to = None
         final_plugin_outcome: PluginOutcome | None = None
         is_validation_step, is_strict = _get_validation_flags(step)

--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, Any, Dict, Optional
+from typing import Protocol, Any, Dict, Optional, Callable, Awaitable
 from dataclasses import dataclass
 from flujo.domain.models import BaseModel
 
@@ -35,6 +35,9 @@ class StepExecutionRequest:
     # Usage limits, propagated so nested executions (e.g., LoopStep) can enforce
     # governor checks mid-execution.
     usage_limits: Optional["UsageLimits"] = None
+    # Streaming support
+    stream: bool = False
+    on_chunk: Optional[Callable[[Any], Awaitable[None]]] = None
 
 
 class ExecutionBackend(Protocol):

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -35,6 +35,8 @@ class LocalBackend(ExecutionBackend):
                 resources=resources,
                 context_model_defined=request.context_model_defined,
                 usage_limits=request.usage_limits,
+                stream=request.stream,
+                on_chunk=request.on_chunk,
             )
             return await self.execute_step(nested_request)
 
@@ -46,4 +48,6 @@ class LocalBackend(ExecutionBackend):
             step_executor=executor,
             context_model_defined=request.context_model_defined,
             usage_limits=request.usage_limits,
+            stream=request.stream,
+            on_chunk=request.on_chunk,
         )

--- a/flujo/testing/utils.py
+++ b/flujo/testing/utils.py
@@ -100,6 +100,7 @@ class DummyRemoteBackend(ExecutionBackend):
             "resources": request.resources,
             "context_model_defined": request.context_model_defined,
             "usage_limits": request.usage_limits,
+            "stream": request.stream,
         }
 
         serialized = orjson.dumps(payload, default=pydantic_default)
@@ -120,6 +121,8 @@ class DummyRemoteBackend(ExecutionBackend):
             resources=reconstruct(request.resources, data.get("resources")),
             context_model_defined=data.get("context_model_defined", False),
             usage_limits=reconstruct(request.usage_limits, data.get("usage_limits")),
+            stream=data.get("stream", False),
+            on_chunk=request.on_chunk,
         )
         roundtrip.step = original_step
         result = await self.local.execute_step(roundtrip)


### PR DESCRIPTION
## Summary
- ensure LoggingBackend example handles non-string streamed chunks
- document `on_chunk` parameter for backend requests
- process streaming failures in `_run_step_logic` without early return

## Testing
- `ruff format flujo tests docs && ruff check flujo tests docs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8ad6403c832c9edaf6cbdefec769