### PR TITLE
Add uv-based Makefile and CI; fix lint formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,149 @@
-name: CI
+# .github/workflows/ci.yml
+# Continuous Integration workflow for the Flujo project.
+
+name: Flujo CI
 
 on:
   push:
-    branches: [main]
+    branches: [ "main" ]
   pull_request:
-    branches: [main]
+    branches: [ "main" ]
+
+# Cancel any in-progress jobs for the same PR/branch when new commits are pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  quality:
+  # ----------------------------------------------------------------------------
+  # Job 1: Linting and Static Type Checking
+  # ----------------------------------------------------------------------------
+  lint-and-typecheck:
+    name: Lint & Typecheck
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run Linter
+        run: make lint
+
+      - name: Run Type Checker
+        run: make typecheck
+
+  # ----------------------------------------------------------------------------
+  # Job 2: Run Tests on a Matrix of Python Versions
+  # ----------------------------------------------------------------------------
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    needs: lint-and-typecheck
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-      - run: make install-dev
-      - run: make quality
-      - run: make cov
-      - run: hatch run pytest tests/benchmarks
-      - run: make audit
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run coverage run --source=flujo --parallel-mode -m pytest tests/
+
+      - name: Store coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}
+          path: .coverage.*
+
+  # ----------------------------------------------------------------------------
+  # Job 3: Combine and Report Code Coverage
+  # ----------------------------------------------------------------------------
+  coverage:
+    name: Report Coverage
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: Combine coverage reports and check threshold
+        run: |
+          if ls .coverage* 1>/dev/null 2>&1; then
+            uv run coverage combine
+          fi
+          uv run coverage report --fail-under=90
+          uv run coverage xml
+          uv run coverage html
+
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-html
+          path: htmlcov
+
+  # ----------------------------------------------------------------------------
+  # Job 4: Live API Tests (Optional but Recommended)
+  # ----------------------------------------------------------------------------
+  # This job is a placeholder for a critical testing practice.
+  # To enable it, you would need to:
+  # 1. Create live tests in a separate directory (e.g., tests/live/).
+  # 2. Add API key secrets to your GitHub repository settings.
+  # 3. Uncomment this job.
+  # test-live:
+  #   name: Live API Tests
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v1
+  #     - name: Install dependencies
+  #       run: uv sync --all-extras
+  #     - name: Run live tests
+  #       run: uv run pytest tests/live/
+  #       env:
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  #         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ pip-delete-this-directory.txt
 docs/_build/
 site/
 /sbom.json
+uv.lock

--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,92 @@
+# Makefile for the Flujo project
+# Provides a consistent set of commands for development, testing, and quality checks.
+
 .DEFAULT_GOAL := help
 
-args = $(filter-out $@,$(MAKECMDGOALS))
+# ------------------------------------------------------------------------------
+# Tooling Checks
+# ------------------------------------------------------------------------------
 
-.PHONY: help setup install-dev audit quality lint format type-check test cov bandit sbom pip-dev pip-install clean package
-
-help:
-	@echo "Available commands:"
-	@echo "  setup         - Install dependencies and pre-commit hooks."
-	@echo "  quality       - Run all code quality checks."
-	@echo "  lint          - Run Ruff linting."
-	@echo "  format        - Auto-format the code."
-	@echo "  type-check    - Run MyPy type checking."
-	@echo "  test          - Run the test suite (use 'make test args=\"-k expr\"')."
-	@echo "  cov           - Run tests with coverage (uses args too)."
-	@echo "  bandit        - Run Bandit security scan."
-	@echo "  sbom          - Generate a CycloneDX SBOM."
-	@echo "  package       - Build the package using Hatch."
-	@echo "  clean         - Remove build artifacts and caches."
-
-setup:
-	@pip install --upgrade pip hatch pre-commit
-	@hatch run setup
+# Ensure uv is installed, as it's the core tool for this workflow.
+.PHONY: .uv
+.uv:
+	@uv --version > /dev/null 2>&1 || (printf "\033[0;31m✖ Error: uv is not installed.\033[0m\n  Please install it via: https://github.com/astral-sh/uv\n" && exit 1)
 
 
-install-dev:
-	@pip install --upgrade pip hatch pre-commit
-	@hatch run setup
+# ------------------------------------------------------------------------------
+# Project Setup & Dependency Management
+# ------------------------------------------------------------------------------
+
+.PHONY: install
+install: .uv ## Install dependencies into a virtual environment
+	@echo "🚀 Creating virtual environment and installing dependencies..."
+	@uv venv
+	@uv sync --all-extras
+	@echo "\n✅ Done! Activate the environment with 'source .venv/bin/activate'"
+
+.PHONY: sync
+sync: .uv ## Update dependencies based on pyproject.toml
+	@echo "🔄 Syncing dependencies..."
+	@uv sync --all-extras
 
 
-audit:
-	@hatch run pip-audit && hatch run bandit-check
+# ------------------------------------------------------------------------------
+# Code Quality & Formatting
+# ------------------------------------------------------------------------------
 
