### PR TITLE
fix: harden import step handling

### DIFF
--- a/docs/creating_yaml.md
+++ b/docs/creating_yaml.md
@@ -1221,9 +1221,10 @@ Imported blueprints are compiled relative to the parent YAML directory and wrapp
 Key options (under `steps[*].config` when `uses: imports.<alias>`):
 - `input_to`: Where to project the parent step input for the child run. One of `initial_prompt`, `scratchpad`, or `both`.
 - `input_scratchpad_key`: Key name used when the input is a scalar and `input_to: scratchpad` (default: `initial_input`).
-- `outputs`: List of mappings `{ child: <path>, parent: <path> }` for deterministic merges when `updates_context: true`.
+ - `outputs`: List of mappings `{ child: <path>, parent: <path> }` for deterministic merges when `updates_context: true`. Omit to merge all child fields; use an empty list to merge none.
 - `inherit_context`: Whether to inherit and deep‑copy the parent context into the child run (default: false).
-- `inherit_conversation`: Whether HITL prompts from the child participate in the parent conversation (default: true).
+ - `inherit_conversation`: Whether HITL prompts from the child participate in the parent's conversation (default: true).
+ - `on_failure`: Behavior when the child import fails: `abort` (default), `skip`, or `continue_with_default`.
 
 Example — three imported pipelines chained end‑to‑end without re‑prompting:
 

--- a/flujo/domain/blueprint/loader.py
+++ b/flujo/domain/blueprint/loader.py
@@ -1504,9 +1504,9 @@ def _make_step_from_blueprint(
                     input_scratchpad_key = raw_cfg.get("input_scratchpad_key", "initial_input")
                     # Accept either a dict mapping (backward compat) or a list of {child, parent}
                     outputs_spec = raw_cfg.get("outputs")
-                    outputs_list: list[_OutputMapping] = []
+                    outputs_list: list[_OutputMapping] | None = None
                     if isinstance(outputs_spec, dict):
-                        # Convert mapping child_path -> parent_path into list of OutputMapping
+                        outputs_list = []
                         for c_path, p_path in outputs_spec.items():
                             try:
                                 outputs_list.append(
@@ -1515,16 +1515,18 @@ def _make_step_from_blueprint(
                             except Exception:
                                 continue
                     elif isinstance(outputs_spec, list):
+                        tmp: list[_OutputMapping] = []
                         for item in outputs_spec:
                             try:
                                 if isinstance(item, dict) and "child" in item and "parent" in item:
-                                    outputs_list.append(
+                                    tmp.append(
                                         _OutputMapping(
                                             child=str(item["child"]), parent=str(item["parent"])
                                         )
                                     )
                             except Exception:
                                 continue
+                        outputs_list = tmp if tmp or outputs_spec == [] else None
                     inherit_conversation = bool(raw_cfg.get("inherit_conversation", True))
                     on_failure = str(raw_cfg.get("on_failure", "abort")).strip().lower()
                     if on_failure not in {"abort", "skip", "continue_with_default"}:

--- a/flujo/domain/dsl/import_step.py
+++ b/flujo/domain/dsl/import_step.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Literal, List
+from typing import Any, Literal
 
 from pydantic import Field
 from ..base_model import BaseModel
@@ -15,8 +15,8 @@ class OutputMapping(BaseModel):
     Example: { child: "scratchpad.final_sql", parent: "scratchpad.final_sql" }
     """
 
-    child: str
-    parent: str
+    child: str = Field(min_length=1)
+    parent: str = Field(min_length=1)
 
 
 class ImportStep(Step[Any, Any]):
@@ -37,8 +37,10 @@ class ImportStep(Step[Any, Any]):
         Optional key when projecting scalar inputs into the scratchpad.
     outputs:
         Optional list of mappings from child context paths → parent context paths.
-        When provided and ``updates_context=True``, only these mapped fields are
-        merged back.
+        Semantics with ``updates_context=True``:
+        - outputs is None → merge all child fields (legacy behavior)
+        - outputs is []   → merge nothing
+        - outputs has items → merge only the listed fields
     inherit_conversation:
         If True, conversation-related fields are preserved end-to-end. This is
         a hint for future enhancements; current implementation relies on context
@@ -53,8 +55,8 @@ class ImportStep(Step[Any, Any]):
     pipeline: Pipeline[Any, Any]
     inherit_context: bool = False
     input_to: Literal["initial_prompt", "scratchpad", "both"] = "initial_prompt"
-    input_scratchpad_key: Optional[str] = "initial_input"
-    outputs: List[OutputMapping] = Field(default_factory=list)
+    input_scratchpad_key: str | None = "initial_input"
+    outputs: list[OutputMapping] | None = None
     inherit_conversation: bool = True
     on_failure: Literal["abort", "skip", "continue_with_default"] = "abort"
 


### PR DESCRIPTION
## Summary
- guard context isolation fallback with deepcopy
- initialize scratchpad dict and type safe deep merge
- support optional outputs mappings and document semantics

## Testing
- `ruff format flujo/application/core/step_policies.py flujo/domain/dsl/import_step.py flujo/domain/blueprint/loader.py`
- `ruff check flujo/application/core/step_policies.py flujo/domain/dsl/import_step.py flujo/domain/blueprint/loader.py`
- `ruff format docs/creating_yaml.md` *(fails: Failed to parse docs/creating_yaml.md:4:6: Simple statements must be separated by newlines or semicolons)*
- `pytest tests/unit/test_import_step_policy.py tests/integration/test_yaml_import_step_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2069b3294832c831311bc0b120225