### PR TITLE
Isolate loop iteration context

### DIFF
--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -143,7 +143,9 @@ async def _execute_parallel_step_logic(
                         ):
                             limit_breach_error = UsageLimitExceededError(
                                 f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded",
-                                PipelineResult(step_history=[result], total_cost_usd=total_cost_so_far),
+                                PipelineResult(
+                                    step_history=[result], total_cost_usd=total_cost_so_far
+                                ),
                             )
                             limit_breached.set()
                         elif (
@@ -152,7 +154,9 @@ async def _execute_parallel_step_logic(
                         ):
                             limit_breach_error = UsageLimitExceededError(
                                 f"Token limit of {usage_limits.total_tokens_limit} exceeded",
-                                PipelineResult(step_history=[result], total_cost_usd=total_cost_so_far),
+                                PipelineResult(
+                                    step_history=[result], total_cost_usd=total_cost_so_far
+                                ),
                             )
                             limit_breached.set()
 
@@ -358,15 +362,28 @@ async def _execute_loop_step_logic(
 
         iteration_succeeded_fully = True
         current_iteration_data_for_body_step = current_body_input
+        iteration_context = copy.deepcopy(context) if context is not None else None
 
         with telemetry.logfire.span(f"Loop '{loop_step.name}' - Iteration {i}"):
             for body_s in loop_step.loop_body_pipeline.steps:
-                body_step_result_obj = await step_executor(
-                    body_s,
-                    current_iteration_data_for_body_step,
-                    context,
-                    resources,
-                )
+                try:
+                    body_step_result_obj = await step_executor(
+                        body_s,
+                        current_iteration_data_for_body_step,
+                        iteration_context,
+                        resources,
+                    )
+                except PausedException:
+                    if context is not None and iteration_context is not None:
+                        if hasattr(context, "__dict__") and hasattr(iteration_context, "__dict__"):
+                            context.__dict__.update(iteration_context.__dict__)
+                        elif hasattr(iteration_context, "__dict__"):
+                            for key, value in iteration_context.__dict__.items():
+                                try:
+                                    setattr(context, key, value)
+                                except Exception:
+                                    pass
+                    raise
 
                 loop_overall_result.latency_s += body_step_result_obj.latency_s
                 loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)

--- a/flujo/domain/dsl/loop.py
+++ b/flujo/domain/dsl/loop.py
@@ -90,17 +90,14 @@ class MapStep(LoopStep[TContext]):
         iterable_input: str,
         **config_kwargs: Any,
     ) -> None:
-        results_attr = f"__{name}_results"
-        items_attr = f"__{name}_items"
+        results_var: contextvars.ContextVar[list[Any]] = contextvars.ContextVar(
+            f"{name}_results", default=[]
+        )
+        items_var: contextvars.ContextVar[list[Any]] = contextvars.ContextVar(
+            f"{name}_items", default=[]
+        )
 
-        async def _collect(item: Any, *, context: BaseModel | None = None) -> Any:
-            if context is None:
-                raise ValueError("map_over requires a context")
-            getattr(context, results_attr).append(item)
-            return item
-
-        collector = Step.from_callable(_collect, name=f"_{name}_collect")
-        body = pipeline_to_run >> collector
+        body = pipeline_to_run
 
         # Initialize base Step/DataModel via pydantic BaseModel.__init__
         BaseModel.__init__(
@@ -112,8 +109,8 @@ class MapStep(LoopStep[TContext]):
                 "plugins": [],
                 "failure_handlers": [],
                 "loop_body_pipeline": body,
-                "exit_condition_callable": lambda _o, ctx: len(getattr(ctx, results_attr, []))
-                >= len(getattr(ctx, items_attr, [])),
+                "exit_condition_callable": lambda _o, ctx: len(results_var.get()) + 1
+                >= len(items_var.get()),
                 "max_loops": 1,
                 "initial_input_to_loop_body_mapper": None,
                 "iteration_input_mapper": None,
@@ -131,8 +128,8 @@ class MapStep(LoopStep[TContext]):
             "_noop_pipeline",
             Pipeline.from_step(Step.from_callable(_noop, name=f"_{name}_noop")),
         )
-        object.__setattr__(self, "_results_attr", results_attr)
-        object.__setattr__(self, "_items_attr", items_attr)
+        object.__setattr__(self, "_results_var", results_var)
+        object.__setattr__(self, "_items_var", items_var)
         object.__setattr__(
             self,
             "_max_loops_var",
@@ -144,33 +141,39 @@ class MapStep(LoopStep[TContext]):
             if ctx is None:
                 raise ValueError("map_over requires a context")
             raw_items = getattr(ctx, iterable_input, [])
-            # Disallow strings & ensure an actual iterable collection
             if isinstance(raw_items, (str, bytes, bytearray)) or not isinstance(
                 raw_items, Iterable
             ):
                 raise TypeError(f"context.{iterable_input} must be a non-string iterable")
             items = list(raw_items)
-            setattr(ctx, items_attr, items)
-            setattr(ctx, results_attr, [])
+            items_var.set(items)
+            results_var.set([])
             if items:
                 self._max_loops_var.set(len(items))
                 self._body_var.set(self._original_body_pipeline)
                 return items[0]
-            # empty: nothing to iterate
             self._max_loops_var.set(1)
             self._body_var.set(self._noop_pipeline)
             return None
 
-        def _iter_mapper(_: Any, ctx: BaseModel | None, i: int) -> Any:
+        def _iter_mapper(out: Any, ctx: BaseModel | None, i: int) -> Any:
             if ctx is None:
                 raise ValueError("map_over requires a context")
-            items = getattr(ctx, items_attr, [])
+            res = results_var.get()
+            res.append(out)
+            results_var.set(res)
+            items = items_var.get()
             return items[i] if i < len(items) else None
 
-        def _output_mapper(_: Any, ctx: BaseModel | None) -> List[Any]:
+        def _output_mapper(out: Any, ctx: BaseModel | None) -> List[Any]:
             if ctx is None:
                 raise ValueError("map_over requires a context")
-            return list(getattr(ctx, results_attr, []))
+            items = items_var.get()
+            res = results_var.get()
+            if not items:
+                return []
+            res.append(out)
+            return list(res)
 
         object.__setattr__(self, "initial_input_to_loop_body_mapper", _initial_mapper)
         object.__setattr__(self, "iteration_input_mapper", _iter_mapper)


### PR DESCRIPTION
## Summary
- ensure LoopStep uses a deep-copied context for each iteration
- keep context modifications isolated per iteration
- update AgenticLoop and refine_until with isolated contexts
- test that loop iteration context does not leak between iterations
- avoid calling iteration mapper when loop hits max_loops
- merge full iteration context back on pause
- expand tests for pause/resume and iteration mapper behavior
- fix context merge when objects lack `__dict__`

## Testing
- `make quality`
- `make test`
- `make cov`


------
https://chatgpt.com/codex/tasks/task_e_686ca8632734832cb7e10f2890830da0