### PR TITLE
Implement state machine docs and tests

### DIFF
--- a/docs/cookbook/state_machine_pipeline.md
+++ b/docs/cookbook/state_machine_pipeline.md
@@ -1,0 +1,40 @@
+# Cookbook: State Machine Pipeline
+
+Use the **state machine pipeline factory** to orchestrate a workflow where the next step to run is determined by context fields. The pipeline loops until a completion flag is set.
+
+```python
+from pydantic import BaseModel
+from flujo import Flujo, Step, step
+from flujo.recipes import make_state_machine_pipeline
+from flujo.domain.models import PipelineContext
+
+class Ctx(PipelineContext):
+    next_state: str = "start"
+    is_complete: bool = False
+    counter: int = 0
+
+@step
+async def start(data: str, *, context: Ctx) -> str:
+    context.counter += 1
+    # Transition to "end" after the first iteration
+    context.next_state = "end" if context.counter > 1 else "start"
+    return data
+
+@step
+async def end(data: str, *, context: Ctx) -> str:
+    context.is_complete = True
+    return f"done after {context.counter} loops"
+
+pipeline = make_state_machine_pipeline(
+    nodes={"start": start, "end": end},
+    context_model=Ctx,
+    router_field="next_state",
+    end_state_field="is_complete",
+)
+
+runner = Flujo(pipeline, context_model=Ctx)
+result = runner.run("go")
+print(result.output)
+```
+
+This pattern removes boilerplate by handling the loop and state dispatch for you.

--- a/examples/11_state_machine_pipeline.py
+++ b/examples/11_state_machine_pipeline.py
@@ -1,0 +1,37 @@
+"""Demonstrates the make_state_machine_pipeline factory."""
+
+import asyncio
+
+from flujo import Flujo, step
+from flujo.recipes import make_state_machine_pipeline
+from flujo.domain.models import PipelineContext
+
+class Ctx(PipelineContext):
+    next_state: str = "start"
+    is_complete: bool = False
+    counter: int = 0
+
+@step
+async def start(data: str, *, context: Ctx) -> str:
+    context.counter += 1
+    context.next_state = "end" if context.counter > 1 else "start"
+    return data
+
+@step
+async def end(data: str, *, context: Ctx) -> str:
+    context.is_complete = True
+    return f"completed after {context.counter} loops"
+
+pipeline = make_state_machine_pipeline(
+    nodes={"start": start, "end": end},
+    context_model=Ctx,
+)
+
+runner = Flujo(pipeline, context_model=Ctx)
+
+async def main() -> None:
+    result = await runner.arun("go")
+    print(result.output)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/flujo/recipes/__init__.py
+++ b/flujo/recipes/__init__.py
@@ -17,6 +17,7 @@ DEPRECATED: The class-based recipes are deprecated:
 # New factory functions (recommended)
 from .factories import (
     make_default_pipeline,
+    make_state_machine_pipeline,
     make_agentic_loop_pipeline,
     run_default_pipeline,
     run_agentic_loop_pipeline,
@@ -29,6 +30,7 @@ from .agentic_loop import AgenticLoop
 __all__ = [
     # Factory functions (recommended)
     "make_default_pipeline",
+    "make_state_machine_pipeline",
     "make_agentic_loop_pipeline",
     "run_default_pipeline",
     "run_agentic_loop_pipeline",


### PR DESCRIPTION
## Summary
- document `make_state_machine_pipeline` usage
- add runnable example for the state machine factory
- provide unit tests for the new factory
- small typing fixes for helpers
- fix Step.from_mapper usage in tests
- validate fields in `make_state_machine_pipeline`

## Testing
- `CI=1 make all`


------
https://chatgpt.com/codex/tasks/task_e_687290a903ac832c9f6c153aff48f39b