### PR TITLE
Preserve feedback history across retries

### DIFF
--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -143,7 +143,9 @@ async def _execute_parallel_step_logic(
                         ):
                             limit_breach_error = UsageLimitExceededError(
                                 f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded",
-                                PipelineResult(step_history=[result], total_cost_usd=total_cost_so_far),
+                                PipelineResult(
+                                    step_history=[result], total_cost_usd=total_cost_so_far
+                                ),
                             )
                             limit_breached.set()
                         elif (
@@ -152,7 +154,9 @@ async def _execute_parallel_step_logic(
                         ):
                             limit_breach_error = UsageLimitExceededError(
                                 f"Token limit of {usage_limits.total_tokens_limit} exceeded",
-                                PipelineResult(step_history=[result], total_cost_usd=total_cost_so_far),
+                                PipelineResult(
+                                    step_history=[result], total_cost_usd=total_cost_so_far
+                                ),
                             )
                             limit_breached.set()
 
@@ -706,8 +710,11 @@ async def _run_step_logic(
     last_raw_output = None
     last_unpacked_output = None
     validation_failed = False
-    last_attempt_feedbacks: list[str] = []
     last_attempt_output = None
+
+    original_data = copy.deepcopy(data)
+    # Aggregate feedback across retries
+    all_feedbacks: list[str] = []
     for attempt in range(1, step.config.max_retries + 1):
         validation_failed = False
         result.attempts = attempt
@@ -912,16 +919,17 @@ async def _run_step_logic(
         if plugin_failed_this_attempt:
             success = False
         # --- END FIX ---
-        # --- JOIN ALL FEEDBACKS ---
+
         feedback = "\n".join(feedbacks).strip() if feedbacks else None
-        # --- END JOIN ---
+        if feedbacks:
+            all_feedbacks.extend(feedbacks)
+
         if not success and attempt == step.config.max_retries:
-            last_attempt_feedbacks = feedbacks.copy()
             last_attempt_output = last_unpacked_output
         if success:
             result.output = unpacked_output
             result.success = True
-            result.feedback = feedback
+            result.feedback = "\n".join(all_feedbacks) if all_feedbacks else None
             result.token_counts += getattr(raw_output, "token_counts", 0)
             result.cost_usd += getattr(raw_output, "cost_usd", 0.0)
             _apply_validation_metadata(
@@ -944,18 +952,27 @@ async def _run_step_logic(
         else:
             current_agent = original_agent
 
-        if feedback:
-            if isinstance(data, dict):
-                data["feedback"] = data.get("feedback", "") + "\n" + feedback
+        joined_feedback = "\n".join(all_feedbacks)
+        if isinstance(original_data, dict):
+            data = copy.deepcopy(original_data)
+            raw_existing = original_data.get("feedback")
+            existing_feedback = str(raw_existing) if raw_existing is not None else ""
+            initial = existing_feedback.strip()
+            combined = "\n".join(filter(None, [initial, joined_feedback]))
+            if combined:
+                data["feedback"] = combined
             else:
-                data = f"{str(data)}\n{feedback}"
+                data.pop("feedback", None)
+        else:
+            if joined_feedback:
+                data = f"{original_data}\n{joined_feedback}"
+            else:
+                data = original_data
         last_feedback = feedback
 
-    # After all retries, set feedback to last attempt's feedbacks
+    # After all retries, aggregate all feedback collected
     result.success = False
-    result.feedback = (
-        "\n".join(last_attempt_feedbacks).strip() if last_attempt_feedbacks else last_feedback
-    )
+    result.feedback = "\n".join(all_feedbacks) if all_feedbacks else last_feedback
     is_validation_step, is_strict = _get_validation_flags(step)
     if validation_failed and is_strict:
         result.output = None

--- a/tests/integration/test_pipeline_runner.py
+++ b/tests/integration/test_pipeline_runner.py
@@ -45,9 +45,113 @@ async def test_feedback_enriches_prompt() -> None:
     )
     step = Step.solution(sol_agent, max_retries=2, plugins=[(plugin, 0)])
     runner = Flujo(step)
-    await gather_result(runner, "SELECT *")
+    result = await gather_result(runner, "SELECT *")
     assert sol_agent.call_count == 2
     assert "SQL Error: XYZ" in sol_agent.inputs[1]
+    step_result = result.step_history[0]
+    assert step_result.feedback == "SQL Error: XYZ"
+
+
+@pytest.mark.asyncio
+async def test_feedback_history_persists_across_retries() -> None:
+    agent = StubAgent(["out1", "out2", "out3"])
+    plugin = DummyPlugin(
+        [
+            PluginOutcome(success=False, feedback="err1"),
+            PluginOutcome(success=False, feedback="err2"),
+            PluginOutcome(success=True),
+        ]
+    )
+    step = Step.solution(agent, max_retries=3, plugins=[(plugin, 0)])
+    runner = Flujo(step)
+    result = await gather_result(runner, "in")
+    assert agent.call_count == 3
+    assert "err1" in agent.inputs[1]
+    assert "err1" in agent.inputs[2] and "err2" in agent.inputs[2]
+    step_result = result.step_history[0]
+    assert step_result.success is True
+    assert step_result.feedback == "err1\nerr2"
+
+
+@pytest.mark.asyncio
+async def test_initial_feedback_preserved_on_retry() -> None:
+    agent = StubAgent(["o1", "o2", "o3"])
+    plugin = DummyPlugin(
+        [
+            PluginOutcome(success=False),
+            PluginOutcome(success=False, feedback="e1"),
+            PluginOutcome(success=True),
+        ]
+    )
+    step = Step.solution(agent, max_retries=3, plugins=[(plugin, 0)])
+    runner = Flujo(step)
+    original = {"prompt": "q", "feedback": "start"}
+    result = await gather_result(runner, original)
+    assert agent.call_count == 3
+    assert agent.inputs[0]["feedback"] == "start"
+    assert agent.inputs[1]["feedback"] == "start"
+    assert agent.inputs[2]["feedback"] == "start\ne1"
+    step_result = result.step_history[0]
+    assert step_result.feedback == "e1"
+
+
+@pytest.mark.asyncio
+async def test_non_dict_input_not_stringified_without_feedback() -> None:
+    agent = StubAgent(["ok", "ok2"])
+    plugin = DummyPlugin(
+        [
+            PluginOutcome(success=False),
+            PluginOutcome(success=True),
+        ]
+    )
+    step = Step.solution(agent, max_retries=2, plugins=[(plugin, 0)])
+    runner = Flujo(step)
+    result = await gather_result(runner, 1)
+    assert agent.call_count == 2
+    assert agent.inputs[0] == 1
+    assert agent.inputs[1] == 1
+    step_result = result.step_history[0]
+    assert step_result.feedback is None
+
+
+@pytest.mark.asyncio
+async def test_whitespace_feedback_removed_on_retry() -> None:
+    agent = StubAgent(["a", "b"])
+    plugin = DummyPlugin(
+        [
+            PluginOutcome(success=False),
+            PluginOutcome(success=True),
+        ]
+    )
+    step = Step.solution(agent, max_retries=2, plugins=[(plugin, 0)])
+    runner = Flujo(step)
+    start = {"prompt": "q", "feedback": "   "}
+    result = await gather_result(runner, start)
+    assert agent.call_count == 2
+    assert agent.inputs[0]["feedback"] == "   "
+    assert "feedback" not in agent.inputs[1]
+    step_result = result.step_history[0]
+    assert step_result.feedback is None
+
+
+@pytest.mark.asyncio
+async def test_none_feedback_removed_on_retry() -> None:
+    agent = StubAgent(["a", "b"])
+    plugin = DummyPlugin(
+        [
+            PluginOutcome(success=False),
+            PluginOutcome(success=True),
+        ]
+    )
+    step = Step.solution(agent, max_retries=2, plugins=[(plugin, 0)])
+    runner = Flujo(step)
+    start = {"prompt": "q", "feedback": None}
+    result = await gather_result(runner, start)
+    assert agent.call_count == 2
+    assert start["feedback"] is None
+    assert "feedback" not in agent.inputs[1]
+    step_result = result.step_history[0]
+    assert step_result.feedback is None
 
 
 async def test_conditional_redirection() -> None:


### PR DESCRIPTION
## Summary
- handle cost/token limit message conflicts
- aggregate feedback across retry attempts
- clean up retry input feedback merging
- test persistence of feedback across retries

## Testing
- `make test`
- `make cov`
- `make quality`


------
https://chatgpt.com/codex/tasks/task_e_686ca8643c14832c95b3f9725e1f96a2