### PR TITLE
Modernize recipes, update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Maintains test isolation and reliability
 - **Pydantic-AI Compatibility:** Fixed a `TypeError` by updating how generation parameters like `temperature` are passed to the underlying `pydantic-ai` agent, ensuring compatibility with `pydantic-ai>=0.4.1`.
 - **Dependencies:** Updated `pyproject.toml` to require `pydantic-ai>=0.4.1`.
+- **Deprecated Recipes:** Marked `AgenticLoop` and `Default` classes as deprecated. Use the factory functions in `flujo.recipes.factories`.
 
 ## [0.6.0] - 2025-01-15
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ provides utilities to manage multi-agent pipelines with minimal setup.
 ## Features
 
 - 📦 **Pydantic Native** – agents, tools, and pipeline context are all defined with Pydantic models for reliable type safety.
-- 🔁 **Opinionated & Flexible** – the `Default` recipe gives you a ready‑made workflow while the DSL lets you build any pipeline.
+- 🔁 **Opinionated & Flexible** – factory functions like `make_default_pipeline()` provide ready‑made workflows while the DSL lets you build any pipeline.
 - 🏗️ **Production Ready** – retries, telemetry, and quality controls help you ship reliable systems.
 - 🗄️ **Optimized State Backend** – high-performance SQLite backend with indexing and admin queries for large-scale deployments.
 - 🧠 **Intelligent Evals** – automated scoring and self‑improvement powered by LLMs.
@@ -129,7 +129,7 @@ Check out the [examples directory](examples/) for more usage examples:
 
 | Script | What it shows |
 | ------ | ------------- |
-| [**00_quickstart.py**](examples/00_quickstart.py) | Hello World with the AgenticLoop recipe. |
+| [**00_quickstart.py**](examples/00_quickstart.py) | Hello World with the AgenticLoop factory. |
 | [**01_weighted_scoring.py**](examples/01_weighted_scoring.py) | Weighted scoring to prioritize docstrings. |
 | [**02_custom_agents.py**](examples/02_custom_agents.py) | Building creative agents with custom prompts. |
 | [**03_reward_scorer.py**](examples/03_reward_scorer.py) | Using an LLM judge via RewardScorer. |

--- a/docs/agent_infrastructure.md
+++ b/docs/agent_infrastructure.md
@@ -138,11 +138,11 @@ result = runner.run("Write a Python function to calculate fibonacci numbers")
 ### Recipe Creation
 
 ```python
-from flujo.recipes import Default
+from flujo.recipes.factories import make_default_pipeline
 from flujo.infra.agents import make_review_agent, make_solution_agent, make_validator_agent
 
-# Create a recipe with factory functions
-recipe = Default(
+# Create a pipeline using the factory functions
+pipeline = make_default_pipeline(
     review_agent=make_review_agent(),
     solution_agent=make_solution_agent(),
     validator_agent=make_validator_agent(),

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -12,16 +12,16 @@ provide for these roles. For custom pipelines with different logic, see
 `Flujo` and the `Step` DSL.
 
 ```python
-from flujo.recipes import Default
+from flujo.recipes.factories import make_default_pipeline
 
