### PR TITLE
Fix streaming step execution to reuse normal logic

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -479,9 +479,11 @@ local_backend = LocalBackend(agent_registry={
 # When a step is executed, a StepExecutionRequest is sent to the backend:
 request = StepExecutionRequest(
     step=Step(...),
-    input_data=..., 
+    input_data=...,
     context=PipelineContext(initial_prompt=""),
     resources=None,
+    stream=False,  # Set to True to enable streaming
+    on_chunk=None,  # Optional callback for streamed chunks
 )
 
 # The execute_step method handles the actual running of the step's logic

--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -613,6 +613,8 @@ async def _run_step_logic(
     context_model_defined: bool,
     usage_limits: UsageLimits | None = None,
     context_setter: Callable[[PipelineResult[TContext], Optional[TContext]], None] | None = None,
+    stream: bool = False,
+    on_chunk: Callable[[Any], Awaitable[None]] | None = None,
 ) -> StepResult:
     """Core logic for executing a single step without engine coupling."""
     if context_setter is None:
@@ -717,7 +719,10 @@ async def _run_step_logic(
         from ...signature_tools import analyze_signature
 
         target = getattr(current_agent, "_agent", current_agent)
-        func = getattr(target, "_step_callable", target.run)
+        func = getattr(target, "_step_callable", None)
+        if func is None:
+            func = target.stream if stream and hasattr(target, "stream") else target.run
+        func = cast(Callable[..., Any], func)
         spec = analyze_signature(func)
 
         if spec.needs_context:
@@ -734,9 +739,39 @@ async def _run_step_logic(
                 agent_kwargs["resources"] = resources
         if step.config.temperature is not None and _accepts_param(func, "temperature"):
             agent_kwargs["temperature"] = step.config.temperature
-        raw_output = await current_agent.run(data, **agent_kwargs)
-        result.latency_s += time.monotonic() - start
-        last_raw_output = raw_output
+        stream_failed = False
+        if stream and hasattr(current_agent, "stream"):
+            chunks: list[Any] = []
+            try:
+                async for chunk in current_agent.stream(data, **agent_kwargs):
+                    if on_chunk is not None:
+                        await on_chunk(chunk)
+                    chunks.append(chunk)
+                result.latency_s += time.monotonic() - start
+                raw_output = (
+                    "".join(chunks)
+                    if chunks and all(isinstance(c, str) for c in chunks)
+                    else chunks
+                )
+                last_raw_output = raw_output
+            except Exception as e:
+                stream_failed = True
+                result.latency_s += time.monotonic() - start
+                partial = (
+                    "".join(chunks)
+                    if chunks and all(isinstance(c, str) for c in chunks)
+                    else chunks
+                )
+                raw_output = partial
+                last_raw_output = raw_output
+                result.output = partial
+                result.feedback = str(e)
+                feedbacks.append(str(e))
+                last_feedback = str(e)
+        else:
+            raw_output = await current_agent.run(data, **agent_kwargs)
+            result.latency_s += time.monotonic() - start
+            last_raw_output = raw_output
 
         if isinstance(raw_output, Mock):
             raise TypeError(
@@ -760,7 +795,7 @@ async def _run_step_logic(
                 unpacked_output = processed
         last_unpacked_output = unpacked_output
 
-        success = True
+        success = not stream_failed
         redirect_to = None
         final_plugin_outcome: PluginOutcome | None = None
         is_validation_step, is_strict = _get_validation_flags(step)
@@ -771,7 +806,9 @@ async def _run_step_logic(
                 from ...signature_tools import analyze_signature
 
                 plugin_kwargs: Dict[str, Any] = {}
-                func = getattr(plugin, "_plugin_callable", plugin.validate)
+                func = cast(
+                    Callable[..., Any], getattr(plugin, "_plugin_callable", plugin.validate)
+                )
                 spec = analyze_signature(func)
 
                 if spec.needs_context:

--- a/flujo/application/runner.py
+++ b/flujo/application/runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import time
 import weakref
 import copy
 from datetime import datetime
@@ -248,7 +247,9 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         data: Any,
         context: Optional[ContextT],
         resources: Optional[AppResources],
-    ) -> StepResult:
+        *,
+        stream: bool = False,
+    ) -> AsyncIterator[Any]:
         """Execute a single step and update context if required.
 
         Parameters
@@ -274,6 +275,12 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
         model. Validation errors are logged and cause the step to be marked as
         failed.
         """
+        q: asyncio.Queue[Any] | None = None
+
+        async def _capture(chunk: Any) -> None:
+            assert q is not None
+            await q.put(chunk)
+
         request = StepExecutionRequest(
             step=step,
             input_data=data,
@@ -281,8 +288,41 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
             resources=resources,
             context_model_defined=self.context_model is not None,
             usage_limits=self.usage_limits,
+            stream=stream,
+            on_chunk=_capture if stream else None,
         )
-        result = await self.backend.execute_step(request)
+
+        if stream:
+            q = asyncio.Queue()
+            task = asyncio.create_task(self.backend.execute_step(request))
+            while True:
+                if not q.empty():
+                    yield q.get_nowait()
+                    continue
+                if task.done():
+                    while not q.empty():
+                        yield q.get_nowait()
+                    try:
+                        result = task.result()
+                    except Exception as e:  # pragma: no cover - defensive
+                        telemetry.logfire.error(
+                            f"Streaming task for step '{step.name}' failed: {e}"
+                        )
+                        result = StepResult(
+                            name=step.name,
+                            output=None,
+                            success=False,
+                            attempts=1,
+                            feedback=str(e),
+                        )
+                    break
+                try:
+                    item = await asyncio.wait_for(q.get(), timeout=0.1)
+                    yield item
+                except asyncio.TimeoutError:
+                    continue
+        else:
+            result = await self.backend.execute_step(request)
         if getattr(step, "updates_context", False):
             if self.context_model is not None and context is not None:
                 update_data = _build_context_update(result.output)
@@ -291,7 +331,8 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         f"Step '{step.name}' has updates_context=True but did not return a dict or Pydantic model. "
                         "Skipping context update."
                     )
-                    return result
+                    yield result
+                    return
 
                 err = _inject_context(context, update_data, self.context_model)
                 if err is not None:
@@ -301,12 +342,13 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                     telemetry.logfire.error(error_msg)
                     result.success = False
                     result.feedback = error_msg
-                    return result
+                    yield result
+                    return
 
                 telemetry.logfire.info(
                     f"Context successfully updated and re-validated by step '{step.name}'."
                 )
-        return result
+        yield result
 
     def _check_usage_limits(
         self,
@@ -470,59 +512,25 @@ class Flujo(Generic[RunnerInT, RunnerOutT, ContextT]):
                         and step.agent is not None
                         and hasattr(step.agent, "stream")
                     ):
-                        agent_kwargs: Dict[str, Any] = {}
-                        target = getattr(step.agent, "_agent", step.agent)
-                        if context is not None and _accepts_param(target.stream, "context"):
-                            agent_kwargs["context"] = context
-                        if self.resources is not None and _accepts_param(
-                            target.stream, "resources"
-                        ):
-                            agent_kwargs["resources"] = self.resources
-                        if step.config.temperature is not None and _accepts_param(
-                            target.stream, "temperature"
-                        ):
-                            agent_kwargs["temperature"] = step.config.temperature
-                        chunks: list[Any] = []
-                        start = time.monotonic()
-                        try:
-                            async for chunk in step.agent.stream(data, **agent_kwargs):
-                                chunks.append(chunk)
-                                yield chunk
-                            latency = time.monotonic() - start
-                            final_output_success: Any
-                            if chunks and all(isinstance(c, str) for c in chunks):
-                                final_output_success = "".join(chunks)
-                            else:
-                                final_output_success = chunks
-                            step_result = StepResult(
-                                name=step.name,
-                                output=final_output_success,
-                                success=True,
-                                attempts=1,
-                                latency_s=latency,
-                            )
-                        except Exception as e:
-                            latency = time.monotonic() - start
-                            final_output_error: Any
-                            if chunks and all(isinstance(c, str) for c in chunks):
-                                final_output_error = "".join(chunks)
-                            else:
-                                final_output_error = chunks
-                            step_result = StepResult(
-                                name=step.name,
-                                output=final_output_error,
-                                success=False,
-                                feedback=str(e),
-                                attempts=1,
-                                latency_s=latency,
-                            )
-                    else:
-                        step_result = await self._run_step(
+                        async for item in self._run_step(
                             step,
                             data,
                             context=context,
                             resources=self.resources,
-                        )
+                            stream=True,
+                        ):
+                            if isinstance(item, StepResult):
+                                step_result = item
+                            else:
+                                yield item
+                    else:
+                        async for item in self._run_step(
+                            step,
+                            data,
+                            context=context,
+                            resources=self.resources,
+                        ):
+                            step_result = cast(StepResult, item)
                 except PausedException as e:
                     if isinstance(context, PipelineContext):
                         context.scratchpad["status"] = "paused"

--- a/flujo/domain/backends.py
+++ b/flujo/domain/backends.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, Any, Dict, Optional
+from typing import Protocol, Any, Dict, Optional, Callable, Awaitable
 from dataclasses import dataclass
 from flujo.domain.models import BaseModel
 
@@ -35,6 +35,9 @@ class StepExecutionRequest:
     # Usage limits, propagated so nested executions (e.g., LoopStep) can enforce
     # governor checks mid-execution.
     usage_limits: Optional["UsageLimits"] = None
+    # Streaming support
+    stream: bool = False
+    on_chunk: Optional[Callable[[Any], Awaitable[None]]] = None
 
 
 class ExecutionBackend(Protocol):

--- a/flujo/infra/backends.py
+++ b/flujo/infra/backends.py
@@ -35,6 +35,8 @@ class LocalBackend(ExecutionBackend):
                 resources=resources,
                 context_model_defined=request.context_model_defined,
                 usage_limits=request.usage_limits,
+                stream=request.stream,
+                on_chunk=request.on_chunk,
             )
             return await self.execute_step(nested_request)
 
@@ -46,4 +48,6 @@ class LocalBackend(ExecutionBackend):
             step_executor=executor,
             context_model_defined=request.context_model_defined,
             usage_limits=request.usage_limits,
+            stream=request.stream,
+            on_chunk=request.on_chunk,
         )

--- a/flujo/testing/utils.py
+++ b/flujo/testing/utils.py
@@ -100,6 +100,7 @@ class DummyRemoteBackend(ExecutionBackend):
             "resources": request.resources,
             "context_model_defined": request.context_model_defined,
             "usage_limits": request.usage_limits,
+            "stream": request.stream,
         }
 
         serialized = orjson.dumps(payload, default=pydantic_default)
@@ -120,6 +121,8 @@ class DummyRemoteBackend(ExecutionBackend):
             resources=reconstruct(request.resources, data.get("resources")),
             context_model_defined=data.get("context_model_defined", False),
             usage_limits=reconstruct(request.usage_limits, data.get("usage_limits")),
+            stream=data.get("stream", False),
+            on_chunk=request.on_chunk,
         )
         roundtrip.step = original_step
         result = await self.local.execute_step(roundtrip)


### PR DESCRIPTION
## Summary
- ensure LoggingBackend example handles non-string streamed chunks
- document `on_chunk` parameter for backend requests
- process streaming failures in `_run_step_logic` without early return
- fix type annotations for streaming logic
- handle race condition and exceptions in streaming runner loop

## Testing
- `make quality`
- `make cov`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c8ad6403c832c9edaf6cbdefec769