-pip-dev:
-	@echo "📦 Installing development dependencies with pip..."
-	@python -m pip install --upgrade pip
-	@python -m pip install -e ".[dev]"
+.PHONY: format
+format: .uv ## Auto-format the code with ruff
+	@echo "🎨 Formatting code..."
+	@uv run ruff format flujo/ tests/
 
-pip-install:
-	@echo "📦 Installing package in development mode with pip..."
-	@python -m pip install --upgrade pip
-	@python -m pip install -e .
+.PHONY: lint
+lint: .uv ## Lint the code and check for formatting issues
+	@echo "🔎 Linting code..."
+	@uv run ruff format --check flujo/ tests/
+	@uv run ruff check flujo/ tests/
 
-quality:
-	@hatch run quality
+.PHONY: typecheck
+typecheck: .uv ## Run static type checking with mypy
+	@echo "🧐 Running static type checking..."
+	@uv run mypy flujo/
 
-lint:
-	@hatch run lint
 
-format:
-	@hatch run format
+# ------------------------------------------------------------------------------
+# Testing & Coverage
+# ------------------------------------------------------------------------------
 
-type-check:
-	@hatch run type-check
+.PHONY: test
+test: .uv ## Run all tests
+	@echo "🧪 Running tests..."
+	@uv run pytest tests/
 
-test:
-	@hatch run test $(args)
+.PHONY: testcov
+testcov: .uv ## Run tests and generate an HTML coverage report
+	@echo "🧪 Running tests with coverage..."
+	@uv run coverage run --source=flujo -m pytest tests/
+	@uv run coverage html
+	@echo "\n✅ Coverage report generated in 'htmlcov/'. Open htmlcov/index.html to view."
 
-cov:
-	@hatch run cov $(args)
 
-bandit:
-	@hatch run bandit-check
+# ------------------------------------------------------------------------------
+# All-in-one & Help
+# ------------------------------------------------------------------------------
 
-sbom:
-	@hatch run cyclonedx
+.PHONY: all
+all: format lint typecheck test ## Run all quality checks (format, lint, typecheck, test)
+	@echo "\n✅ All local checks passed! You are ready to push."
 