-orchestrator = Default(
-    review_agent: AsyncAgentProtocol[Any, Checklist],
-    solution_agent: AsyncAgentProtocol[Any, str],
-    validator_agent: AsyncAgentProtocol[Any, Checklist],
-    reflection_agent: Optional[AsyncAgentProtocol[Any, str]] = None,
-    max_iters: Optional[int] = None,
-    k_variants: Optional[int] = None,
-    reflection_limit: Optional[int] = None,
+pipeline = make_default_pipeline(
+    review_agent=review_agent,
+    solution_agent=solution_agent,
+    validator_agent=validator_agent,
+    reflection_agent=reflection_agent,
+    max_iters=max_iters,
+    k_variants=k_variants,
+    reflection_limit=reflection_limit,
 )
 ```
 

--- a/docs/guides/choosing_your_loop.md
+++ b/docs/guides/choosing_your_loop.md
@@ -38,8 +38,13 @@ This pattern is great for research or data gathering tasks where the exact steps
 aren't known ahead of time.
 
 ```python
-agentic_loop = AgenticLoop(planner_agent=planner, agent_registry={"tool": tool})
-result = agentic_loop.run("Find information about Python")
+from flujo.recipes.factories import make_agentic_loop_pipeline, run_agentic_loop_pipeline
+
+pipeline = make_agentic_loop_pipeline(
+    planner_agent=planner,
+    agent_registry={"tool": tool},
+)
+result = run_agentic_loop_pipeline(pipeline, "Find information about Python")
 ```
 
 The loop continues until the planner issues a `FinishCommand`. Every command is
@@ -70,7 +75,9 @@ loop_step = Step.loop_until(
 ### After: `AgenticLoop.as_step()`
 
 ```python
-loop = AgenticLoop(
+from flujo.recipes.factories import make_agentic_loop_pipeline
+
+loop = make_agentic_loop_pipeline(
     planner_agent=planner_agent,
     agent_registry={"execute": execute_command},
 ).as_step(name="ExplorationLoop")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,7 +113,7 @@ import flujo
 print(f"Version: {flujo.__version__}")
 
 # Test basic import
-from flujo.recipes import Default
+from flujo.recipes.factories import make_default_pipeline
 from flujo import Task
 print("✅ Installation successful!")
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,13 +109,16 @@ This guide helps you resolve common issues when using `flujo`.
 
 2. Verify model configuration:
    ```python
-   from flujo.recipes import Default
+   from flujo.recipes.factories import make_default_pipeline
 
-   orchestrator = Default(
+   pipeline = make_default_pipeline(
+       review_agent=review_agent,
+       solution_agent=solution_agent,
+       validator_agent=validator_agent,
        model="openai:gpt-4",
-       temperature=0.7
+       temperature=0.7,
    )
-   print(orchestrator.model_config)
+   print(pipeline)
    ```
 
 ## Runtime Issues
@@ -209,11 +212,16 @@ This guide helps you resolve common issues when using `flujo`.
 
 3. Optimize configuration:
    ```python
-   orchestrator = Default(
+   from flujo.recipes.factories import make_default_pipeline
+
+   pipeline = make_default_pipeline(
+       review_agent=review_agent,
+       solution_agent=solution_agent,
+       validator_agent=validator_agent,
        model="openai:gpt-4",
        max_tokens=1000,  # Limit token usage
        timeout=30,       # Set reasonable timeout
-       cache=True        # Enable caching
+       cache=True,       # Enable caching
    )
    ```
 

--- a/flujo/application/self_improvement.py
+++ b/flujo/application/self_improvement.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import json
-from typing import Any, Callable, Awaitable, Iterable, Optional, cast
+from typing import Any, Callable, Awaitable, Iterable, Optional
 
 from pydantic_evals.reporting import EvaluationReport, ReportCase
 
@@ -26,12 +25,10 @@ class SelfImprovementAgent:
         self._agent = agent
 
     async def run(self, prompt: str) -> ImprovementReport:
-        raw = await self._agent.run(prompt)
-        if isinstance(raw, (dict, list)):
-            data = json.dumps(raw)
-        else:
-            data = str(raw)
-        return cast(ImprovementReport, ImprovementReport.model_validate_json(data))
+        result = await self._agent.run(prompt)
+        if isinstance(result, ImprovementReport):
+            return result
+        return ImprovementReport.model_validate(result)
 
 
 def _find_step(

--- a/flujo/infra/agents.py
+++ b/flujo/infra/agents.py
@@ -19,7 +19,7 @@ import warnings
 from tenacity import AsyncRetrying, RetryError, stop_after_attempt, wait_exponential
 
 from flujo.infra.settings import settings
-from flujo.domain.models import Checklist
+from flujo.domain.models import Checklist, ImprovementReport
 from flujo.domain.processors import AgentProcessors
 from flujo.domain.agent_protocol import (
     AsyncAgentProtocol,
@@ -356,10 +356,10 @@ def get_reflection_agent(
 
 def make_self_improvement_agent(
     model: str | None = None,
-) -> AsyncAgentWrapper[Any, str]:
+) -> AsyncAgentWrapper[Any, ImprovementReport]:
     """Create the SelfImprovementAgent."""
     model_name = model or settings.default_self_improvement_model
-    return make_agent_async(model_name, SELF_IMPROVE_SYS, str)
+    return make_agent_async(model_name, SELF_IMPROVE_SYS, ImprovementReport)
 
 
 def make_repair_agent(model: str | None = None) -> AsyncAgentWrapper[Any, str]:

--- a/flujo/recipes/default.py
+++ b/flujo/recipes/default.py
@@ -52,7 +52,7 @@ class Default:
         warnings.warn(
             "The Default class is deprecated. Use make_default_pipeline() and run_default_pipeline() "
             "from flujo.recipes.factories for better transparency, composability, and future YAML/AI support.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
         _ = max_iters, k_variants, reflection_limit

--- a/tests/integration/test_agentic_loop_recipe.py
+++ b/tests/integration/test_agentic_loop_recipe.py
@@ -11,6 +11,11 @@ from flujo.testing.utils import StubAgent
 from flujo.domain.models import PipelineContext
 
 
+def test_agentic_loop_emits_deprecation_warning() -> None:
+    with pytest.warns(DeprecationWarning):
+        AgenticLoop(StubAgent([]), {})
+
+
 @pytest.mark.asyncio
 async def test_agent_delegation_and_finish() -> None:
     planner = StubAgent(

--- a/tests/integration/test_self_improvement.py
+++ b/tests/integration/test_self_improvement.py
@@ -1,10 +1,10 @@
-import json
 import functools
 import pytest
 from flujo.application.self_improvement import (
     evaluate_and_improve,
     SelfImprovementAgent,
 )
+from flujo.domain.models import ImprovementReport, ImprovementSuggestion
 from flujo.application.runner import Flujo
 from flujo.application.eval_adapter import run_pipeline_async
 from flujo.domain import Step
@@ -13,20 +13,18 @@ from pydantic_evals import Dataset, Case
 
 
 class DummyAgent:
-    async def run(self, prompt: str) -> str:
-        return json.dumps(
-            {
-                "suggestions": [
-                    {
-                        "target_step_name": "solution",
-                        "suggestion_type": "prompt_modification",
-                        "failure_pattern_summary": "error",
-                        "detailed_explanation": "fix it",
-                        "prompt_modification_details": {"modification_instruction": "fix"},
-                        "example_failing_input_snippets": ["c1"],
-                    }
-                ]
-            }
+    async def run(self, prompt: str) -> ImprovementReport:
+        return ImprovementReport(
+            suggestions=[
+                ImprovementSuggestion(
+                    target_step_name="solution",
+                    suggestion_type="prompt_modification",
+                    failure_pattern_summary="error",
+                    detailed_explanation="fix it",
+                    prompt_modification_details={"modification_instruction": "fix"},
+                    example_failing_input_snippets=["c1"],
+                )
+            ]
         )
 
 
@@ -62,9 +60,9 @@ async def test_self_improvement_context_includes_config_and_prompts(monkeypatch)
     captured: dict[str, str] = {}
 
     class CaptureAgent:
-        async def run(self, prompt: str) -> str:
+        async def run(self, prompt: str) -> ImprovementReport:
             captured["prompt"] = prompt
-            return json.dumps({"suggestions": []})
+            return ImprovementReport(suggestions=[])
 
     agent = StubAgent(["ok"])
     agent.system_prompt = "Test prompt"

--- a/tests/unit/test_self_improvement_agent.py
+++ b/tests/unit/test_self_improvement_agent.py
@@ -1,12 +1,11 @@
-import json
 import pytest
 from flujo.infra.agents import SELF_IMPROVE_SYS
 from flujo.application.self_improvement import SelfImprovementAgent, ImprovementReport
 
 
 class DummyAgent:
-    async def run(self, prompt: str) -> str:
-        return json.dumps({"suggestions": []})
+    async def run(self, prompt: str) -> ImprovementReport:
+        return ImprovementReport(suggestions=[])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deprecate class-based Default recipe with proper warning
- update factory documentation and quickstart
- rely on pydantic output for self-improvement agents
- adjust integration tests for deprecation warning
- update CHANGELOG for v0.6.1

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make testcov`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_687012b2b014832c952391f4e50f3e30