### PR TITLE
Add uv-based Makefile and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,146 @@
-name: CI
+# .github/workflows/ci.yml
+# Continuous Integration workflow for the Flujo project.
+
+name: Flujo CI
 
 on:
   push:
-    branches: [main]
+    branches: [ "main" ]
   pull_request:
-    branches: [main]
+    branches: [ "main" ]
+
+# Cancel any in-progress jobs for the same PR/branch when new commits are pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  quality:
+  # ----------------------------------------------------------------------------
+  # Job 1: Linting and Static Type Checking
+  # ----------------------------------------------------------------------------
+  lint-and-typecheck:
+    name: Lint & Typecheck
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run Linter
+        run: make lint
+
+      - name: Run Type Checker
+        run: make typecheck
+
+  # ----------------------------------------------------------------------------
+  # Job 2: Run Tests on a Matrix of Python Versions
+  # ----------------------------------------------------------------------------
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    needs: lint-and-typecheck
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-      - run: make install-dev
-      - run: make quality
-      - run: make cov
-      - run: hatch run pytest tests/benchmarks
-      - run: make audit
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run coverage run --source=flujo --parallel-mode -m pytest tests/
+
+      - name: Store coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}
+          path: .coverage.*
+
+  # ----------------------------------------------------------------------------
+  # Job 3: Combine and Report Code Coverage
+  # ----------------------------------------------------------------------------
+  coverage:
+    name: Report Coverage
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: Combine coverage reports and check threshold
+        run: |
+          uv run coverage combine
+          uv run coverage report --fail-under=90
+          uv run coverage xml
+          uv run coverage html
+
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-html
+          path: htmlcov
+
+  # ----------------------------------------------------------------------------
+  # Job 4: Live API Tests (Optional but Recommended)
+  # ----------------------------------------------------------------------------
+  # This job is a placeholder for a critical testing practice.
+  # To enable it, you would need to:
+  # 1. Create live tests in a separate directory (e.g., tests/live/).
+  # 2. Add API key secrets to your GitHub repository settings.
+  # 3. Uncomment this job.
+  # test-live:
+  #   name: Live API Tests
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v1
+  #     - name: Install dependencies
+  #       run: uv sync --all-extras
+  #     - name: Run live tests
+  #       run: uv run pytest tests/live/
+  #       env:
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  #         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,91 @@
+# Makefile for the Flujo project
+# Provides a consistent set of commands for development, testing, and quality checks.
+
 .DEFAULT_GOAL := help
 
-args = $(filter-out $@,$(MAKECMDGOALS))
+# ------------------------------------------------------------------------------
+# Tooling Checks
+# ------------------------------------------------------------------------------
 
-.PHONY: help setup install-dev audit quality lint format type-check test cov bandit sbom pip-dev pip-install clean package
-
-help:
-	@echo "Available commands:"
-	@echo "  setup         - Install dependencies and pre-commit hooks."
-	@echo "  quality       - Run all code quality checks."
-	@echo "  lint          - Run Ruff linting."
-	@echo "  format        - Auto-format the code."
-	@echo "  type-check    - Run MyPy type checking."
-	@echo "  test          - Run the test suite (use 'make test args=\"-k expr\"')."
-	@echo "  cov           - Run tests with coverage (uses args too)."
-	@echo "  bandit        - Run Bandit security scan."
-	@echo "  sbom          - Generate a CycloneDX SBOM."
-	@echo "  package       - Build the package using Hatch."
-	@echo "  clean         - Remove build artifacts and caches."
-
-setup:
-	@pip install --upgrade pip hatch pre-commit
-	@hatch run setup
+# Ensure uv is installed, as it's the core tool for this workflow.
+.PHONY: .uv
+.uv:
+	@uv --version > /dev/null 2>&1 || (printf "\033[0;31m✖ Error: uv is not installed.\033[0m\n  Please install it via: https://github.com/astral-sh/uv\n" && exit 1)
 
 
-install-dev:
-	@pip install --upgrade pip hatch pre-commit
-	@hatch run setup
+# ------------------------------------------------------------------------------
+# Project Setup & Dependency Management
+# ------------------------------------------------------------------------------
+
+.PHONY: install
+install: .uv ## Install dependencies into a virtual environment
+	@echo "🚀 Creating virtual environment and installing dependencies..."
+	@uv venv
+	@uv sync --all-extras
+	@echo "\n✅ Done! Activate the environment with 'source .venv/bin/activate'"
+
+.PHONY: sync
+sync: .uv ## Update dependencies based on pyproject.toml
+	@echo "🔄 Syncing dependencies..."
+	@uv sync --all-extras
 
 
-audit:
-	@hatch run pip-audit && hatch run bandit-check
+# ------------------------------------------------------------------------------
+# Code Quality & Formatting
+# ------------------------------------------------------------------------------
 
