### PR TITLE
Fix dynamic router execution

### DIFF
--- a/docs/cookbook/dynamic_parallel_router.md
+++ b/docs/cookbook/dynamic_parallel_router.md
@@ -1,0 +1,34 @@
+# Cookbook: Dynamic Parallel Router
+
+Use a **Dynamic Parallel Router** when a router agent decides at runtime which branches to execute concurrently. This pattern is useful for multi-step assistants that delegate to specialized sub-pipelines based on user intent.
+
+```python
+from flujo import Flujo, Step
+from flujo.domain import MergeStrategy, PipelineContext
+
+class Ctx(PipelineContext):
+    task: str
+
+async def router_agent(data: str, *, context: Ctx | None = None) -> list[str]:
+    if "billing" in data.lower():
+        return ["billing"]
+    if "support" in data.lower():
+        return ["support"]
+    return ["billing", "support"]
+
+billing = Step.from_mapper(lambda x: f"billing:{x}")
+support = Step.from_mapper(lambda x: f"support:{x}")
+
+router = Step.dynamic_parallel_branch(
+    name="router",
+    router_agent=router_agent,
+    branches={"billing": billing, "support": support},
+    merge_strategy=MergeStrategy.MERGE_SCRATCHPAD,
+)
+
+runner = Flujo(router, context_model=Ctx)
+result = runner.run("Need billing info")
+print(result.step_history[-1].metadata_["executed_branches"])  # ['billing']
+```
+
+The step runs only the branches returned by `router_agent` and merges their outputs using the same semantics as `Step.parallel`.