-cyclonedx: sbom
+.PHONY: help
+help: ## ✨ Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk '/^[a-zA-Z0-9_-]+:.*?##/ { \
+		helpMessage = match($$0, /## (.*)/); \
+		if (helpMessage) { \
+			recipe = $$1; \
+			sub(/:/, "", recipe); \
+			printf "  \033[36m%-20s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH); \
+		} \
+	}' $(MAKEFILE_LIST)
 
-package:
-	@echo "📦 Building package with Hatch..."
-	@hatch build
-
-clean:
-	@echo "🧹 Cleaning up build artifacts and caches..."
-	@rm -rf build/
-	@rm -rf dist/
-	@rm -rf *.egg-info/
-	@rm -rf .pytest_cache/
-	@rm -rf .mypy_cache/
-	@rm -rf .ruff_cache/
-	@rm -rf .coverage
-	@rm -rf coverage.xml
-	@rm -rf htmlcov/
-	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-	@find . -type f -name "*.pyc" -delete 2>/dev/null || true

--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -61,9 +61,7 @@ __all__ = [
 
 
 # Default context setter used when running step logic outside the Flujo runner
-def _default_set_final_context(
-    result: PipelineResult[TContext], ctx: Optional[TContext]
-) -> None:
+def _default_set_final_context(result: PipelineResult[TContext], ctx: Optional[TContext]) -> None:
     """Write ``ctx`` into ``result`` if present."""
 
     if ctx is not None:
@@ -71,8 +69,8 @@ def _default_set_final_context(
 
 
 # Track fallback chain per execution context to detect loops
-_fallback_chain_var: contextvars.ContextVar[list[Step[Any, Any]]] = (
-    contextvars.ContextVar("_fallback_chain", default=[])
+_fallback_chain_var: contextvars.ContextVar[list[Step[Any, Any]]] = contextvars.ContextVar(
+    "_fallback_chain", default=[]
 )
 
 
@@ -125,9 +123,7 @@ async def _execute_parallel_step_logic(
                         f"Branch '{key}' cancelled due to limit breach in sibling branch"
                     )
                     branch_res.success = False
-                    branch_res.feedback = (
-                        "Cancelled due to usage limit breach in sibling branch"
-                    )
+                    branch_res.feedback = "Cancelled due to usage limit breach in sibling branch"
                     break
 
                 sr = await step_executor(s, current, ctx_copy, resources)
@@ -150,10 +146,8 @@ async def _execute_parallel_step_logic(
                             limit_breach_error = UsageLimitExceededError(
                                 f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded",
                                 PipelineResult(
- 
                                     step_history=[result],
                                     total_cost_usd=total_cost_so_far,
- 
                                 ),
                             )
                             limit_breached.set()
@@ -164,10 +158,8 @@ async def _execute_parallel_step_logic(
                             limit_breach_error = UsageLimitExceededError(
                                 f"Token limit of {usage_limits.total_tokens_limit} exceeded",
                                 PipelineResult(
- 
                                     step_history=[result],
                                     total_cost_usd=total_cost_so_far,
- 
                                 ),
                             )
                             limit_breached.set()
@@ -201,19 +193,14 @@ async def _execute_parallel_step_logic(
 
     branch_order = list(parallel_step.branches.keys())
     tasks = {
-        asyncio.create_task(run_branch(k, pipe)): k
-        for k, pipe in parallel_step.branches.items()
+        asyncio.create_task(run_branch(k, pipe)): k for k, pipe in parallel_step.branches.items()
     }
 
     while tasks:
-        done, pending = await asyncio.wait(
-            tasks.keys(), return_when=asyncio.FIRST_COMPLETED
-        )
+        done, pending = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
 
         if limit_breached.is_set():
-            telemetry.logfire.info(
-                "Usage limit breached, cancelling remaining tasks..."
-            )
+            telemetry.logfire.info("Usage limit breached, cancelling remaining tasks...")
             for task in pending:
                 task.cancel()
             if pending:
@@ -244,10 +231,7 @@ async def _execute_parallel_step_logic(
         else:
             failed_branches[name] = br
 
-    if (
-        failed_branches
-        and parallel_step.on_branch_failure == BranchFailureStrategy.PROPAGATE
-    ):
+    if failed_branches and parallel_step.on_branch_failure == BranchFailureStrategy.PROPAGATE:
         result.success = False
         fail_name = next(iter(failed_branches))
         result.feedback = f"Branch '{fail_name}' failed. Propagating failure."
@@ -290,10 +274,7 @@ async def _execute_parallel_step_logic(
                 parallel_step.merge_strategy(context, branch_ctx)
                 continue
 
-            if (
-                parallel_step.merge_strategy == MergeStrategy.OVERWRITE
-                and merged is not None
-            ):
+            if parallel_step.merge_strategy == MergeStrategy.OVERWRITE and merged is not None:
                 branch_data = branch_ctx.model_dump()
                 keys = parallel_step.context_include_keys or list(branch_data.keys())
                 for key in keys:
@@ -307,9 +288,8 @@ async def _execute_parallel_step_logic(
                             merged[key].update(branch_data[key])
                         else:
                             merged[key] = branch_data[key]
-            elif (
-                parallel_step.merge_strategy == MergeStrategy.MERGE_SCRATCHPAD
-                and hasattr(branch_ctx, "scratchpad")
+            elif parallel_step.merge_strategy == MergeStrategy.MERGE_SCRATCHPAD and hasattr(
+                branch_ctx, "scratchpad"
             ):
                 branch_pc = cast(PipelineContext, branch_ctx)
                 context_pc = cast(PipelineContext, context)
@@ -318,10 +298,7 @@ async def _execute_parallel_step_logic(
                 for key, val in branch_pc.scratchpad.items():
                     if key in base_snapshot and base_snapshot[key] == val:
                         continue
-                    if (
-                        key in context_pc.scratchpad
-                        and context_pc.scratchpad[key] != val
-                    ):
+                    if key in context_pc.scratchpad and context_pc.scratchpad[key] != val:
                         raise ValueError(
                             f"Scratchpad key collision for '{key}' in branch '{branch_name}'"
                         )
@@ -332,10 +309,7 @@ async def _execute_parallel_step_logic(
                     context_pc.scratchpad[key] = val
                     seen_keys.add(key)
 
-        if (
-            parallel_step.merge_strategy == MergeStrategy.OVERWRITE
-            and merged is not None
-        ):
+        if parallel_step.merge_strategy == MergeStrategy.OVERWRITE and merged is not None:
             validated = context.__class__.model_validate(merged)
             context.__dict__.update(validated.__dict__)
 
@@ -353,9 +327,7 @@ async def _execute_parallel_step_logic(
             and result.cost_usd > usage_limits.total_cost_usd_limit
         ):
             result.success = False
-            result.feedback = (
-                f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
-            )
+            result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
             pr_cost: PipelineResult[TContext] = PipelineResult(
                 step_history=[result], total_cost_usd=result.cost_usd
             )
@@ -366,9 +338,7 @@ async def _execute_parallel_step_logic(
             and result.token_counts > usage_limits.total_tokens_limit
         ):
             result.success = False
-            result.feedback = (
-                f"Token limit of {usage_limits.total_tokens_limit} exceeded"
-            )
+            result.feedback = f"Token limit of {usage_limits.total_tokens_limit} exceeded"
             pr_tokens: PipelineResult[TContext] = PipelineResult(
                 step_history=[result], total_cost_usd=result.cost_usd
             )
@@ -404,9 +374,7 @@ async def _execute_loop_step_logic(
                 f"Error in initial_input_to_loop_body_mapper for LoopStep '{loop_step.name}': {e}"
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = (
-                f"Initial input mapper raised an exception: {e}"
-            )
+            loop_overall_result.feedback = f"Initial input mapper raised an exception: {e}"
             return loop_overall_result
     else:
         current_body_input = loop_step_initial_input
@@ -447,24 +415,21 @@ async def _execute_loop_step_logic(
                     raise
 
                 loop_overall_result.latency_s += body_step_result_obj.latency_s
-                loop_overall_result.cost_usd += getattr(
-                    body_step_result_obj, "cost_usd", 0.0
-                )
-                loop_overall_result.token_counts += getattr(
-                    body_step_result_obj, "token_counts", 0
-                )
+                loop_overall_result.cost_usd += getattr(body_step_result_obj, "cost_usd", 0.0)
+                loop_overall_result.token_counts += getattr(body_step_result_obj, "token_counts", 0)
 
                 if usage_limits is not None:
                     if (
                         usage_limits.total_cost_usd_limit is not None
-                        and loop_overall_result.cost_usd
-                        > usage_limits.total_cost_usd_limit
+                        and loop_overall_result.cost_usd > usage_limits.total_cost_usd_limit
                     ):
                         telemetry.logfire.warn(
                             f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
                         )
                         loop_overall_result.success = False
-                        loop_overall_result.feedback = f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+                        loop_overall_result.feedback = (
+                            f"Cost limit of ${usage_limits.total_cost_usd_limit} exceeded"
+                        )
                         pr: PipelineResult[TContext] = PipelineResult(
                             step_history=[loop_overall_result],
                             total_cost_usd=loop_overall_result.cost_usd,
@@ -473,8 +438,7 @@ async def _execute_loop_step_logic(
                         raise UsageLimitExceededError(loop_overall_result.feedback, pr)
                     if (
                         usage_limits.total_tokens_limit is not None
-                        and loop_overall_result.token_counts
-                        > usage_limits.total_tokens_limit
+                        and loop_overall_result.token_counts > usage_limits.total_tokens_limit
                     ):
                         telemetry.logfire.warn(
                             f"Token limit of {usage_limits.total_tokens_limit} exceeded"
@@ -488,9 +452,7 @@ async def _execute_loop_step_logic(
                             total_cost_usd=loop_overall_result.cost_usd,
                         )
                         context_setter(pr_tokens, context)
-                        raise UsageLimitExceededError(
-                            loop_overall_result.feedback, pr_tokens
-                        )
+                        raise UsageLimitExceededError(loop_overall_result.feedback, pr_tokens)
 
                 if not body_step_result_obj.success:
                     telemetry.logfire.warn(
@@ -515,9 +477,7 @@ async def _execute_loop_step_logic(
                 f"Error in exit_condition_callable for LoopStep '{loop_step.name}': {e}"
             )
             loop_overall_result.success = False
-            loop_overall_result.feedback = (
-                f"Exit condition callable raised an exception: {e}"
-            )
+            loop_overall_result.feedback = f"Exit condition callable raised an exception: {e}"
             break
 
         if should_exit:
@@ -577,16 +537,16 @@ async def _execute_loop_step_logic(
                     f"Error in loop_output_mapper for LoopStep '{loop_step.name}': {e}"
                 )
                 loop_overall_result.success = False
-                loop_overall_result.feedback = (
-                    f"Loop output mapper raised an exception: {e}"
-                )
+                loop_overall_result.feedback = f"Loop output mapper raised an exception: {e}"
                 loop_overall_result.output = None
         else:
             loop_overall_result.output = last_successful_iteration_body_output
     else:
         loop_overall_result.output = final_body_output_of_last_iteration
         if not loop_overall_result.feedback:
-            loop_overall_result.feedback = "Loop did not complete successfully or exit condition not met positively."
+            loop_overall_result.feedback = (
+                "Loop did not complete successfully or exit condition not met positively."
+            )
 
     return loop_overall_result
 
@@ -608,9 +568,7 @@ async def _execute_conditional_step_logic(
     branch_succeeded = False
 
     try:
-        branch_key_to_execute = conditional_step.condition_callable(
-            conditional_step_input, context
-        )
+        branch_key_to_execute = conditional_step.condition_callable(conditional_step_input, context)
         telemetry.logfire.info(
             f"ConditionalStep '{conditional_step.name}': Condition evaluated to branch key '{branch_key_to_execute}'."
         )
@@ -634,9 +592,7 @@ async def _execute_conditional_step_logic(
             )
 
         if conditional_step.branch_input_mapper:
-            input_for_branch = conditional_step.branch_input_mapper(
-                conditional_step_input, context
-            )
+            input_for_branch = conditional_step.branch_input_mapper(conditional_step_input, context)
         else:
             input_for_branch = conditional_step_input
 
@@ -649,9 +605,7 @@ async def _execute_conditional_step_logic(
             ) as span:
                 if executed_branch_key is not None:
                     try:
-                        span.set_attribute(
-                            "executed_branch_key", str(executed_branch_key)
-                        )
+                        span.set_attribute("executed_branch_key", str(executed_branch_key))
                     except Exception as e:
                         telemetry.logfire.error(f"Error setting span attribute: {e}")
                 branch_step_result_obj = await step_executor(
@@ -662,9 +616,7 @@ async def _execute_conditional_step_logic(
                 )
 
             conditional_overall_result.latency_s += branch_step_result_obj.latency_s
-            conditional_overall_result.cost_usd += getattr(
-                branch_step_result_obj, "cost_usd", 0.0
-            )
+            conditional_overall_result.cost_usd += getattr(branch_step_result_obj, "cost_usd", 0.0)
             conditional_overall_result.token_counts += getattr(
                 branch_step_result_obj, "token_counts", 0
             )
@@ -690,19 +642,15 @@ async def _execute_conditional_step_logic(
             exc_info=True,
         )
         conditional_overall_result.success = False
-        conditional_overall_result.feedback = (
-            f"Error executing conditional logic or branch: {e}"
-        )
+        conditional_overall_result.feedback = f"Error executing conditional logic or branch: {e}"
         return conditional_overall_result
 
     conditional_overall_result.success = branch_succeeded
     if branch_succeeded:
         if conditional_step.branch_output_mapper:
             try:
-                conditional_overall_result.output = (
-                    conditional_step.branch_output_mapper(
-                        branch_output, executed_branch_key, context
-                    )
+                conditional_overall_result.output = conditional_step.branch_output_mapper(
+                    branch_output, executed_branch_key, context
                 )
             except Exception as e:
                 telemetry.logfire.error(
@@ -720,12 +668,8 @@ async def _execute_conditional_step_logic(
 
     conditional_overall_result.attempts = 1
     if executed_branch_key is not None:
-        conditional_overall_result.metadata_ = (
-            conditional_overall_result.metadata_ or {}
-        )
-        conditional_overall_result.metadata_["executed_branch_key"] = str(
-            executed_branch_key
-        )
+        conditional_overall_result.metadata_ = conditional_overall_result.metadata_ or {}
+        conditional_overall_result.metadata_["executed_branch_key"] = str(executed_branch_key)
 
     return conditional_overall_result
 
@@ -739,9 +683,7 @@ async def _run_step_logic(
     step_executor: StepExecutor[TContext],
     context_model_defined: bool,
     usage_limits: UsageLimits | None = None,
-    context_setter: (
-        Callable[[PipelineResult[TContext], Optional[TContext]], None] | None
-    ) = None,
+    context_setter: (Callable[[PipelineResult[TContext], Optional[TContext]], None] | None) = None,
     stream: bool = False,
     on_chunk: Callable[[Any], Awaitable[None]] | None = None,
 ) -> StepResult:
@@ -753,9 +695,7 @@ async def _run_step_logic(
     if step.agent is not None:
         visited_ids.add(id(step.agent))
     if isinstance(step, CacheStep):
-        key = _generate_cache_key(
-            step.wrapped_step, data, context=context, resources=resources
-        )
+        key = _generate_cache_key(step.wrapped_step, data, context=context, resources=resources)
         cached: StepResult | None = None
         if key:
             try:
@@ -808,9 +748,7 @@ async def _run_step_logic(
             context_setter=context_setter,
         )
     if isinstance(step, HumanInTheLoopStep):
-        message = (
-            step.message_for_user if step.message_for_user is not None else str(data)
-        )
+        message = step.message_for_user if step.message_for_user is not None else str(data)
         if isinstance(context, PipelineContext):
             context.scratchpad["status"] = "paused"
         raise PausedException(message)
@@ -991,9 +929,7 @@ async def _run_step_logic(
                 for validator in step.validators
             ]
             try:
-                validation_results = await asyncio.gather(
-                    *validation_tasks, return_exceptions=True
-                )
+                validation_results = await asyncio.gather(*validation_tasks, return_exceptions=True)
             except Exception as e:  # pragma: no cover - defensive
                 validation_results = [e]
 
@@ -1012,9 +948,7 @@ async def _run_step_logic(
                 collected_results.append(vres)
                 if not vres.is_valid:
                     fb = vres.feedback or "No details provided."
-                    failed_checks_feedback.append(
-                        f"Check '{vres.validator_name}' failed: {fb}"
-                    )
+                    failed_checks_feedback.append(f"Check '{vres.validator_name}' failed: {fb}")
 
             if step.persist_validation_results_to and context is not None:
                 if hasattr(context, step.persist_validation_results_to):
@@ -1060,9 +994,7 @@ async def _run_step_logic(
         if redirect_to:
             redirect_id = id(redirect_to)
             if redirect_id in visited_ids:
-                raise InfiniteRedirectError(
-                    f"Redirect loop detected in step {step.name}"
-                )
+                raise InfiniteRedirectError(f"Redirect loop detected in step {step.name}")
             visited_ids.add(redirect_id)
             current_agent = redirect_to
         else:
@@ -1079,9 +1011,7 @@ async def _run_step_logic(
     # After all retries, set feedback to accumulated feedbacks
     result.success = False
     result.feedback = (
-        "\n".join(accumulated_feedbacks).strip()
-        if accumulated_feedbacks
-        else last_feedback
+        "\n".join(accumulated_feedbacks).strip() if accumulated_feedbacks else last_feedback
     )
     is_validation_step, is_strict = _get_validation_flags(step)
     if validation_failed and is_strict:
@@ -1089,14 +1019,10 @@ async def _run_step_logic(
     else:
         result.output = last_attempt_output
     result.token_counts += (
-        getattr(last_raw_output, "token_counts", 1)
-        if last_raw_output is not None
-        else 0
+        getattr(last_raw_output, "token_counts", 1) if last_raw_output is not None else 0
     )
     result.cost_usd += (
-        getattr(last_raw_output, "cost_usd", 0.0)
-        if last_raw_output is not None
-        else 0.0
+        getattr(last_raw_output, "cost_usd", 0.0) if last_raw_output is not None else 0.0
     )
     _apply_validation_metadata(
         result,

--- a/flujo/processors/repair.py
+++ b/flujo/processors/repair.py
@@ -70,9 +70,7 @@ class DeterministicRepairProcessor:
         except Exception as e:
             import logging
 
-            logging.warning(
-                f"DeterministicRepairProcessor: ast.literal_eval failed: {e}"
-            )
+            logging.warning(f"DeterministicRepairProcessor: ast.literal_eval failed: {e}")
             # pass
 
         raise ValueError("DeterministicRepairProcessor: unable to repair payload.")

--- a/tests/processors/test_repair.py
+++ b/tests/processors/test_repair.py
@@ -7,7 +7,5 @@ from flujo.processors.repair import DeterministicRepairProcessor, MAX_LITERAL_EV
 async def test_literal_eval_size_guard() -> None:
     proc = DeterministicRepairProcessor()
     oversized = "x" * (MAX_LITERAL_EVAL_SIZE + 1)
-    with pytest.raises(
-        ValueError, match="Input too large for safe literal evaluation."
-    ):
+    with pytest.raises(ValueError, match="Input too large for safe literal evaluation."):
         await proc.process(oversized)

--- a/tests/unit/test_parallel_step_strategies.py
+++ b/tests/unit/test_parallel_step_strategies.py
@@ -19,9 +19,7 @@ class Ctx(PipelineContext):
 
 
 class ScratchAgent:
-    def __init__(
-        self, key: str, val: Any, delay: float = 0.0, fail: bool = False
-    ) -> None:
+    def __init__(self, key: str, val: Any, delay: float = 0.0, fail: bool = False) -> None:
         self.key = key
         self.val = val
         self.delay = delay
@@ -43,10 +41,7 @@ class SafeScratchAgent:
 
     async def run(self, data: Any, *, context: FlujoBaseModel | None = None) -> Any:
         if context is not None:
-            if (
-                not hasattr(context, "scratchpad")
-                or getattr(context, "scratchpad") is None
-            ):
+            if not hasattr(context, "scratchpad") or getattr(context, "scratchpad") is None:
                 context.scratchpad = {}
             context.scratchpad[self.key] = self.val
         return data
@@ -73,9 +68,7 @@ async def test_merge_strategy_no_merge() -> None:
     }
     parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.NO_MERGE)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert "x" not in result.final_pipeline_context.scratchpad
     assert "y" not in result.final_pipeline_context.scratchpad
 
@@ -83,18 +76,12 @@ async def test_merge_strategy_no_merge() -> None:
 @pytest.mark.asyncio
 async def test_merge_strategy_overwrite() -> None:
     branches = {
-        "a": Step.model_validate(
-            {"name": "a", "agent": ScratchAgent("v", 1, delay=0.1)}
-        ),
-        "b": Step.model_validate(
-            {"name": "b", "agent": ScratchAgent("v", 2, delay=0.2)}
-        ),
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("v", 1, delay=0.1)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("v", 2, delay=0.2)}),
     }
     parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.OVERWRITE)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert result.final_pipeline_context.scratchpad["v"] == 2
 
 
@@ -126,13 +113,9 @@ async def test_merge_strategy_merge_scratchpad() -> None:
         "a": Step.model_validate({"name": "a", "agent": ScratchAgent("x", 1)}),
         "b": Step.model_validate({"name": "b", "agent": ScratchAgent("y", 2)}),
     }
-    parallel = Step.parallel(
-        "par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD
-    )
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert result.final_pipeline_context.scratchpad["x"] == 1
     assert result.final_pipeline_context.scratchpad["y"] == 2
 
@@ -143,14 +126,10 @@ async def test_merge_scratchpad_detects_collision() -> None:
         "a": Step.model_validate({"name": "a", "agent": ScratchAgent("dup", 1)}),
         "b": Step.model_validate({"name": "b", "agent": ScratchAgent("dup", 2)}),
     }
-    parallel = Step.parallel(
-        "par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD
-    )
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
     runner = Flujo(parallel, context_model=Ctx)
     with pytest.raises(ValueError):
-        await gather_result(
-            runner, "data", initial_context_data={"initial_prompt": "goal"}
-        )
+        await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
 
 
 @pytest.mark.asyncio
@@ -158,14 +137,10 @@ async def test_merge_scratchpad_requires_scratchpad() -> None:
     branches = {
         "a": Step.model_validate({"name": "a", "agent": SafeScratchAgent("x", 1)}),
     }
-    parallel = Step.parallel(
-        "par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD
-    )
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
     runner = Flujo(parallel, context_model=NoScratchCtx)
     with pytest.raises(ValueError):
-        await gather_result(
-            runner, "data", initial_context_data={"initial_prompt": "goal"}
-        )
+        await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
 
 
 @pytest.mark.asyncio
@@ -173,13 +148,9 @@ async def test_merge_scratchpad_handles_none() -> None:
     branches = {
         "a": Step.model_validate({"name": "a", "agent": SafeScratchAgent("x", 1)}),
     }
-    parallel = Step.parallel(
-        "par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD
-    )
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
     runner = Flujo(parallel, context_model=OptionalScratchCtx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert result.final_pipeline_context.scratchpad["x"] == 1
 
 
@@ -189,9 +160,7 @@ async def test_merge_scratchpad_alphabetical_order() -> None:
         "b": Step.model_validate({"name": "b", "agent": ScratchAgent("dup", 2)}),
         "a": Step.model_validate({"name": "a", "agent": ScratchAgent("dup", 1)}),
     }
-    parallel = Step.parallel(
-        "par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD
-    )
+    parallel = Step.parallel("par", branches, merge_strategy=MergeStrategy.MERGE_SCRATCHPAD)
     runner = Flujo(parallel, context_model=Ctx)
     with pytest.raises(ValueError) as exc:
         await gather_result(
@@ -214,9 +183,7 @@ async def test_merge_strategy_callable() -> None:
     }
     parallel = Step.parallel("par", branches, merge_strategy=custom_merge)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert sorted(result.final_pipeline_context.scratchpad["vals"]) == [1, 2]
 
 
@@ -224,17 +191,11 @@ async def test_merge_strategy_callable() -> None:
 async def test_branch_failure_propagate() -> None:
     branches = {
         "ok": Step.model_validate({"name": "ok", "agent": ScratchAgent("a", 1)}),
-        "bad": Step.model_validate(
-            {"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}
-        ),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
     }
-    parallel = Step.parallel(
-        "par", branches, on_branch_failure=BranchFailureStrategy.PROPAGATE
-    )
+    parallel = Step.parallel("par", branches, on_branch_failure=BranchFailureStrategy.PROPAGATE)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     assert not result.step_history[-1].success
     assert isinstance(result.step_history[-1].output["bad"], StepResult)
 
@@ -243,17 +204,11 @@ async def test_branch_failure_propagate() -> None:
 async def test_branch_failure_ignore() -> None:
     branches = {
         "ok": Step.model_validate({"name": "ok", "agent": ScratchAgent("a", 1)}),
-        "bad": Step.model_validate(
-            {"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}
-        ),
+        "bad": Step.model_validate({"name": "bad", "agent": ScratchAgent("b", 2, fail=True)}),
     }
-    parallel = Step.parallel(
-        "par", branches, on_branch_failure=BranchFailureStrategy.IGNORE
-    )
+    parallel = Step.parallel("par", branches, on_branch_failure=BranchFailureStrategy.IGNORE)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     step_result = result.step_history[-1]
     assert step_result.success
     assert isinstance(step_result.output["bad"], StepResult)
@@ -262,20 +217,12 @@ async def test_branch_failure_ignore() -> None:
 @pytest.mark.asyncio
 async def test_branch_failure_ignore_all_fail() -> None:
     branches = {
-        "a": Step.model_validate(
-            {"name": "a", "agent": ScratchAgent("x", 1, fail=True)}
-        ),
-        "b": Step.model_validate(
-            {"name": "b", "agent": ScratchAgent("y", 2, fail=True)}
-        ),
+        "a": Step.model_validate({"name": "a", "agent": ScratchAgent("x", 1, fail=True)}),
+        "b": Step.model_validate({"name": "b", "agent": ScratchAgent("y", 2, fail=True)}),
     }
-    parallel = Step.parallel(
-        "par", branches, on_branch_failure=BranchFailureStrategy.IGNORE
-    )
+    parallel = Step.parallel("par", branches, on_branch_failure=BranchFailureStrategy.IGNORE)
     runner = Flujo(parallel, context_model=Ctx)
-    result = await gather_result(
-        runner, "data", initial_context_data={"initial_prompt": "goal"}
-    )
+    result = await gather_result(runner, "data", initial_context_data={"initial_prompt": "goal"})
     step_result = result.step_history[-1]
     assert not step_result.success
     assert all(isinstance(step_result.output[name], StepResult) for name in branches)


### PR DESCRIPTION
## Summary
- replace Makefile with uv-based tasks for install, lint, typecheck and tests
- add GitHub Actions workflow using uv and multi-version testing
- run `ruff format` to fix lint failures in step_logic and tests
- ignore `uv.lock`
- guard coverage combining in CI

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make sync`


------
https://chatgpt.com/codex/tasks/task_e_686d699b557c832c8f7c62a14c86fe4a