-pip-dev:
-	@echo "📦 Installing development dependencies with pip..."
-	@python -m pip install --upgrade pip
-	@python -m pip install -e ".[dev]"
+.PHONY: format
+format: .uv ## Auto-format the code with ruff
+	@echo "🎨 Formatting code..."
+	@uv run ruff format flujo/ tests/
 
-pip-install:
-	@echo "📦 Installing package in development mode with pip..."
-	@python -m pip install --upgrade pip
-	@python -m pip install -e .
+.PHONY: lint
+lint: .uv ## Lint the code and check for formatting issues
+	@echo "🔎 Linting code..."
+	@uv run ruff format --check flujo/ tests/
+	@uv run ruff check flujo/ tests/
 
-quality:
-	@hatch run quality
+.PHONY: typecheck
+typecheck: .uv ## Run static type checking with mypy
+	@echo "🧐 Running static type checking..."
+	@uv run mypy flujo/
 
-lint:
-	@hatch run lint
 
-format:
-	@hatch run format
+# ------------------------------------------------------------------------------
+# Testing & Coverage
+# ------------------------------------------------------------------------------
 
-type-check:
-	@hatch run type-check
+.PHONY: test
+test: .uv ## Run all tests
+	@echo "🧪 Running tests..."
+	@uv run pytest tests/
 
-test:
-	@hatch run test $(args)
+.PHONY: testcov
+testcov: .uv ## Run tests and generate an HTML coverage report
+	@echo "🧪 Running tests with coverage..."
+	@uv run coverage run --source=flujo -m pytest tests/
+	@uv run coverage html
+	@echo "\n✅ Coverage report generated in 'htmlcov/'. Open htmlcov/index.html to view."
 
-cov:
-	@hatch run cov $(args)
 
-bandit:
-	@hatch run bandit-check
+# ------------------------------------------------------------------------------
+# All-in-one & Help
+# ------------------------------------------------------------------------------
 
-sbom:
-	@hatch run cyclonedx
+.PHONY: all
+all: format lint typecheck test ## Run all quality checks (format, lint, typecheck, test)
+	@echo "\n✅ All local checks passed! You are ready to push."
 
-cyclonedx: sbom
-
-package:
-	@echo "📦 Building package with Hatch..."
-	@hatch build
-
-clean:
-	@echo "🧹 Cleaning up build artifacts and caches..."
-	@rm -rf build/
-	@rm -rf dist/
-	@rm -rf *.egg-info/
-	@rm -rf .pytest_cache/
-	@rm -rf .mypy_cache/
-	@rm -rf .ruff_cache/
-	@rm -rf .coverage
-	@rm -rf coverage.xml
-	@rm -rf htmlcov/
-	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-	@find . -type f -name "*.pyc" -delete 2>/dev/null || true
+.PHONY: help
+help: ## ✨ Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk '/^[a-zA-Z0-9_-]+:.*?##/ { \
+helpMessage = match($$0, /## (.*)/); \
+if (helpMessage) { \
+recipe = $$1; \
+sub(/:/, "", recipe); \
+printf "  \033[36m%-20s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH); \
+} \
+}' $(MAKEFILE_LIST)


### PR DESCRIPTION
## Summary
- replace existing Makefile with new uv-based helpers
- overhaul CI workflow to use uv, run lint/typecheck separately, test on matrix, and report coverage

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d478b667c832cae752fa667eb0fc2