--- a/docs/pipeline_branching.md
+++ b/docs/pipeline_branching.md
@@ -55,3 +55,17 @@ Running the pipeline will execute either the `process_numbers` or `process_text`
 
 See [pipeline_dsl.md](pipeline_dsl.md) for an overview of the DSL. A runnable example can be found in [this script on GitHub](https://github.com/aandresalvarez/flujo/blob/main/examples/08_branch_step.py).
 
+
+## Dynamic Parallel Router
+
+`DynamicParallelRouterStep` extends branching by letting an agent decide which branches to execute in parallel at runtime. The router agent returns a list of branch names, and only those branches run.
+
+```python
+router = Step.dynamic_parallel_branch(
+    name="router",
+    router_agent=my_router_agent,
+    branches={"billing": billing_pipe, "support": support_pipe},
+)
+```
+
+The executed branch names are stored in `StepResult.metadata_["executed_branches"]`.

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -722,6 +722,20 @@ This feature is particularly beneficial when:
 - You want to minimize wasted resources when limits are exceeded
 - You need predictable execution times under resource constraints
 
+### Dynamic Parallel Router
+
+Use `Step.dynamic_parallel_branch()` when an agent selects which parallel branches to run at runtime. The router agent returns a list of branch names.
+
+```python
+router = Step.dynamic_parallel_branch(
+    name="router",
+    router_agent=my_router_agent,
+    branches={"billing": billing_pipe, "support": support_pipe},
+)
+```
+
+The step behaves like `Step.parallel` and records executed branches in `StepResult.metadata_["executed_branches"]`.
+
 ## Loop Steps
 
 Loop steps execute a pipeline repeatedly until a condition is met.

--- a/flujo/application/core/step_logic.py
+++ b/flujo/application/core/step_logic.py
@@ -18,6 +18,7 @@ from ...domain.dsl.step import (
     BranchKey,
     HumanInTheLoopStep,
 )
+from ...domain.dsl.dynamic_router import DynamicParallelRouterStep
 from ...domain.models import (
     BaseModel,
     PipelineResult,
@@ -56,6 +57,7 @@ __all__ = [
     "_execute_parallel_step_logic",
     "_execute_loop_step_logic",
     "_execute_conditional_step_logic",
+    "_execute_dynamic_router_step_logic",
     "_run_step_logic",
 ]
 
@@ -654,6 +656,91 @@ async def _execute_conditional_step_logic(
     return conditional_overall_result
 
 
+async def _execute_dynamic_router_step_logic(
+    router_step: DynamicParallelRouterStep[TContext],
+    router_input: Any,
+    context: Optional[TContext],
+    resources: Optional[AppResources],
+    *,
+    step_executor: StepExecutor[TContext],
+    context_model_defined: bool,
+    usage_limits: UsageLimits | None = None,
+    context_setter: Callable[[PipelineResult[TContext], Optional[TContext]], None],
+) -> StepResult:
+    """Run router agent then execute selected branches in parallel."""
+
+    result = StepResult(name=router_step.name)
+    try:
+        from ...signature_tools import analyze_signature
+
+        func = getattr(router_step.router_agent, "run", router_step.router_agent)
+        spec = analyze_signature(func)
+
+        router_kwargs: Dict[str, Any] = {}
+        if spec.needs_context:
+            if context is None:
+                raise TypeError(
+                    "Router agent requires a context but none was provided to the runner."
+                )
+            router_kwargs["context"] = context
+        elif _accepts_param(func, "context") and context is not None:
+            router_kwargs["context"] = context
+
+        if resources is not None:
+            if spec.needs_resources:
+                router_kwargs["resources"] = resources
+            elif _accepts_param(func, "resources"):
+                router_kwargs["resources"] = resources
+
+        raw = await func(router_input, **router_kwargs)
+        branch_keys = getattr(raw, "output", raw)
+    except Exception as e:  # pragma: no cover - defensive
+        telemetry.logfire.error(f"Router agent error in '{router_step.name}': {e}")
+        result.success = False
+        result.feedback = f"Router agent error: {e}"
+        return result
+
+    if not isinstance(branch_keys, list):
+        branch_keys = [branch_keys]
+
+    selected: Dict[str, Step[Any, Any] | Pipeline[Any, Any]] = {
+        k: v for k, v in router_step.branches.items() if k in branch_keys
+    }
+    if not selected:
+        result.success = True
+        result.output = {}
+        result.attempts = 1
+        result.metadata_ = {"executed_branches": []}
+        return result
+
+    config_kwargs = router_step.config.model_dump()
+
+    parallel_step = Step.parallel(
+        name=f"{router_step.name}_parallel",
+        branches=selected,
+        context_include_keys=router_step.context_include_keys,
+        merge_strategy=router_step.merge_strategy,
+        on_branch_failure=router_step.on_branch_failure,
+        **config_kwargs,
+    )
+
+    parallel_result = await _execute_parallel_step_logic(
+        parallel_step,
+        router_input,
+        context,
+        resources,
+        step_executor=step_executor,
+        context_model_defined=context_model_defined,
+        usage_limits=usage_limits,
+        context_setter=context_setter,
+    )
+
+    parallel_result.name = router_step.name
+    parallel_result.metadata_ = parallel_result.metadata_ or {}
+    parallel_result.metadata_["executed_branches"] = list(selected.keys())
+    return parallel_result
+
+
 async def _run_step_logic(
     step: Step[Any, Any],
     data: Any,
@@ -715,6 +802,17 @@ async def _run_step_logic(
             step_executor=step_executor,
             context_model_defined=context_model_defined,
             usage_limits=usage_limits,
+        )
+    if isinstance(step, DynamicParallelRouterStep):
+        return await _execute_dynamic_router_step_logic(
+            step,
+            data,
+            context,
+            resources,
+            step_executor=step_executor,
+            context_model_defined=context_model_defined,
+            usage_limits=usage_limits,
+            context_setter=context_setter,
         )
     if isinstance(step, ParallelStep):
         return await _execute_parallel_step_logic(

--- a/flujo/domain/dsl/__init__.py
+++ b/flujo/domain/dsl/__init__.py
@@ -72,4 +72,9 @@ def __getattr__(name: str) -> Any:
 
         globals()[name] = HumanInTheLoopStep
         return HumanInTheLoopStep
+    if name == "DynamicParallelRouterStep":
+        from .dynamic_router import DynamicParallelRouterStep
+
+        globals()[name] = DynamicParallelRouterStep
+        return DynamicParallelRouterStep
     raise AttributeError(f"module 'flujo.domain.dsl' has no attribute '{name}'")

--- a/flujo/domain/dsl/dynamic_router.py
+++ b/flujo/domain/dsl/dynamic_router.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union, Self
+
+from pydantic import Field
+
+from ..models import BaseModel
+from .step import Step, MergeStrategy, BranchFailureStrategy
+from .pipeline import Pipeline
+
+TContext = TypeVar("TContext", bound=BaseModel)
+
+__all__ = ["DynamicParallelRouterStep"]
+
+
+class DynamicParallelRouterStep(Step[Any, Any], Generic[TContext]):
+    """Dynamically execute a subset of branches in parallel.
+
+    ``router_agent`` is invoked first and should return a list of branch
+    names to execute. Only the selected branches are then run in parallel
+    using the same semantics as :class:`ParallelStep`.
+
+    Example
+    -------
+    >>> router_step = Step.dynamic_parallel_branch(
+    ...     name="Router",
+    ...     router_agent=my_router_agent,
+    ...     branches={"Billing": billing_pipe, "Support": support_pipe},
+    ... )
+    """
+
+    router_agent: Any = Field(description="Agent that returns branches to run.")
+    branches: Dict[str, Pipeline[Any, Any]] = Field(
+        description="Mapping of branch names to pipelines."
+    )
+    context_include_keys: Optional[List[str]] = Field(
+        default=None,
+        description="Context keys to include when copying context to branches.",
+    )
+    merge_strategy: Union[MergeStrategy, Callable[[TContext, TContext], None]] = Field(
+        default=MergeStrategy.NO_MERGE,
+        description="Strategy for merging branch contexts back.",
+    )
+    on_branch_failure: BranchFailureStrategy = Field(
+        default=BranchFailureStrategy.PROPAGATE,
+        description="How to handle branch failures.",
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @classmethod
+    def model_validate(cls: type[Self], *args: Any, **kwargs: Any) -> Self:  # noqa: D401
+        if args and isinstance(args[0], dict):
+            branches = args[0].get("branches", {})
+        else:
+            branches = kwargs.get("branches", {})
+        if not branches:
+            raise ValueError("'branches' dictionary cannot be empty.")
+
+        normalized: Dict[str, Pipeline[Any, Any]] = {}
+        for key, branch in branches.items():
+            if isinstance(branch, Step):
+                normalized[key] = Pipeline.from_step(branch)
+            else:
+                normalized[key] = branch
+
+        if args and isinstance(args[0], dict):
+            args = (dict(args[0], branches=normalized),) + args[1:]
+        else:
+            kwargs["branches"] = normalized
+        return super().model_validate(*args, **kwargs)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return (
+            f"DynamicParallelRouterStep(name={self.name!r}, branches={list(self.branches.keys())})"
+        )


### PR DESCRIPTION
## Summary
- improve DynamicParallelRouterStep execution logic
- ensure executed branches metadata is accurate
- guard router_agent parameter injection
- document dynamic router usage in docs
- fix router agent invocation and typing
- ensure context None isn't injected into router agents

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_6871961ef150832c80bb65b31a28e658