### PR TITLE
Add retries and fallback params to step creation

### DIFF
--- a/docs/cookbook/error_recovery.md
+++ b/docs/cookbook/error_recovery.md
@@ -6,15 +6,19 @@ LLM calls occasionally fail or produce unusable results. You want the pipeline t
 
 ## The Solution
 
-Use `Step.fallback()` to declare a backup step that runs when the primary step fails after its retries are exhausted.
+Declare a backup step with the `fallback` argument so it runs when the primary step fails after its retries are exhausted.
 
 ```python
-from flujo import Step, Flujo
+from flujo import step, Flujo
 from flujo.testing.utils import StubAgent
 
-primary = Step("primary", StubAgent(["fail"]), max_retries=1)
-backup = Step("backup", StubAgent(["ok"]))
-primary.fallback(backup)
+@step
+async def backup(x: str) -> str:
+    return "ok"
+
+@step(retries=1, fallback=backup)
+async def primary(x: str) -> str:
+    return "fail"
 
 runner = Flujo(primary)
 result = runner.run("data")

--- a/docs/cookbook/resilience_and_performance.md
+++ b/docs/cookbook/resilience_and_performance.md
@@ -26,16 +26,20 @@ that steps with the same name but different behaviors do not collide.
 
 ## Building Resilient Pipelines with Fallbacks
 
-The `Step.fallback()` method lets you declare a backup step that runs if the primary step fails.
+Declare a backup step right in the decorator so it runs if the primary step fails.
 This is useful for handling transient errors or providing a simpler model when a complex one is unreliable.
 
 ```python
-from flujo import Step, Flujo
+from flujo import step, Flujo
 from flujo.testing.utils import StubAgent
 
-primary = Step("primary", StubAgent(["fail"]), max_retries=1)
-backup = Step("backup", StubAgent(["ok"]))
-primary.fallback(backup)
+@step
+async def backup(x: str) -> str:
+    return "ok"
+
+@step(retries=1, fallback=backup)
+async def primary(x: str) -> str:
+    return "fail"
 
 runner = Flujo(primary)
 result = runner.run("data")

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -407,12 +407,11 @@ pipeline = (
 
 ```python
 # Configure retries at the step level
-step = Step.solution(
-    solution_agent,
-    retries=3,
-    backoff_factor=2,
-    retry_on_error=True
-)
+@step(retries=3)
+async def solve(x: str) -> str:
+    ...  # your logic here
+
+step = solve
 
 # Configure retries at the pipeline level
 runner = Flujo(
@@ -562,16 +561,19 @@ Steps can be configured with various options:
 
 ### Fallback Steps
 
-Use `.fallback(other_step)` to specify an alternate step to run if the primary
-step fails after exhausting its retries. The fallback receives the same input as
-the original step.
+Specify a fallback step directly when defining the primary step. The fallback
+receives the same input as the original step.
 
 ```python
-from flujo import Step
+from flujo import step, Step
 
-primary = Step("generate", primary_agent, max_retries=2)
-backup = Step("backup", backup_agent)
-primary.fallback(backup)
+@step
+async def backup(x: str) -> str:
+    ...
+
+@step(retries=2, fallback=backup)
+async def generate(x: str) -> str:
+    ...
 ```
 
 If the fallback succeeds, the overall step is marked successful and

--- a/tests/integration/test_declarative_retry_fallback.py
+++ b/tests/integration/test_declarative_retry_fallback.py
@@ -1,0 +1,27 @@
+import pytest
+from flujo.domain import Step, step
+from flujo.testing.utils import DummyPlugin, gather_result
+from flujo.application.runner import Flujo
+from flujo.domain.plugins import PluginOutcome
+
+@pytest.mark.asyncio
+async def test_decorator_retries_and_fallback_executes() -> None:
+    async def fb(x: str) -> str:
+        return "ok"
+
+    fallback_step = Step.from_callable(fb, name="fb")
+
+    @step(retries=3, fallback=fallback_step)
+    async def primary(x: str) -> str:
+        return "bad"
+
+    plugin = DummyPlugin([PluginOutcome(success=False, feedback="err")] * 3)
+    primary.plugins.append((plugin, 0))
+
+    runner = Flujo(primary)
+    result = await gather_result(runner, "data")
+    sr = result.step_history[0]
+    assert sr.success is True
+    assert sr.output == "ok"
+    assert sr.metadata_["fallback_triggered"] is True
+    assert plugin.call_count == 3

--- a/tests/unit/test_step_retries_fallback.py
+++ b/tests/unit/test_step_retries_fallback.py
@@ -1,0 +1,21 @@
+import pytest
+from flujo.domain import Step, step
+from flujo.testing.utils import StubAgent, DummyPlugin, gather_result
+from flujo.domain.plugins import PluginOutcome
+
+@pytest.mark.asyncio
+async def test_step_decorator_retries_sets_config() -> None:
+    @step(retries=3)
+    async def do(x: int) -> int:
+        return x
+
+    assert do.config.max_retries == 3
+
+@pytest.mark.asyncio
+async def test_step_from_callable_fallback_argument() -> None:
+    async def primary(x: str) -> str:
+        return x
+
+    fb = Step.from_callable(lambda x: "fb")
+    step_instance = Step.from_callable(primary, fallback=fb)
+    assert step_instance.fallback_step is fb


### PR DESCRIPTION
## Summary
- add `retries` and `fallback` parameters to `Step.from_callable` and decorator
- expose the new parameters in adapter step and from_mapper
- update docs for new API
- test new behavior with unit and integration tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6870799dbc68832c83f0a3485a45842a