### PR TITLE
Improve feedback accumulation in retry logic

### DIFF
--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -822,8 +822,8 @@ async def _run_step_logic(
     last_raw_output = None
     last_unpacked_output = None
     validation_failed = False
-    last_attempt_feedbacks: list[str] = []
     last_attempt_output = None
+    accumulated_feedbacks: list[str] = []
     for attempt in range(1, step.config.max_retries + 1):
         validation_failed = False
         result.attempts = attempt
@@ -1035,9 +1035,10 @@ async def _run_step_logic(
         # --- END FIX ---
         # --- JOIN ALL FEEDBACKS ---
         feedback = "\n".join(feedbacks).strip() if feedbacks else None
+        if feedback:
+            accumulated_feedbacks.extend(feedbacks)
         # --- END JOIN ---
         if not success and attempt == step.config.max_retries:
-            last_attempt_feedbacks = feedbacks.copy()
             last_attempt_output = last_unpacked_output
         if success:
             result.output = unpacked_output
@@ -1072,13 +1073,14 @@ async def _run_step_logic(
                 data["feedback"] = data.get("feedback", "") + "\n" + feedback
             else:
                 data = f"{str(data)}\n{feedback}"
-        last_feedback = feedback
+        # Store all feedback so far for the next iteration
+        last_feedback = "\n".join(accumulated_feedbacks).strip() if accumulated_feedbacks else None
 
-    # After all retries, set feedback to last attempt's feedbacks
+    # After all retries, set feedback to accumulated feedbacks
     result.success = False
     result.feedback = (
-        "\n".join(last_attempt_feedbacks).strip()
-        if last_attempt_feedbacks
+        "\n".join(accumulated_feedbacks).strip()
+        if accumulated_feedbacks
         else last_feedback
     )
     is_validation_step, is_strict = _get_validation_flags(step)


### PR DESCRIPTION
## Summary
- improve the retry self-correction logic by accumulating all feedback across retry attempts
- avoid duplicating old feedback in the next retry's input
- refine assignment of last_feedback after each attempt

## Testing
- `ruff check flujo/application/core/step_logic.py`
- `make test` *(fails: hatch not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5fbadae0832cba80309ee86c25e7