### PR TITLE
Fix(blueprint): use FlujoBaseModel for dynamic YAML models; Docs: clarify templating of previous_step vs steps.<name>.output

### DIFF
--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -18,6 +18,12 @@ Friendly presets for non-technical users:
 - `map.init`: pre-run ops applied once before mapping begins.
 - `map.finalize`: post-aggregation mapping; sees the aggregated results as `previous_step`.
 
+Tip on templating prior outputs:
+
+- `previous_step` is the raw output of the immediately preceding step; use filters like `tojson` directly on it: `"{{ previous_step | tojson }}"`.
+- For a specific earlier step by name, use the `steps` map proxy: `"{{ steps.my_step.output | tojson }}"`.
+- Avoid `"{{ previous_step.output }}"` — `previous_step` is not a proxy and has no `.output` attribute.
+
 ## Parallel Reduction
 - `reduce: keys|values|union|concat|first|last` applied after branches complete:
   - `keys`: returns branch names in declared order.

--- a/docs/creating_yaml.md
+++ b/docs/creating_yaml.md
@@ -726,7 +726,29 @@ steps:
 **Template Variables:**
 - `context`: The current pipeline context.
 - `previous_step`: The output from the immediately preceding step.
+- `steps`: Map of prior steps by name (values are proxies exposing `.output/.result/.value`).
 - `this`: (Inside a `map` step) The current item from the iterable.
+
+### Previous Step vs Steps Map
+
+Flujo exposes the last step’s value directly as `previous_step` and also exposes a map of prior steps under `steps.<name>`.
+
+- `previous_step` is the raw output value of the last step. It does not have `.output`/`.result`/`.value` attributes.
+- `steps.<name>` entries are proxies that do expose `.output`/`.result`/`.value` for convenience.
+- Use the `tojson` filter when you want a JSON string for a structured value.
+
+Examples:
+
+```yaml
+# ✅ Correct: serialize the raw previous value
+input: "{{ previous_step | tojson }}"
+
+# ✅ Correct: access a named prior step via proxy
+input: "{{ steps.generate_greeting.output | tojson }}"
+
+# ❌ Incorrect: previous_step is a raw value (no .output); this becomes null
+input: "{{ previous_step.output | tojson }}"
+```
 
 ### Context Management
 

--- a/docs/creating_yaml_best_practices.md
+++ b/docs/creating_yaml_best_practices.md
@@ -741,6 +741,7 @@ steps:
 **Guidelines:**
 - **Use HITL steps strategically**: Combine `ask_user` with AI agents for intelligent interactions
 - **Stringify complex outputs**: Use `flujo.builtins.stringify` to handle type conversions
+- **Template clarity**: Use `{{ previous_step | tojson }}` for the last step’s structured output, or `{{ steps.<name>.output | tojson }}` for a named step. Avoid `{{ previous_step.output }}` since `previous_step` is the raw value, not a proxy.
 - **Build incrementally**: Add complexity one step at a time
 - **Test each addition**: Ensure the pipeline works before adding more steps
 

--- a/flujo/domain/blueprint/model_generator.py
+++ b/flujo/domain/blueprint/model_generator.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Type
 from typing import Literal as _Literal
 
 from pydantic import BaseModel, Field, create_model
+from flujo.domain.base_model import BaseModel as FlujoBaseModel
 
 
 JsonSchema = Dict[str, Any]
@@ -92,7 +93,10 @@ def generate_model_from_schema(name: str, schema: JsonSchema) -> Type[BaseModel]
             primitive_fields["value"] = (annotation, Field(..., description=str(desc)))
         from typing import cast as _cast
 
-        return _cast(Type[BaseModel], create_model(model_name, **primitive_fields))
+        return _cast(
+            Type[BaseModel],
+            create_model(model_name, __base__=FlujoBaseModel, **primitive_fields),
+        )
 
     # Object handling
     properties: Dict[str, Any] = schema.get("properties") or {}
@@ -145,7 +149,10 @@ def generate_model_from_schema(name: str, schema: JsonSchema) -> Type[BaseModel]
 
     from typing import cast as _cast
 
-    return _cast(Type[BaseModel], create_model(model_name, **fields))
+    return _cast(
+        Type[BaseModel],
+        create_model(model_name, __base__=FlujoBaseModel, **fields),
+    )
 
 
 __all__ = ["generate_model_from_schema"]


### PR DESCRIPTION
Summary
- Blueprint: generate_model_from_schema now sets __base__=flujo.domain.base_model.BaseModel for both object and primitive wrapper models.
- Docs: clarified templating semantics and added correct/incorrect examples for using tojson with previous_step vs steps.<name>.output.

Rationale
- Template misuse ({{ previous_step.output }}) caused null; docs now explain the right usage ({{ previous_step | tojson }} or {{ steps.<name>.output | tojson }}).
- The base-model alignment ensures consistent config/serialization across dynamic models and Flujo domain models.

Verification
- make typecheck, make lint, make format all pass.
- Quick local repro confirms proper JSON via tojson for dynamic models and expected null when misusing previous_step.output.

Files
- flujo/domain/blueprint/model_generator.py
- docs/creating_yaml.md
- docs/creating_yaml_best_practices.md
- docs/blueprints.md

Notes
- No behavior change to templating engine; this PR only aligns dynamic model base and clarifies docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear guidance on templating prior step outputs in YAML workflows.
  * Clarified difference between raw previous_step and named steps proxies (steps.<name>) with correct usage examples (e.g., piping to tojson) and anti-patterns to avoid.
  * Introduced a best-practices note to improve template clarity.

* **Refactor**
  * Standardized generated models to consistently inherit from the common base model for improved uniformity. No behavioral or API changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->