### PR TITLE
Fix inconsistent token_counts default

### DIFF
--- a/flujo/tracing/manager.py
+++ b/flujo/tracing/manager.py
@@ -131,7 +131,7 @@ class TraceManager:
                 "attempts": payload.step_result.attempts,
                 "latency_s": payload.step_result.latency_s,
                 "cost_usd": getattr(payload.step_result, "cost_usd", 0.0),
-                "token_counts": getattr(payload.step_result, "token_counts", {}),
+                "token_counts": getattr(payload.step_result, "token_counts", 0),
                 "feedback": payload.step_result.feedback,
             }
         )

--- a/tests/unit/test_tracing_manager.py
+++ b/tests/unit/test_tracing_manager.py
@@ -209,6 +209,7 @@ class TestTraceManager:
         assert child_span.attributes["attempts"] == 3
         assert child_span.attributes["latency_s"] == 0.5
         assert child_span.attributes["feedback"] == "Test error"
+        assert child_span.attributes["token_counts"] == 0
 
     @pytest.mark.asyncio
     async def test_nested_spans_are_correctly_structured(self):


### PR DESCRIPTION
## Summary
- use integer 0 when populating token_counts for failed steps
- assert token_counts=0 for failed steps in TraceManager test

## Testing
- `pytest tests/unit/test_tracing_manager.py::TestTraceManager::test_step_failure_marks_span_as_failed -q`

------
https://chatgpt.com/codex/tasks/task_e_68780f2c4da0832c82e7079b9187edbb