### PR TITLE
Add agent decorators for validation and monitoring

### DIFF
--- a/docs/building_resilient_agents.md
+++ b/docs/building_resilient_agents.md
@@ -1,0 +1,59 @@
+# Building Resilient Agents
+
+Flujo provides decorators that make it simple to add validation and monitoring to your agents.
+These helpers are not only for complex workflows with fallbacks. **Every** agent
+benefits from validated inputs/outputs and visibility into its execution. By
+standardizing these concerns at the framework level you get data integrity and
+performance insights without extra boilerplate.
+
+## Validating Inputs and Outputs
+
+Use `@validated_agent` to ensure your agent's `run` method receives and returns data that matches your Pydantic models.
+
+```python
+from pydantic import BaseModel
+from flujo.agents import validated_agent
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+
+class InputModel(BaseModel):
+    value: int
+
+class OutputModel(BaseModel):
+    doubled: int
+
+@validated_agent(InputModel, OutputModel)
+class MyAgent(AsyncAgentProtocol[InputModel, OutputModel]):
+    async def run(self, data: InputModel, **kwargs) -> OutputModel:
+        return OutputModel(doubled=data.value * 2)
+```
+
+Passing invalid data will raise `AgentIOValidationError`.
+
+## Monitoring Agent Calls
+
+`@monitored_agent` records execution metrics using the global monitor instance.
+
+```python
+from flujo.agents import monitored_agent
+from flujo.monitor import global_monitor
+
+@monitored_agent("my_agent")
+class MyMonitoredAgent(AsyncAgentProtocol[str, str]):
+    async def run(self, data: str, **kwargs) -> str:
+        return data.upper()
+
+# After running
+# global_monitor.calls contains details of each invocation
+```
+
+## Combining Decorators
+
+Decorators are composable. Apply `@monitored_agent` on top so monitoring captures validation failures.
+
+```python
+@monitored_agent("combo")
+@validated_agent(InputModel, OutputModel)
+class CombinedAgent(AsyncAgentProtocol[InputModel, OutputModel]):
+    async def run(self, data: InputModel, **kwargs) -> OutputModel:
+        return OutputModel(doubled=data.value * 2)
+```

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -32,6 +32,8 @@ from .domain.models import Task, Candidate
 from .infra.agents import make_agent_async
 from .infra.settings import settings
 from .infra.telemetry import init_telemetry
