### PR TITLE
Add architect templates and dynamic prompt support

### DIFF
--- a/examples/prompts/dynamic_template/README.md
+++ b/examples/prompts/dynamic_template/README.md
@@ -1,0 +1,17 @@
+Dynamic Prompt Template Example
+
+Files
+- `pipeline.yaml`: Defines an agent with a templated `system_prompt` loaded from a file with variables.
+- `prompts/summarize_with_context.md`: Prompt template using variables `max_sentences`, `topic`, `author`, plus runtime `context` and `previous_step`.
+
+Usage
+- Validate the pipeline (no API calls):
+  - `python -m flujo.cli.main validate pipeline.yaml`
+
+- Run the pipeline (requires API keys configured via `make install` and `flujo.toml`):
+  - `python -m flujo.cli.main run pipeline.yaml` (provide appropriate input/context via CLI options or your app integration)
+
+Notes
+- `topic` is resolved from `context.current_topic` at runtime.
+- `author` is resolved from the previous step output (here just a placeholder; in a multi-step pipeline, pass through a dict with `author_name`).
+- The agent’s `system_prompt` is rendered just-in-time per run and restored after execution.

--- a/examples/prompts/dynamic_template/pipeline.yaml
+++ b/examples/prompts/dynamic_template/pipeline.yaml
@@ -1,0 +1,22 @@
+version: "0.1"
+
+agents:
+  contextual_summarizer:
+    model: "openai:gpt-4o-mini"
+    system_prompt:
+      from_file: "./prompts/summarize_with_context.md"
+      variables:
+        max_sentences: 5
+        topic: "{{ context.current_topic }}"
+        author: "{{ previous_step.author_name }}"
+    output_schema:
+      type: object
+      properties:
+        summary:
+          type: string
+      required: [summary]
+
+steps:
+  - kind: step
+    name: GenerateSummary
+    uses: agents.contextual_summarizer

--- a/examples/prompts/dynamic_template/prompts/summarize_with_context.md
+++ b/examples/prompts/dynamic_template/prompts/summarize_with_context.md
@@ -1,0 +1,11 @@
+You are a helpful assistant. Write a concise summary.
+
+Topic: {{ topic }}
+Author: {{ author }}
+Max sentences: {{ max_sentences }}
+
+Context for this run:
+- User: {{ context.user }}
+- Previous Output: {{ previous_step }}
+
+Please produce a clear, factual summary in at most {{ max_sentences }} sentences about "{{ topic }}".

--- a/flujo/agents/__init__.py
+++ b/flujo/agents/__init__.py
@@ -10,7 +10,12 @@ This is the public API for the flujo agents package.
 
 from .monitoring import monitored_agent
 from .factory import make_agent, _unwrap_type_adapter
