### PR TITLE
Fix outdated imports in docs

### DIFF
--- a/docs/The_flujo_way.md
+++ b/docs/The_flujo_way.md
@@ -23,7 +23,7 @@ Use `AsyncAgentProtocol` for simple agents that don't need typed context:
 ```python
 from flujo.domain.agent_protocol import AsyncAgentProtocol
 from flujo.domain.resources import AppResources
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class TriageContext(PipelineContext):
     post_content: str
@@ -46,7 +46,7 @@ For agents that need typed pipeline context, use `ContextAwareAgentProtocol`:
 
 ```python
 from flujo.domain.agent_protocol import ContextAwareAgentProtocol
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class ResearchContext(PipelineContext):
     research_topic: str = "Unknown"
@@ -88,7 +88,7 @@ research_step = Step("PlanResearch", PlanResearchAgent())
 
 ```python
 from flujo import Step, Pipeline
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 def route(ctx: TriageContext, _):
     if ctx.author_reputation < 0.2: return "high_risk"
@@ -148,7 +148,7 @@ refine_step = Step.refine_until(
 ### A. Basic Context
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class ModerationContext(PipelineContext):
     post_id: int
@@ -160,7 +160,7 @@ class ModerationContext(PipelineContext):
 ### B. Extended Context with Built-in Features
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from pydantic import Field
 
 class ResearchContext(PipelineContext):
@@ -224,7 +224,7 @@ quality_gate = Step.validate_step(
 
 ```python
 from flujo import Flujo
-from flujo.domain.models import UsageLimits
+from flujo.models import UsageLimits
 
 runner = Flujo(pipeline, usage_limits=UsageLimits(total_cost_usd_limit=0.50))
 ```
@@ -285,7 +285,7 @@ DEFAULT_REVIEW_MODEL=openai:gpt-4
 ### B. Per-agent model + settings
 
 ```python
