### PR TITLE
Automate API docs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,11 +47,7 @@ nav:
     - 'v0.7.0': 'migration/v0.7.0.md'
     - 'v0.6.0': 'migration/v0.6.0.md'
     - 'v0.4.0': 'migration/v0.4.0.md'
-  - 'API Reference':
-    - 'Application': 'api/application.md'
-    - 'Domain (DSL)': 'api/domain.md'
-    - 'Models': 'api/models.md'
-    - 'Exceptions': 'api/exceptions.md'
+  - 'API Reference': 'api/'
 
 # Configure the theme (Material for MkDocs is the best choice)
 theme:


### PR DESCRIPTION
## Summary
- automate API reference navigation in MkDocs

## Testing
- `make lint`
- `make typecheck`
- `make test` *(fails: prometheus_client missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ab9884fec832c9602b1f8f5259dee