-from .wrapper import AsyncAgentWrapper, make_agent_async
+from .wrapper import (
+    AsyncAgentWrapper,
+    make_agent_async,
+    TemplatedAsyncAgentWrapper,
+    make_templated_agent_async,
+)
 from .repair import DeterministicRepairProcessor, make_repair_agent, get_repair_agent
 from .utils import get_raw_output_from_exception
 from .recipes import (
@@ -38,6 +43,8 @@ __all__ = [
     "_unwrap_type_adapter",
     "AsyncAgentWrapper",
     "make_agent_async",
+    "TemplatedAsyncAgentWrapper",
+    "make_templated_agent_async",
     # Repair functions
     "DeterministicRepairProcessor",
     "make_repair_agent",

--- a/flujo/domain/blueprint/schema.py
+++ b/flujo/domain/blueprint/schema.py
@@ -8,11 +8,13 @@ from pydantic import BaseModel, model_validator
 class AgentModel(BaseModel):
     model: str
 
-    # FSD-022: Allow externalized prompt via { from_file: "path" }
-    class FromFile(BaseModel):
+    # FSD-022 + Template Variables: Allow externalized prompt via
+    # { from_file: "path", variables: { ... } }
+    class PromptTemplateSpec(BaseModel):
         from_file: str
+        variables: Optional[Dict[str, Any]] = None
 
-    system_prompt: Union[str, "AgentModel.FromFile"]
+    system_prompt: Union[str, "AgentModel.PromptTemplateSpec"]
     output_schema: Dict[str, Any]
     # Optional provider-specific controls (e.g., GPT-5: reasoning, text verbosity)
     model_settings: Optional[Dict[str, Any]] = None
@@ -27,10 +29,12 @@ class AgentModel(BaseModel):
         if isinstance(data, dict):
             prompt = data.get("system_prompt")
             if isinstance(prompt, dict):
-                if "from_file" not in prompt or len(prompt.keys()) != 1:
+                # Allow {from_file} or {from_file, variables}
+                allowed = {"from_file", "variables"}
+                if "from_file" not in prompt or any(k not in allowed for k in prompt.keys()):
                     # Let ValueError propagate so Pydantic surfaces a clear error
                     raise ValueError(
-                        "system_prompt dictionary must contain only the 'from_file' key"
+                        "system_prompt dictionary must include 'from_file' and only optional 'variables'"
                     )
         return data
 

--- a/tests/unit/test_blueprint_prompt_template.py
+++ b/tests/unit/test_blueprint_prompt_template.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+
+def _make_yaml(path_ref: str) -> str:
+    return f"""
+version: "0.1"
+agents:
+  templated:
+    model: "openai:gpt-4o-mini"
+    system_prompt:
+      from_file: {path_ref}
+      variables:
+        max_sentences: 5
+        topic: "{{{{ context.topic }}}}"
+        author: "{{{{ previous_step.author_name }}}}"
+    output_schema: {{ type: "object" }}
+steps:
+  - kind: step
+    name: S1
+    uses: agents.templated
+"""
+
+
+def test_compiler_wires_templated_wrapper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base_dir = tmp_path
+    prompts_dir = base_dir / "prompts"
+    prompts_dir.mkdir()
+    prompt_file = prompts_dir / "tmpl.md"
+    prompt_text = (
+        "Summarize {{ topic }} in {{ max_sentences }} sentences by {{ author }}.\n"
+        "User: {{ context.user }} Prev: {{ previous_step.value }}"
+    )
+    prompt_file.write_text(prompt_text)
+
+    yaml_text = _make_yaml("./prompts/tmpl.md")
+
+    captured: List[Tuple[str, str, dict[str, Any]]] = []
+
+    # Patch compiler's make_templated_agent_async to capture arguments
+    import flujo.domain.blueprint.compiler as compiler_mod
+
+    def fake_make_templated_agent_async(
+        *,
+        model: str,
+        template_string: str,
+        variables_spec: dict[str, Any] | None,
+        **kwargs: Any,
+    ) -> Any:
+        captured.append((model, template_string, variables_spec or {}))
+
+        async def _agent(x: Any, *a: Any, **k: Any) -> Any:  # pragma: no cover - placeholder
+            return x
+
+        return _agent
+
+    monkeypatch.setattr(
+        compiler_mod, "make_templated_agent_async", fake_make_templated_agent_async, raising=True
+    )
+
+    # Load via public loader with base_dir
+    from flujo.domain.blueprint import load_pipeline_blueprint_from_yaml
+
+    _ = load_pipeline_blueprint_from_yaml(yaml_text, base_dir=str(base_dir))
+
+    assert captured, "make_templated_agent_async should be called for templated prompt spec"
+    model_name, template_string, variables = captured[0]
+    assert template_string == prompt_text
+    assert variables["max_sentences"] == 5
+    assert variables["topic"] == "{{ context.topic }}"
+    assert variables["author"] == "{{ previous_step.author_name }}"

--- a/tests/unit/test_templated_agent_wrapper.py
+++ b/tests/unit/test_templated_agent_wrapper.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from flujo.agents.wrapper import TemplatedAsyncAgentWrapper
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.system_prompt: str | None = None
+        self.called_with_prompt: str | None = None
+
+    async def run(self, x: Any, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - trivial
+        # Record the prompt value at call-time
+        self.called_with_prompt = self.system_prompt
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_templated_wrapper_renders_and_restores_prompt() -> None:
+    agent = _FakeAgent()
+    template = "Hello {{ user }} about {{ previous_step.topic }}"
+    variables = {"user": "{{ context.user }}"}
+    wrapper = TemplatedAsyncAgentWrapper(
+        agent,
+        template_string=template,
+        variables_spec=variables,
+        max_retries=1,
+        timeout=5,
+        model_name="openai:gpt-4o-mini",
+    )
+
+    prev_output = {"topic": "testing"}
+    ctx = {"user": "Alice"}
+
+    result = await wrapper.run_async(prev_output, context=ctx)
+    assert result == "ok"
+    # Ensure the underlying agent saw the rendered prompt
+    assert agent.called_with_prompt == "Hello Alice about testing"
+    # Ensure original prompt is restored after call
+    assert agent.system_prompt is None


### PR DESCRIPTION
This PR adds support for architect templates and dynamic prompt functionality, including: - Dynamic template examples and documentation - New test files for blueprint prompt templates - Templated agent wrapper functionality - Code formatting improvements via ruff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dynamic prompt templating for agents, allowing system prompts to be loaded from files with variables resolved at runtime from context and previous steps.
  - Introduced blueprint support for templated prompts in YAML pipelines.
  - Added configurable timeout and max_retries options for agents.

- Documentation
  - New example and README demonstrating a Dynamic Prompt Template workflow, including setup and run instructions.

- Tests
  - Added unit tests covering blueprint wiring for templated prompts and runtime rendering/restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->