### PR TITLE
Add safety check around literal_eval

### DIFF
--- a/tests/processors/test_repair.py
+++ b/tests/processors/test_repair.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flujo.processors.repair import DeterministicRepairProcessor, MAX_LITERAL_EVAL_SIZE
+
+
+@pytest.mark.asyncio
+async def test_literal_eval_size_guard() -> None:
+    proc = DeterministicRepairProcessor()
+    oversized = "x" * (MAX_LITERAL_EVAL_SIZE + 1)
+    with pytest.raises(
+        ValueError, match="Input too large for safe literal evaluation."
+    ):
+        await proc.process(oversized)


### PR DESCRIPTION
## Summary
- guard against huge inputs in `DeterministicRepairProcessor`
- test oversized candidate to ensure ValueError is raised

## Testing
- `make test`
- `make cov`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_686ca864be30832ca335a7ebd545288b