+from .agents import validated_agent, monitored_agent
+from .monitor import global_monitor, FlujoMonitor, FailureType
 
 # 3. Define __all__ to control `from flujo import *` behavior and document the public API.
 __all__ = [
@@ -44,6 +46,11 @@ __all__ = [
     "Task",
     "Candidate",
     "make_agent_async",
+    "validated_agent",
+    "monitored_agent",
+    "global_monitor",
+    "FlujoMonitor",
+    "FailureType",
     # Global Singletons & Initializers
     "settings",
     "init_telemetry",

--- a/flujo/agents/__init__.py
+++ b/flujo/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agent utilities including validation and monitoring decorators."""
+
+from .validation import validated_agent
+from .monitoring import monitored_agent
+
+__all__ = ["validated_agent", "monitored_agent"]

--- a/flujo/agents/monitoring.py
+++ b/flujo/agents/monitoring.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import Any, Callable, Type, Any as _Any
+
+from ..exceptions import AgentIOValidationError
+from ..monitor import FailureType, global_monitor
+
+
+def monitored_agent(agent_name: str) -> Callable[[Type[_Any]], Type[_Any]]:
+    """Class decorator that records telemetry for the agent's ``run`` method."""
+
+    def decorator(agent_class: Type[_Any]) -> Type[_Any]:
+        original_run = agent_class.run
+
+        @wraps(original_run)
+        async def monitored_run(self: _Any, data: Any, **kwargs: Any) -> Any:
+            start = time.time()
+            exception = None
+            result = None
+            try:
+                result = await original_run(self, data, **kwargs)
+                return result
+            except Exception as e:  # pragma: no cover - passthrough
+                exception = e
+                raise
+            finally:
+                duration_ms = (time.time() - start) * 1000
+                success = exception is None
+                failure_type = None
+                if isinstance(exception, AgentIOValidationError):
+                    failure_type = FailureType.VALIDATION_ERROR
+                elif exception is not None:
+                    failure_type = FailureType.EXECUTION_ERROR
+                global_monitor.record_agent_call(
+                    agent_name=agent_name,
+                    success=success,
+                    execution_time_ms=duration_ms,
+                    input_data=data,
+                    output_data=result if success else None,
+                    failure_type=failure_type,
+                    error_message=str(exception) if exception else None,
+                    exception=exception,
+                )
+
+        agent_class.run = monitored_run
+        return agent_class
+
+    return decorator

--- a/flujo/agents/validation.py
+++ b/flujo/agents/validation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Type, Any as _Any
+from pydantic import BaseModel, ValidationError
+
+from ..exceptions import AgentIOValidationError
+
+
+def validated_agent(
+    input_model: Type[BaseModel], output_model: Type[BaseModel]
+) -> Callable[[Type[_Any]], Type[_Any]]:
+    """Class decorator that validates the ``run`` method's input and output."""
+
+    def decorator(agent_class: Type[_Any]) -> Type[_Any]:
+        original_run = agent_class.run
+
+        @wraps(original_run)
+        async def validated_run(self: _Any, data: Any, **kwargs: Any) -> Any:
+            try:
+                validated_input = input_model.model_validate(data)
+            except ValidationError as e:
+                raise AgentIOValidationError(
+                    f"Input validation failed for {agent_class.__name__}"
+                ) from e
+
+            raw_output = await original_run(self, validated_input, **kwargs)
+
+            try:
+                return output_model.model_validate(raw_output)
+            except ValidationError as e:
+                raise AgentIOValidationError(
+                    f"Output validation failed for {agent_class.__name__}"
+                ) from e
+
+        agent_class.run = validated_run
+        return agent_class
+
+    return decorator

--- a/flujo/exceptions.py
+++ b/flujo/exceptions.py
@@ -116,3 +116,9 @@ class TypeMismatchError(ConfigurationError):
     """Raised when consecutive steps have incompatible types."""
 
     pass
+
+
+class AgentIOValidationError(OrchestratorError):
+    """Raised when an agent's input or output validation fails."""
+
+    pass

--- a/flujo/monitor.py
+++ b/flujo/monitor.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class FailureType(Enum):
+    VALIDATION_ERROR = "validation_error"
+    EXECUTION_ERROR = "execution_error"
+
+
+class FlujoMonitor:
+    """Simple in-memory monitor for agent calls."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def record_agent_call(
+        self,
+        *,
+        agent_name: str,
+        success: bool,
+        execution_time_ms: float,
+        input_data: Any,
+        output_data: Any = None,
+        failure_type: FailureType | None = None,
+        error_message: str | None = None,
+        exception: Exception | None = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "agent_name": agent_name,
+                "success": success,
+                "execution_time_ms": execution_time_ms,
+                "input_data": input_data,
+                "output_data": output_data,
+                "failure_type": failure_type,
+                "error_message": error_message,
+                "exception": exception,
+            }
+        )
+
+
+global_monitor = FlujoMonitor()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - 'Agentic Patterns': 'user_guide/agentic-patterns.md'
     - 'Testing Your Pipelines': 'user_guide/testing.md'
   - 'Agent Infrastructure': 'agent_infrastructure.md'
+  - 'Building Resilient Agents': 'building_resilient_agents.md'
   - 'Examples':
     - 'Basic Pipeline': 'examples/basic-pipeline.md'
   - 'API Reference':

--- a/tests/unit/test_agent_decorators.py
+++ b/tests/unit/test_agent_decorators.py
@@ -1,0 +1,78 @@
+import pytest
+from pydantic import BaseModel
+
+from flujo.agents import validated_agent, monitored_agent
+from flujo.domain.agent_protocol import AsyncAgentProtocol
+from flujo.monitor import global_monitor, FailureType
+from flujo.exceptions import AgentIOValidationError
+
+
+class InModel(BaseModel):
+    value: int
+
+
+class OutModel(BaseModel):
+    doubled: int
+
+
+@validated_agent(InModel, OutModel)
+class SimpleAgent(AsyncAgentProtocol[InModel, OutModel]):
+    async def run(self, data: InModel, **kwargs) -> OutModel:
+        return OutModel(doubled=data.value * 2)
+
+
+@monitored_agent("mon_agent")
+class MonitoredAgent(AsyncAgentProtocol[str, str]):
+    async def run(self, data: str, **kwargs) -> str:
+        return data.upper()
+
+
+@monitored_agent("combo")
+@validated_agent(InModel, OutModel)
+class ComboAgent(AsyncAgentProtocol[InModel, OutModel]):
+    async def run(self, data: InModel, **kwargs) -> OutModel:
+        return OutModel(doubled=data.value * 2)
+
+
+@pytest.mark.asyncio
+async def test_validated_agent_raises() -> None:
+    agent = SimpleAgent()
+    with pytest.raises(AgentIOValidationError):
+        await agent.run({"value": "oops"})
+
+
+@pytest.mark.asyncio
+async def test_monitored_agent_records() -> None:
+    global_monitor.calls.clear()
+    agent = MonitoredAgent()
+    result = await agent.run("hi")
+    assert result == "HI"
+    assert len(global_monitor.calls) == 1
+    rec = global_monitor.calls[0]
+    assert rec["agent_name"] == "mon_agent"
+    assert rec["success"] is True
+    assert rec["output_data"] == "HI"
+
+
+@pytest.mark.asyncio
+async def test_decorator_composition_success() -> None:
+    global_monitor.calls.clear()
+    agent = ComboAgent()
+    result = await agent.run({"value": 3})
+    assert result.doubled == 6
+    assert len(global_monitor.calls) == 1
+    rec = global_monitor.calls[0]
+    assert rec["success"] is True
+    assert rec["failure_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_decorator_composition_validation_error() -> None:
+    global_monitor.calls.clear()
+    agent = ComboAgent()
+    with pytest.raises(AgentIOValidationError):
+        await agent.run({"value": "bad"})
+    assert len(global_monitor.calls) == 1
+    rec = global_monitor.calls[0]
+    assert rec["success"] is False
+    assert rec["failure_type"] == FailureType.VALIDATION_ERROR


### PR DESCRIPTION
## Summary
- introduce `validated_agent` and `monitored_agent` decorators
- record agent telemetry via a simple `FlujoMonitor`
- expose new helpers from the package
- document usage in *Building Resilient Agents*
- add unit tests
- clarify docs about applying decorators to all agents

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_68706ae41070832cbac86af2d3253350