### PR TITLE
Implement serialization determinism tests

### DIFF
--- a/flujo/steps/cache_step.py
+++ b/flujo/steps/cache_step.py
@@ -86,7 +86,8 @@ def _serialize_for_cache_key(
                     node_result_dict: dict[str, Any] = {}
 
                     # Process each field individually, only marking fields that are actually circular
-                    for k, v in d.items():
+                    for k in sorted(d.keys(), key=str):
+                        v = d[k]
                         if k == "next":
                             next_obj = getattr(obj, "next", None)
                             if (
@@ -117,7 +118,8 @@ def _serialize_for_cache_key(
 
                     return node_result_dict
                 result_dict: dict[str, Any] = {}
-                for k, v in d.items():
+                for k in sorted(d.keys(), key=str):
+                    v = d[k]
                     # Special-case agent field for Step
                     if isinstance(obj, Step) and k == "agent":
                         original_agent = getattr(obj, "agent", None)
@@ -148,7 +150,8 @@ def _serialize_for_cache_key(
             if "run_id" in d and "initial_prompt" in d:
                 d.pop("run_id", None)
             result: dict[Any, Any] = {}
-            for k, v in d.items():
+            for k in sorted(d.keys(), key=str):
+                v = d[k]
                 # Always check for custom serializer for every value
                 custom_serializer_v = lookup_custom_serializer(v)
                 if custom_serializer_v is not None:
@@ -165,8 +168,8 @@ def _serialize_for_cache_key(
                         if "run_id" in v_dict:
                             v_dict.pop("run_id", None)
                         result[k] = {
-                            kk: _serialize_for_cache_key(vv, visited, _is_root=False)
-                            for kk, vv in v_dict.items()
+                            kk: _serialize_for_cache_key(v_dict[kk], visited, _is_root=False)
+                            for kk in sorted(v_dict.keys(), key=str)
                         }
                     except (ValueError, RecursionError):
                         field_names = []
@@ -183,8 +186,8 @@ def _serialize_for_cache_key(
                     )
                 elif isinstance(v, dict):
                     result[k] = {
-                        kk: _serialize_for_cache_key(vv, visited, _is_root=False)
-                        for kk, vv in v.items()
+                        kk: _serialize_for_cache_key(v[kk], visited, _is_root=False)
+                        for kk in sorted(v.keys(), key=str)
                     }
                 else:
                     result[k] = _serialize_for_cache_key(v, visited, _is_root=False)
@@ -309,15 +312,15 @@ def _serialize_list_for_key(obj_list: list[Any], visited: Optional[Set[int]] = N
                     d.pop("run_id", None)
                 result_list.append(
                     {
-                        k: _serialize_for_cache_key(val, visited, _is_root=False)
-                        for k, val in d.items()
+                        k: _serialize_for_cache_key(d[k], visited, _is_root=False)
+                        for k in sorted(d.keys(), key=str)
                     }
                 )
             elif isinstance(v, dict):
                 result_list.append(
                     {
-                        k: _serialize_for_cache_key(val, visited, _is_root=False)
-                        for k, val in v.items()
+                        k: _serialize_for_cache_key(v[k], visited, _is_root=False)
+                        for k in sorted(v.keys(), key=str)
                     }
                 )
             elif isinstance(v, (list, tuple)):

--- a/flujo/utils/serialization.py
+++ b/flujo/utils/serialization.py
@@ -422,6 +422,11 @@ def safe_serialize(
     _seen.add(obj_id)
 
     try:
+        # Give priority to custom serializers over built-in handling
+        custom_serializer = lookup_custom_serializer(obj)
+        if custom_serializer:
+            return safe_serialize(custom_serializer(obj), default_serializer, _seen)
+
         # Handle None
         if obj is None:
             return None

--- a/tests/benchmarks/test_serialization_performance_new.py
+++ b/tests/benchmarks/test_serialization_performance_new.py
@@ -1,0 +1,7 @@
+"""Placeholder for additional serialization performance benchmarks."""
+
+import pytest
+
+pytest.skip("Performance benchmark placeholder", allow_module_level=True)
+
+# TODO: Implement benchmark_pydantic_model_serialization

--- a/tests/security/test_state_deserialization.py
+++ b/tests/security/test_state_deserialization.py
@@ -1,0 +1,7 @@
+"""Security tests for state deserialization."""
+
+import pytest
+
+pytest.skip("Security tests not implemented", allow_module_level=True)
+
+# TODO: test_resuming_from_malicious_state_fails_safely

--- a/tests/unit/test_serialization_core.py
+++ b/tests/unit/test_serialization_core.py
@@ -1,0 +1,52 @@
+import pytest
+from pydantic import BaseModel
+
+from flujo.steps.cache_step import _generate_cache_key, _serialize_for_cache_key
+from flujo.utils.serialization import (
+    safe_serialize,
+    register_custom_serializer,
+    reset_custom_serializer_registry,
+)
+from flujo.domain.dsl import Step
+
+
+class SelfRefModel(BaseModel):
+    value: int
+    next: "SelfRefModel | None" = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+SelfRefModel.model_rebuild()
+
+
+@pytest.fixture(autouse=True)
+def clear_serializers():
+    reset_custom_serializer_registry()
+    yield
+    reset_custom_serializer_registry()
+
+
+def test_determinism_with_unordered_collections() -> None:
+    step = Step(name="determinism")
+    data1 = {"a": 1, "b": 2, "set": {3, 1}}
+    data2 = {"b": 2, "a": 1, "set": {1, 3}}
+    key1 = _generate_cache_key(step, data1)
+    key2 = _generate_cache_key(step, data2)
+    assert key1 == key2
+
+
+def test_circular_reference_handling() -> None:
+    node = SelfRefModel(value=1)
+    node.next = node
+    serialized = _serialize_for_cache_key(node)
+    assert serialized["next"] == f"<{SelfRefModel.__name__} circular>"
+
+
+def test_custom_serializer_is_honored() -> None:
+    def custom_int(value: int) -> str:
+        return f"INT:{value}"
+
+    register_custom_serializer(int, custom_int)
+    result = safe_serialize({"num": 7})
+    assert result["num"] == "INT:7"


### PR DESCRIPTION
## Summary
- ensure custom serializers run before built-in logic
- sort keys when serializing dicts for cache keys
- add unit tests for determinism, circular refs, and custom serializer priority
- add placeholders for benchmark and security tests

## Testing
- `CI=true make all`

------
https://chatgpt.com/codex/tasks/task_e_6872dcbba4ac832ca9c0c37cc68ea0d0