### PR TITLE
fix: mkdocs build command not found in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Build the documentation site
-        run: mkdocs build
+        run: uv run mkdocs build
 
       - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Fix mkdocs build command not found error in deploy-docs workflow by using uv run mkdocs build instead of mkdocs build directly.