### PR TITLE
Add self-improvement E2E test

### DIFF
--- a/tests/e2e/cassettes/self_improvement.yaml
+++ b/tests/e2e/cassettes/self_improvement.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"prompt":"Analyze the following failed and successful pipeline runs to
+      identify root causes and suggest improvements.\n\n--- FAILED CASES ---\n\nCase:
+      fail_case\nInput: Prompt1\n- Step ''solution'': Output=''This output is definitely
+      far too long and verbose to be considered concise.'' (success=True)\n  Config(retries=1,
+      timeout=Nones)\n  SystemPromptSummary: \"\"\n- Step ''validate'': Output=''None''
+      (success=False, feedback=''Check ''ConciseValidator'' failed: too verbose'')\n  Config(retries=1,
+      timeout=Nones)\n  SystemPromptSummary: \"\"\n\n\n--- SUCCESSFUL EXAMPLE FOR
+      CONTRAST ---\n\nCase: success_case\nInput: Prompt2\n- Step ''solution'': Output=''Short
+      answer.'' (success=True)\n  Config(retries=1, timeout=Nones)\n  SystemPromptSummary:
+      \"\"\n- Step ''validate'': Output=''Short answer.'' (success=True)\n  Config(retries=1,
+      timeout=Nones)\n  SystemPromptSummary: \"\"","response":{"suggestions":[{"target_step_name":"solution","suggestion_type":"prompt_modification","failure_pattern_summary":"Solution
+      step output too verbose","detailed_explanation":"Shorten the solution output.","prompt_modification_details":{"modification_instruction":"Be
+      concise."},"example_failing_input_snippets":["Prompt1"],"estimated_impact":"HIGH","estimated_effort_to_implement":"LOW"}]}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1264'
+      content-type:
+      - application/json
+      host:
+      - httpbin.org
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://httpbin.org/anything
+  response:
+    body:
+      string: "{\n  \"args\": {}, \n  \"data\": \"{\\\"prompt\\\":\\\"Analyze the
+        following failed and successful pipeline runs to identify root causes and
+        suggest improvements.\\\\n\\\\n--- FAILED CASES ---\\\\n\\\\nCase: fail_case\\\\nInput:
+        Prompt1\\\\n- Step 'solution': Output='This output is definitely far too long
+        and verbose to be considered concise.' (success=True)\\\\n  Config(retries=1,
+        timeout=Nones)\\\\n  SystemPromptSummary: \\\\\\\"\\\\\\\"\\\\n- Step 'validate':
+        Output='None' (success=False, feedback='Check 'ConciseValidator' failed: too
+        verbose')\\\\n  Config(retries=1, timeout=Nones)\\\\n  SystemPromptSummary:
+        \\\\\\\"\\\\\\\"\\\\n\\\\n\\\\n--- SUCCESSFUL EXAMPLE FOR CONTRAST ---\\\\n\\\\nCase:
+        success_case\\\\nInput: Prompt2\\\\n- Step 'solution': Output='Short answer.'
+        (success=True)\\\\n  Config(retries=1, timeout=Nones)\\\\n  SystemPromptSummary:
+        \\\\\\\"\\\\\\\"\\\\n- Step 'validate': Output='Short answer.' (success=True)\\\\n
+        \ Config(retries=1, timeout=Nones)\\\\n  SystemPromptSummary: \\\\\\\"\\\\\\\"\\\",\\\"response\\\":{\\\"suggestions\\\":[{\\\"target_step_name\\\":\\\"solution\\\",\\\"suggestion_type\\\":\\\"prompt_modification\\\",\\\"failure_pattern_summary\\\":\\\"Solution
+        step output too verbose\\\",\\\"detailed_explanation\\\":\\\"Shorten the solution
+        output.\\\",\\\"prompt_modification_details\\\":{\\\"modification_instruction\\\":\\\"Be
+        concise.\\\"},\\\"example_failing_input_snippets\\\":[\\\"Prompt1\\\"],\\\"estimated_impact\\\":\\\"HIGH\\\",\\\"estimated_effort_to_implement\\\":\\\"LOW\\\"}]}}\",
+        \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\",
+        \n    \"Accept-Encoding\": \"gzip, deflate\", \n    \"Content-Length\": \"1264\",
+        \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\",
+        \n    \"User-Agent\": \"python-httpx/0.28.1\", \n    \"X-Amzn-Trace-Id\":
+        \"Root=1-68731b11-55ae48f81637f97b72106e5e\", \n    \"X-Envoy-Expected-Rq-Timeout-Ms\":
+        \"900000\", \n    \"X-No-Mitm\": \"False\"\n  }, \n  \"json\": {\n    \"prompt\":
+        \"Analyze the following failed and successful pipeline runs to identify root
+        causes and suggest improvements.\\n\\n--- FAILED CASES ---\\n\\nCase: fail_case\\nInput:
+        Prompt1\\n- Step 'solution': Output='This output is definitely far too long
+        and verbose to be considered concise.' (success=True)\\n  Config(retries=1,
+        timeout=Nones)\\n  SystemPromptSummary: \\\"\\\"\\n- Step 'validate': Output='None'
+        (success=False, feedback='Check 'ConciseValidator' failed: too verbose')\\n
+        \ Config(retries=1, timeout=Nones)\\n  SystemPromptSummary: \\\"\\\"\\n\\n\\n---
+        SUCCESSFUL EXAMPLE FOR CONTRAST ---\\n\\nCase: success_case\\nInput: Prompt2\\n-
+        Step 'solution': Output='Short answer.' (success=True)\\n  Config(retries=1,
+        timeout=Nones)\\n  SystemPromptSummary: \\\"\\\"\\n- Step 'validate': Output='Short
+        answer.' (success=True)\\n  Config(retries=1, timeout=Nones)\\n  SystemPromptSummary:
+        \\\"\\\"\", \n    \"response\": {\n      \"suggestions\": [\n        {\n          \"detailed_explanation\":
+        \"Shorten the solution output.\", \n          \"estimated_effort_to_implement\":
+        \"LOW\", \n          \"estimated_impact\": \"HIGH\", \n          \"example_failing_input_snippets\":
+        [\n            \"Prompt1\"\n          ], \n          \"failure_pattern_summary\":
+        \"Solution step output too verbose\", \n          \"prompt_modification_details\":
+        {\n            \"modification_instruction\": \"Be concise.\"\n          },
+        \n          \"suggestion_type\": \"prompt_modification\", \n          \"target_step_name\":
+        \"solution\"\n        }\n      ]\n    }\n  }, \n  \"method\": \"POST\", \n
+        \ \"origin\": \"52.242.197.97\", \n  \"url\": \"https://httpbin.org/anything\"\n}\n"
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-origin:
+      - '*'
+      content-length:
+      - '3352'
+      content-type:
+      - application/json
+      date:
+      - Sun, 13 Jul 2025 02:33:53 GMT
+      server:
+      - envoy
+      x-envoy-upstream-service-time:
+      - '141'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/e2e/test_e2e_self_improvement.py
+++ b/tests/e2e/test_e2e_self_improvement.py
@@ -1,0 +1,88 @@
+import functools
+import vcr
+import pytest
+import httpx
+from flujo.application.runner import Flujo
+from flujo.application.eval_adapter import run_pipeline_async
+from flujo.application.self_improvement import evaluate_and_improve, SelfImprovementAgent
+from flujo.domain.models import ImprovementReport, SuggestionType
+from flujo.domain import Step
+from flujo.validation import BaseValidator, ValidationResult
+from flujo.testing.utils import StubAgent
+from pydantic_evals import Dataset, Case
+
+
+class ConciseValidator(BaseValidator):
+    async def validate(self, output_to_check: str, *, context=None) -> ValidationResult:
+        words = len(str(output_to_check).split())
+        return ValidationResult(
+            is_valid=words <= 5,
+            feedback=None if words <= 5 else "too verbose",
+            validator_name=self.name,
+        )
+
+
+class IdentityAgent:
+    async def run(self, data: str) -> str:
+        return data
+
+
+IMPROVEMENT_JSON = {
+    "suggestions": [
+        {
+            "target_step_name": "solution",
+            "suggestion_type": "prompt_modification",
+            "failure_pattern_summary": "Solution step output too verbose",
+            "detailed_explanation": "Shorten the solution output.",
+            "prompt_modification_details": {"modification_instruction": "Be concise."},
+            "example_failing_input_snippets": ["Prompt1"],
+            "estimated_impact": "HIGH",
+            "estimated_effort_to_implement": "LOW",
+        }
+    ]
+}
+
+
+class EchoAgent:
+    async def run(self, prompt: str) -> dict:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://httpbin.org/anything",
+                json={"prompt": prompt, "response": IMPROVEMENT_JSON},
+            )
+        return resp.json()["json"]["response"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+@vcr.use_cassette("tests/e2e/cassettes/self_improvement.yaml")
+async def test_e2e_self_improvement_workflow() -> None:
+    solution_agent = StubAgent(
+        [
+            "This output is definitely far too long and verbose to be considered concise.",
+            "Short answer.",
+        ]
+    )
+    pipeline = Step.solution(solution_agent) >> Step.validate_step(
+        IdentityAgent(), validators=[ConciseValidator()]
+    )
+    runner = Flujo(pipeline)
+    dataset = Dataset(
+        cases=[
+            Case(name="fail_case", inputs="Prompt1", expected_output=None),
+            Case(name="success_case", inputs="Prompt2", expected_output=None),
+        ]
+    )
+    report = await evaluate_and_improve(
+        functools.partial(run_pipeline_async, runner=runner),
+        dataset,
+        SelfImprovementAgent(EchoAgent()),
+        pipeline_definition=pipeline,
+    )
+    assert isinstance(report, ImprovementReport)
+    assert report.suggestions
+    sugg = report.suggestions[0]
+    assert sugg.target_step_name == "solution"
+    assert sugg.suggestion_type == SuggestionType.PROMPT_MODIFICATION
+    assert "verbose" in sugg.failure_pattern_summary.lower()
+    assert sugg.prompt_modification_details is not None


### PR DESCRIPTION
## Summary
- add an end-to-end test for `evaluate_and_improve`
- include a VCR cassette for the recorded HTTP call

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_687319942ab4832c9ab302dd4164d106