### PR TITLE
Automate API docs nav

### DIFF
--- a/docs/agent_infrastructure.md
+++ b/docs/agent_infrastructure.md
@@ -328,7 +328,7 @@ content_review_agent = make_review_agent(
 ### Getting Help
 
 - Check the [Troubleshooting Guide](troubleshooting.md)
-- Review the [API Reference](api_reference.md)
+- Review the [API Reference](api/index.md)
 - Search [existing issues](https://github.com/aandresalvarez/flujo/issues)
 
 ## Next Steps

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -84,7 +84,7 @@ custom_pipeline = (
 )
 
 # The `processors` argument lets you run custom pre- and post-processing
-# logic for a step. See [Using Processors](cookbook/using_processors.md).
+# logic for a step. See [Using Processors](../cookbook/using_processors.md).
 
 # You can also build steps from async functions using
 # `Step.from_mapper` or the `mapper` alias:
@@ -953,10 +953,10 @@ flujo pipeline-mermaid \
 
 ## Next Steps
 
-- Explore [Pipeline DSL Guide](pipeline_dsl.md) for advanced workflows
-- Read [Intelligent Evals](intelligent_evals.md) for evaluation strategies
-- Check [Telemetry Guide](telemetry.md) for monitoring setup
-- Review [Extending Guide](extending.md) for custom components
+- Explore [Pipeline DSL Guide](../pipeline_dsl.md) for advanced workflows
+- Read [Intelligent Evals](../intelligent_evals.md) for evaluation strategies
+- Check [Telemetry Guide](../telemetry.md) for monitoring setup
+- Review [Extending Guide](../extending.md) for custom components
 
 ## Pipeline Visualization
 
@@ -989,7 +989,7 @@ mermaid_code = pipeline.to_mermaid_with_detail_level("medium")
 print(mermaid_code)
 ```
 
-See also: [Visualizing Pipelines](cookbook/visualizing_pipelines.md)
+See also: [Visualizing Pipelines](../cookbook/visualizing_pipelines.md)
 
 ## Serialization Utilities
 
@@ -1394,4 +1394,4 @@ class CustomStateBackend(StateBackend):
         # ... save logic
 ```
 
-For more detailed examples and advanced usage patterns, see the [Advanced Serialization Guide](cookbook/advanced_serialization.md).
+For more detailed examples and advanced usage patterns, see the [Advanced Serialization Guide](../cookbook/advanced_serialization.md).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -480,5 +480,5 @@ async for chunk in runner.stream_async("hello"):
 
 - Try the [Tutorial](tutorial.md) for hands-on examples
 - Explore [Use Cases](use_cases.md) for inspiration
-- Read the [API Reference](api_reference.md) for details
+- Read the [API Reference](api/index.md) for details
 - Learn about [Custom Components](extending.md)

--- a/docs/cookbook/visualizing_pipelines.md
+++ b/docs/cookbook/visualizing_pipelines.md
@@ -49,7 +49,7 @@ The output is a Mermaid code block. You can:
 
 ---
 
-For more, see the [API Reference](../api_reference.md#pipeline-visualization).
+For more, see the [API Reference](../api/index.md#pipeline-visualization).
 
 ## Basic Usage
 

--- a/docs/documentation_status.md
+++ b/docs/documentation_status.md
@@ -46,7 +46,7 @@ The documentation has been systematically reviewed and updated to reflect the cu
 - ✅ **UPDATED**: Enhanced troubleshooting section
 - ✅ **UPDATED**: Added CLI-based verification steps
 
-#### `docs/api_reference.md` - API Documentation
+#### `docs/api/index.md` - API Documentation
 - ✅ **UPDATED**: Fixed Default recipe workflow description (now includes Reflection step)
 - ✅ **UPDATED**: Corrected agent type annotations and signatures
 - ✅ **UPDATED**: Updated Pipeline DSL examples with actual API
@@ -108,7 +108,7 @@ All documented CLI commands verified in `flujo/cli/main.py`:
 - ✅ `installation.md` - Installation guide
 - ✅ `quickstart.md` - Quick start guide
 - ✅ `concepts.md` - Core concepts
-- ✅ `api_reference.md` - API reference
+- ✅ `api/index.md` - API reference
 - ✅ `index.md` - Main landing page
 
 ### Existing (Not Modified - Assumed Current)

--- a/docs/migration/v0.4.0.md
+++ b/docs/migration/v0.4.0.md
@@ -145,6 +145,6 @@ from flujo.utils import format_prompt
 ## Need Help?
 
 If you encounter any issues during migration, please:
-1. Check the [API Reference](../api_reference.md) for the new import paths
+1. Check the [API Reference](../api/index.md) for the new import paths
 2. Look at the updated [examples](../examples/) for working code
 3. Open an issue on GitHub if you find any problems

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -374,7 +374,7 @@ print(details)
 1. **Documentation**
    - [Installation Guide](installation.md)
    - [Usage Guide](usage.md)
-   - [API Reference](api_reference.md)
+   - [API Reference](api/index.md)
 
 2. **Community**
    - [GitHub Issues](https://github.com/aandresalvarez/flujo/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,11 +47,12 @@ nav:
     - 'v0.7.0': 'migration/v0.7.0.md'
     - 'v0.6.0': 'migration/v0.6.0.md'
     - 'v0.4.0': 'migration/v0.4.0.md'
+  # Use mkdocstrings to automatically generate the navigation for all
+  # modules under docs/api. This keeps the API reference up to date as
+  # files are added or removed without needing manual edits here.
   - 'API Reference':
-    - 'Application': 'api/application.md'
-    - 'Domain (DSL)': 'api/domain.md'
-    - 'Models': 'api/models.md'
-    - 'Exceptions': 'api/exceptions.md'
+      - 'Overview': 'api/index.md'
+      - 'api/'
 
 # Configure the theme (Material for MkDocs is the best choice)
 theme:


### PR DESCRIPTION
## Summary
- update MkDocs config to build API docs from `docs/api/`
- rename `docs/api_reference.md` to `docs/api/index.md`
- fix links pointing to the API reference

## Testing
- `make format`
- `make lint`
- `mkdocs build --site-dir /tmp/site`
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687ab9884fec832c9602b1f8f5259dee