### PR TITLE
cli: ensure project root is on sys.path for skills imports

### DIFF
--- a/flujo/cli/main.py
+++ b/flujo/cli/main.py
@@ -48,6 +48,15 @@ import os
 # Expose Flujo class for tests that monkeypatch flujo.cli.main.Flujo.run
 from flujo.application.runner import Flujo as _Flujo  # re-export for test monkeypatch compatibility
 
+# Ensure project root is importable for custom packages (e.g., skills/)
+try:
+    _project_root = Path.cwd()
+    import sys as _sys
+    if str(_project_root) not in _sys.path:
+        _sys.path.insert(0, str(_project_root))
+except Exception:
+    pass
+
 # Import Flujo class for testing compatibility - commented out as unused
 # from flujo.application.runner import Flujo
 


### PR DESCRIPTION
Adds project root to sys.path in CLI import path so YAML pipelines that reference custom packages (e.g., skills.helpers:fn) resolve without requiring users to set PYTHONPATH manually.\n\n- Behavior: No impact when project root is already on sys.path.\n- Motivation: Avoids 'No module named "skills"' when running 'flujo run' in a project with custom skills.\n- Alternative: Could set PYTHONPATH in init template or before pipeline execution; this patch ensures consistent behavior from CLI entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves CLI reliability by automatically discovering project-local modules, reducing “module not found” errors across environments and CI.
  * Ensures local plugins and extensions load consistently without manual PYTHONPATH or environment tweaks.
  * Provides stable behavior when running from different working directories, including project root.
  * Backward-compatible change; no updates required to existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->