-from flujo import make_agent_async
+from flujo.infra.agents import make_agent_async
 
 agent = make_agent_async(
     model="openai:gpt-4",
@@ -388,7 +388,7 @@ from flujo import (
 from flujo.domain.agent_protocol import AsyncAgentProtocol, ContextAwareAgentProtocol
 
 # Models and types
-from flujo.domain.models import BaseModel, UsageLimits, PipelineResult
+from flujo.models import BaseModel, UsageLimits, PipelineResult
 
 # Resources
 from flujo.domain.resources import AppResources

--- a/docs/agent_infrastructure.md
+++ b/docs/agent_infrastructure.md
@@ -285,7 +285,7 @@ Leverage type hints for better IDE support:
 
 ```python
 from flujo.infra.agents import make_review_agent
-from flujo.domain.models import Checklist
+from flujo.models import Checklist
 
 # Type hints help with IDE support
 review_agent: AsyncAgentProtocol[Any, Checklist] = make_review_agent()

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -62,7 +62,7 @@ class MyResources(AppResources):
 
 my_resources = MyResources(db_pool=make_pool())
 
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class MyContext(PipelineContext):
     counter: int = 0
@@ -201,7 +201,7 @@ This protocol is for agents that need to access or modify the pipeline's shared 
 
 ```python
 from flujo.domain.agent_protocol import ContextAwareAgentProtocol
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from typing import Any
 
 class MyCustomContext(PipelineContext):
@@ -218,7 +218,7 @@ class MyContextAwareAgent(ContextAwareAgentProtocol[str, str, MyCustomContext]):
 `flujo` provides utilities for creating and configuring agents.
 
 ```python
-from flujo import make_agent_async
+from flujo.infra.agents import make_agent_async
 
 # Create a custom agent
 agent = make_agent_async(
@@ -1074,7 +1074,7 @@ Decorator to mark a field as serializable with a custom serializer. **This funct
 ```python
 # DEPRECATED - Use register_custom_serializer or manual field_serializer instead
 from flujo.utils import serializable_field
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     @serializable_field(lambda x: x.to_dict())
@@ -1170,7 +1170,7 @@ The following types are automatically handled by the enhanced `BaseModel`:
 #### Usage
 
 ```python
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 from datetime import datetime
 from enum import Enum
 
@@ -1200,7 +1200,7 @@ For model-specific serialization, use Pydantic's `@field_serializer`:
 
 ```python
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType
@@ -1272,7 +1272,7 @@ step = CacheStep.cached(some_step)
 Custom types in pipeline context are automatically handled:
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from flujo.utils import register_custom_serializer
 
 class CustomContext(PipelineContext):

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -11,7 +11,7 @@ the `PipelineContext`.
 
 ```python
 from flujo.recipes.factories import make_agentic_loop_pipeline
-from flujo import make_agent_async
+from flujo.infra.agents import make_agent_async
 from flujo.domain.commands import AgentCommand
 planner = make_agent_async(
     "openai:gpt-4o",
@@ -81,7 +81,7 @@ The library provides four default agents:
 ### Creating Custom Agents
 
 ```python
-from flujo import make_agent_async
+from flujo.infra.agents import make_agent_async
 
 custom_agent = make_agent_async(
     "openai:gpt-4",  # Model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ print(f"Current solution model: {settings.default_solution_model}")
 ### Model Selection
 
 ```python
-from flujo import make_agent_async
+from flujo.infra.agents import make_agent_async
 
 # Use different models for different agents
 review_agent = make_agent_async(
@@ -187,7 +187,7 @@ runner = Flujo(
 ### Custom Scoring
 
 ```python
-from flujo import weighted_score
+from flujo.domain.scoring import weighted_score
 
 # Define custom weights
 weights = {

--- a/docs/cookbook/advanced_serialization.md
+++ b/docs/cookbook/advanced_serialization.md
@@ -20,7 +20,7 @@ The `BaseModel` in Flujo automatically handles serialization of common types:
 Most custom types will work automatically without any configuration:
 
 ```python
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 from datetime import datetime
 from enum import Enum
 
@@ -68,7 +68,7 @@ Now, **any** Flujo model containing a `datetime` will use your custom format whe
 
 ```python
 from flujo.utils import register_custom_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class DatabaseConnection:
     def __init__(self, host: str, port: int):
@@ -169,7 +169,7 @@ For fields that need custom serialization, use the `@field_serializer` decorator
 
 ```python
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType
@@ -189,7 +189,7 @@ Flujo previously provided a convenience decorator for field serialization, but t
 ```python
 # DEPRECATED - Don't use this approach
 from flujo.utils import serializable_field
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     @serializable_field(lambda x: x.to_dict())
@@ -212,7 +212,7 @@ class MyModel(BaseModel):
 2. **Manual field_serializer:**
 ```python
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     complex_object: ComplexType
@@ -258,7 +258,7 @@ register_custom_serializer(MyCustomType, serialize_my_type)
 
 ```python
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     non_serializable_field: MyCustomType
@@ -271,7 +271,7 @@ class MyModel(BaseModel):
 ### Option 3: Convert to Serializable Types
 
 ```python
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     # Store as string instead of custom object
@@ -287,7 +287,7 @@ class MyModel(BaseModel):
 ### Option 4: Use `Any` Type with Automatic Fallback
 
 ```python
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     # The BaseModel will automatically handle serialization
@@ -312,7 +312,7 @@ class MyModel(BaseModel):
 ### After (New Approach)
 ```python
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType

--- a/docs/cookbook/async_map.md
+++ b/docs/cookbook/async_map.md
@@ -4,7 +4,7 @@
 
 ```python
 from flujo import Flujo, Step, Pipeline
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Numbers(PipelineContext):
     values: list[int]

--- a/docs/cookbook/serialization_quick_reference.md
+++ b/docs/cookbook/serialization_quick_reference.md
@@ -36,7 +36,7 @@ register_custom_serializer(datetime, lambda dt: dt.strftime("%Y-%m-%d %H:%M:%S")
 ### Enable Arbitrary Types
 
 ```python
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType
@@ -212,7 +212,7 @@ class CustomContext(PipelineContext):
 
 ```python
 from flujo.utils import register_custom_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 from datetime import datetime
 
 # Register custom serializers

--- a/docs/cookbook/state_machine_pipeline.md
+++ b/docs/cookbook/state_machine_pipeline.md
@@ -6,7 +6,7 @@ Use the **state machine pipeline factory** to orchestrate a workflow where the n
 from pydantic import BaseModel
 from flujo import Flujo, Step, step
 from flujo.recipes import make_state_machine_pipeline
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     next_state: str = "start"

--- a/docs/cookbook/using_processors.md
+++ b/docs/cookbook/using_processors.md
@@ -8,7 +8,7 @@
 from flujo import Step, AgentProcessors
 from flujo.processors import AddContextVariables, StripMarkdownFences
 from flujo.testing.utils import StubAgent
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     product: str

--- a/docs/documentation_guide.md
+++ b/docs/documentation_guide.md
@@ -25,7 +25,7 @@ All narrative documentation (tutorials, guides, specifications) lives in the `/d
 
 ### Step 2: Update Python Docstrings for API Reference
 
-Our API reference is generated automatically. To improve it, you must edit the docstrings directly in the Python source code (e.g., in `flujo/domain/pipeline_dsl.py`).
+Our API reference is generated automatically. To improve it, you must edit the docstrings directly in the Python source code (e.g., in `flujo/domain/dsl/`).
 
 We follow the **Google Python Style Guide** for docstrings. A good docstring includes:
 * A one-line summary.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -55,7 +55,7 @@ Implement the `ExecutionBackend` protocol and pass your implementation to
 
 ```python
 from flujo.domain.backends import ExecutionBackend, StepExecutionRequest
-from flujo.domain.models import StepResult
+from flujo.models import StepResult
 
 class LoggingBackend(ExecutionBackend):
     def __init__(self, registry: dict[str, Any]):
@@ -98,7 +98,7 @@ When you use a custom function as a `mapper` in a `Step`, `flujo` analyzes its s
 
 ```python
 from flujo import Step, Flujo
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from flujo.domain.resources import AppResources
 
 class MyContext(PipelineContext):

--- a/docs/migration/v0.7.0.md
+++ b/docs/migration/v0.7.0.md
@@ -52,7 +52,7 @@ class MyModel(BaseModel):
 ```python
 # After (v0.7.0)
 from pydantic import field_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType
@@ -66,7 +66,7 @@ class MyModel(BaseModel):
 
 ```python
 # After (v0.7.0)
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyModel(BaseModel):
     custom_field: MyCustomType
@@ -149,7 +149,7 @@ The `BaseModel` now includes intelligent fallback serialization for:
 
 ```python
 from flujo.utils import register_custom_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class DatabaseConnection:
     def __init__(self, host: str, port: int):
@@ -250,7 +250,7 @@ Run this test to verify your custom types work correctly:
 
 ```python
 from flujo.utils import register_custom_serializer
-from flujo.domain.models import BaseModel
+from flujo.models import BaseModel
 
 class MyCustomType:
     def __init__(self, value):

--- a/docs/modular_workflows.md
+++ b/docs/modular_workflows.md
@@ -18,7 +18,7 @@ upper_step = Step.from_mapper(to_upper)
 `Step.map_over` runs a pipeline for each item in an iterable stored in the pipeline context. The collected outputs are returned as a list.
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     nums: list[int]
@@ -50,7 +50,7 @@ print(result.step_history[-1].output)  # [0, 1, 2, 3]
 `Step.parallel` executes multiple branch pipelines concurrently and aggregates their outputs in a dictionary keyed by branch name.
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     val: int = 0

--- a/docs/pipeline_context.md
+++ b/docs/pipeline_context.md
@@ -8,7 +8,7 @@ For complete details on implementing context aware components see the [Stateful 
 
 ## Best Practices for Custom Context Models
 
-To create your own context model, **inherit from `flujo.domain.models.PipelineContext`**.
+To create your own context model, **inherit from `flujo.models.PipelineContext`**.
 This base class provides important built-in fields managed by the engine:
 
 - `initial_prompt: str` – automatically populated with the first input of each `run()` call.
@@ -19,7 +19,7 @@ This base class provides important built-in fields managed by the engine:
 A minimal custom context looks like this:
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from pydantic import Field
 
 class MyDiscoveryContext(PipelineContext):

--- a/docs/pipeline_dsl.md
+++ b/docs/pipeline_dsl.md
@@ -241,7 +241,7 @@ if result.step_history[-1].metadata_.get('validation_passed') == False:
 ```
 
 # With custom scoring
-from flujo import weighted_score
+from flujo.domain.scoring import weighted_score
 
 weights = {
     "correctness": 0.6,
@@ -304,7 +304,7 @@ pipeline = Step.review(review_agent) >> loop_step >> Step.validate_step(validato
 a `Flujo` runner can share a mutable Pydantic model instance across all steps in a single run. Pass a context model when creating the runner and declare a `context` parameter in your step functions or agents. See [Typed Pipeline Context](pipeline_context.md) for a full explanation.
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class MyContext(PipelineContext):
     counter: int = 0

--- a/docs/pipeline_looping.md
+++ b/docs/pipeline_looping.md
@@ -20,7 +20,7 @@ A single context instance is passed into every iteration. The loop body can modi
 
 ```python
 from flujo.domain import Step, Pipeline
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     counter: int = 0

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,8 @@ Create a new file `hello_agentic.py`:
 
 ```python
 from flujo.recipes.factories import make_agentic_loop_pipeline, run_agentic_loop_pipeline
-from flujo import make_agent_async, init_telemetry
+from flujo.infra.agents import make_agent_async
+from flujo.infra import init_telemetry
 from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
 
 init_telemetry()

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -18,7 +18,7 @@ The orchestrator includes several scoring mechanisms:
 The simplest scoring method counts passed checklist items:
 
 ```python
-from flujo import ratio_score
+from flujo.domain.scoring import ratio_score
 
 # Calculate a simple pass/fail ratio
 score = ratio_score(checklist)
@@ -30,7 +30,7 @@ score = ratio_score(checklist)
 Assign different weights to checklist items:
 
 ```python
-from flujo import weighted_score
+from flujo.domain.scoring import weighted_score
 
 # Define weights for different criteria
 weights = {
@@ -50,7 +50,8 @@ score = weighted_score(checklist, weights)
 Use an AI model to evaluate quality:
 
 ```python
-from flujo import make_agent_async, model_score
+from flujo.infra.agents import make_agent_async
+from flujo.domain.scoring import model_score
 
 # Create a scoring agent
 scorer_agent = make_agent_async(

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -67,7 +67,7 @@ When your pipeline uses a context model, provide `initial_context_data` to the r
 
 ```python
 from flujo import Flujo, Step, step
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from flujo.testing.utils import StubAgent
 
 class Ctx(PipelineContext):
@@ -251,7 +251,7 @@ Asserts that the final pipeline context contains specific expected updates. This
 
 ```python
 from flujo import Flujo, Step
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from flujo.testing.utils import StubAgent
 
 class MyContext(PipelineContext):

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,7 +249,7 @@ This guide helps you resolve common issues when using `flujo`.
 **Solutions:**
 1. Check telemetry configuration:
    ```python
-   from flujo import init_telemetry
+   from flujo.infra import init_telemetry
 
    init_telemetry(
        enable_export=True,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -37,7 +37,8 @@ We'll begin with the `AgenticLoop` pattern. A planner agent decides which tool a
 ```python
 # 📂 step_1_agentic_loop.py
 from flujo.recipes.factories import make_agentic_loop_pipeline, run_agentic_loop_pipeline
-from flujo import make_agent_async, init_telemetry
+from flujo.infra.agents import make_agent_async
+from flujo.infra import init_telemetry
 from flujo.domain.commands import AgentCommand, FinishCommand, RunAgentCommand
 
 init_telemetry()
@@ -116,7 +117,8 @@ Professional AI workflows often involve a mix of models to balance cost, speed, 
 ```python
 # 📂 step_3_mixing_models.py
 from flujo.recipes.factories import make_default_pipeline, run_default_pipeline
-from flujo import make_agent_async, init_telemetry
+from flujo.infra.agents import make_agent_async
+from flujo.infra import init_telemetry
 from flujo.models import Task
 from flujo.infra.agents import make_review_agent, make_validator_agent
 init_telemetry()
@@ -146,7 +148,9 @@ Let's build a workflow that extracts information from a block of text into a str
 ```python
 # 📂 step_4_structured_output.py
 from pydantic import BaseModel, Field
-from flujo import Step, Flujo, make_agent_async, init_telemetry
+from flujo import Step, Flujo
+from flujo.infra.agents import make_agent_async
+from flujo.infra import init_telemetry
 from flujo.models import Checklist
 
 init_telemetry()
@@ -335,7 +339,7 @@ accumulate data or pass configuration during a run. See
 [Typed Pipeline Context](pipeline_context.md) for more details.
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Stats(PipelineContext):
     calls: int = 0

--- a/docs/typing_guide.md
+++ b/docs/typing_guide.md
@@ -55,7 +55,7 @@ To share state across steps, define a Pydantic model and have your agents or plu
 > Steps, agents, and plugins can declare a `context` parameter to receive the shared context.
 
 ```python
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from flujo.domain.agent_protocol import ContextAwareAgentProtocol
 from flujo.domain.plugins import ContextAwarePluginProtocol, PluginOutcome
 
@@ -79,7 +79,7 @@ Every call to `Flujo.run()` creates a fresh context instance. Mutations are visi
 
 ```python
 from flujo import Flujo, step, PipelineResult
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 
 class Ctx(PipelineContext):
     history: list[str] = []

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,8 +30,10 @@ pip install flujo[bench]
 from flujo.recipes.factories import make_default_pipeline, run_default_pipeline
 from flujo.infra.agents import make_review_agent, make_solution_agent, make_validator_agent
 from flujo import (
-    Flujo, Task, init_telemetry,
+    Flujo,
+    Task,
 )
+from flujo.infra import init_telemetry
 
 # Initialize telemetry (optional)
 init_telemetry()
@@ -145,7 +147,7 @@ flujo run my_pipeline.py --input "Prompt" --context-model MyContext --json
 
 ```python
 from flujo import step, Pipeline
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from pydantic import Field
 
 class MyContext(PipelineContext):
@@ -187,7 +189,7 @@ Below is a complete example pipeline file you can run directly with the CLI:
 
 ```python
 from flujo import step, Pipeline
-from flujo.domain.models import PipelineContext
+from flujo.models import PipelineContext
 from pydantic import Field
 
 class DemoContext(PipelineContext):


### PR DESCRIPTION
## Summary
- update docs to use layered imports
- reference `UsageLimits` from `flujo.models`
- switch to `init_telemetry` and `make_agent_async` from `flujo.infra`
- fix documentation guide for new DSL path

## Testing
- `make lint`
- `make test`
- `make typecheck`
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_68749b136f24832cab8993eeaffc8a6f