### PR TITLE
Add nested UsageGovernor integration test

### DIFF
--- a/tests/integration/test_usage_governor.py
+++ b/tests/integration/test_usage_governor.py
@@ -182,3 +182,107 @@ async def test_governor_parallel_step_limit() -> None:
         await gather_result(runner, 0)
 
     assert "Cost limit of $0.15 exceeded" in str(exc_info.value)
+
+
+class VariableMetricAgent(AsyncAgentProtocol[int, MockAgentOutput]):
+    """Agent that allows custom cost and token metrics."""
+
+    def __init__(self, cost: float = 0.1, tokens: int = 100) -> None:
+        self.cost = cost
+        self.tokens = tokens
+
+    async def run(self, data: int | MockAgentOutput, **kwargs: Any) -> MockAgentOutput:
+        val = data.value if isinstance(data, MockAgentOutput) else data
+        return MockAgentOutput(value=val + 1, cost_usd=self.cost, token_counts=self.tokens)
+
+
+@pytest.mark.asyncio
+async def test_governor_loop_with_nested_parallel_limit() -> None:
+    """Governor enforces limits in LoopStep containing a ParallelStep."""
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": VariableMetricAgent(cost=0.1)}),
+        "b": Step.model_validate({"name": "b", "agent": VariableMetricAgent(cost=0.1)}),
+    }
+    parallel = Step.parallel("inner_parallel", branches)
+    loop_step = Step.loop_until(
+        name="outer_loop",
+        loop_body_pipeline=Pipeline.from_step(parallel),
+        exit_condition_callable=lambda _out, _ctx: False,
+        iteration_input_mapper=lambda _out, _ctx, _i: 0,
+        max_loops=10,
+    )
+    limits = UsageLimits(total_cost_usd_limit=0.5)
+    runner = Flujo(loop_step, usage_limits=limits)
+
+    with pytest.raises(UsageLimitExceededError) as exc_info:
+        await gather_result(runner, 0)
+
+    assert "Cost limit of $0.5 exceeded" in str(exc_info.value)
+    result: PipelineResult = exc_info.value.result
+    assert result.total_cost_usd == pytest.approx(0.6)
+    assert len(result.step_history) == 1
+    loop_result = result.step_history[0]
+    assert not loop_result.success
+    assert loop_result.attempts == 3
+    assert loop_result.cost_usd == pytest.approx(0.6)
+    assert "limit" in (loop_result.feedback or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_governor_parallel_limit_first_branch_exceeds() -> None:
+    """Governor triggers when the first parallel branch breaches the limit."""
+    branches = {
+        "expensive": Step.model_validate(
+            {"name": "expensive", "agent": VariableMetricAgent(cost=0.6)}
+        ),
+        "cheap": Step.model_validate({"name": "cheap", "agent": VariableMetricAgent(cost=0.1)}),
+    }
+    parallel = Step.parallel("parallel_breach", branches)
+    loop_step = Step.loop_until(
+        name="loop_parallel_breach",
+        loop_body_pipeline=Pipeline.from_step(parallel),
+        iteration_input_mapper=lambda _out, _ctx, _i: 0,
+        exit_condition_callable=lambda _out, _ctx: False,
+        max_loops=10,
+    )
+    limits = UsageLimits(total_cost_usd_limit=0.5)
+    runner = Flujo(loop_step, usage_limits=limits)
+
+    with pytest.raises(UsageLimitExceededError):
+        await gather_result(runner, 0)
+
+
+@pytest.mark.asyncio
+async def test_governor_cumulative_cost_updates() -> None:
+    """Total cost should accumulate correctly across loop iterations."""
+    branches = {
+        "a": Step.model_validate({"name": "a", "agent": VariableMetricAgent(cost=0.1)}),
+        "b": Step.model_validate({"name": "b", "agent": VariableMetricAgent(cost=0.1)}),
+    }
+    parallel = Step.parallel("count_parallel", branches)
+
+    iteration_counter = 0
+
+    def _exit_after_four(_out: Any, _ctx: Any) -> bool:
+        nonlocal iteration_counter
+        iteration_counter += 1
+        return iteration_counter >= 4
+
+    loop_step = Step.loop_until(
+        name="count_loop",
+        loop_body_pipeline=Pipeline.from_step(parallel),
+        iteration_input_mapper=lambda _out, _ctx, _i: 0,
+        exit_condition_callable=_exit_after_four,
+        max_loops=10,
+    )
+    limits = UsageLimits(total_cost_usd_limit=2.0)
+    runner = Flujo(loop_step, usage_limits=limits)
+
+    result = await gather_result(runner, 0)
+
+    assert result.total_cost_usd == pytest.approx(0.8)
+    assert len(result.step_history) == 1
+    loop_result = result.step_history[0]
+    assert loop_result.success
+    assert loop_result.attempts == 4
+    assert loop_result.cost_usd == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
- extend usage governor integration tests with nested LoopStep containing ParallelStep
- include corner case of limit exceeded in first parallel branch
- verify cost accumulation across iterations

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_68731563a8f0832cbdcec8a1f9e4ca10