### PR TITLE
Fix(validation): recurse nested imports

### DIFF
--- a/flujo/cli/helpers.py
+++ b/flujo/cli/helpers.py
@@ -1400,7 +1400,7 @@ def get_pipeline_step_names(path: str) -> list[str]:
     return [step.name for step in pipeline.steps]
 
 
-def validate_pipeline_file(path: str, *, include_imports: bool = True) -> Any:
+def validate_pipeline_file(path: str, *, include_imports: bool = True) -> ValidationReport:
     """Return the validation report for a pipeline file.
 
     Args:
@@ -1415,20 +1415,24 @@ def validate_pipeline_file(path: str, *, include_imports: bool = True) -> Any:
 
         # Ensure relative imports resolve from the YAML file directory
         base_dir = os.path.dirname(os.path.abspath(path))
-        pipeline = load_pipeline_blueprint_from_yaml(yaml_text, base_dir=base_dir)
+        pipeline: Pipeline[Any, Any] = load_pipeline_blueprint_from_yaml(
+            yaml_text, base_dir=base_dir
+        )
     else:
         pipeline, _ = load_pipeline_from_file(path)
-    from typing import cast as _cast
 
-    return _cast(Any, pipeline).validate_graph(include_imports=include_imports)
+    return pipeline.validate_graph(include_imports=include_imports)
 
 
-def validate_yaml_text(yaml_text: str, base_dir: Optional[str] = None) -> ValidationReport:
+def validate_yaml_text(
+    yaml_text: str, base_dir: Optional[str] = None, *, include_imports: bool = False
+) -> ValidationReport:
     """Validate a YAML blueprint string and return its ValidationReport.
 
     Args:
         yaml_text: The YAML blueprint content.
         base_dir: Optional base directory to resolve relative imports within YAML.
+        include_imports: When True, recursively validate imported blueprints (aggregated into report).
 
     Returns:
         ValidationReport: The validation report from pipeline.validate_graph().
@@ -1437,10 +1441,9 @@ def validate_yaml_text(yaml_text: str, base_dir: Optional[str] = None) -> Valida
         Exit: If loading the YAML fails.
     """
     from flujo.domain.blueprint import load_pipeline_blueprint_from_yaml
-    from typing import cast as _cast
 
     pipeline = load_pipeline_blueprint_from_yaml(yaml_text, base_dir=base_dir)
-    return _cast(Any, pipeline).validate_graph()
+    return pipeline.validate_graph(include_imports=include_imports)
 
 
 def sanitize_blueprint_yaml(yaml_text: str) -> str:

--- a/flujo/domain/blueprint/loader.py
+++ b/flujo/domain/blueprint/loader.py
@@ -1729,11 +1729,9 @@ def _make_step_from_blueprint(
                         config=step_config,
                     )
                     # Record the import alias for validation/reporting purposes
-                    try:
-                        if hasattr(st, "meta") and isinstance(st.meta, dict):
-                            st.meta["import_alias"] = alias
-                    except Exception:
-                        pass
+                    meta = getattr(st, "meta", None)
+                    if isinstance(meta, dict):
+                        meta["import_alias"] = alias
                 except Exception as e:
                     raise BlueprintError(
                         f"Failed to wrap imported pipeline '{alias}' as ImportStep: {e}"

--- a/tests/unit/domain/validation/test_validation_new_features.py
+++ b/tests/unit/domain/validation/test_validation_new_features.py
@@ -91,8 +91,9 @@ def test_validate_imports_aggregates_child_findings(tmp_path: Path) -> None:
     report_no_children = pipeline.validate_graph(include_imports=False)
     # Parent only; child warnings should not be present
     assert all("[import:RunChild]" not in w.message for w in report_no_children.warnings)
+    assert all("[import:child]" not in w.message for w in report_no_children.warnings)
 
-    # With children aggregated, we should see the child's V-A1 surfaced
+    # With children aggregated, we should see the child's V-T1 surfaced
     report_with_children = pipeline.validate_graph(include_imports=True)
     msgs = [w.message for w in report_with_children.warnings]
     assert any("[import:child]" in m for m in msgs), msgs


### PR DESCRIPTION
## Summary
- recurse into nested ImportStep pipelines and prefix findings with alias
- tighten CLI validation helpers with concrete types and import flag
- cover import recursion and aggregation in validation tests

## Testing
- `uv run ruff check flujo/cli/helpers.py flujo/domain/blueprint/loader.py flujo/domain/dsl/pipeline.py tests/unit/domain/validation/test_validation_new_features.py`
- `uv run mypy flujo/domain/dsl/pipeline.py flujo/cli/helpers.py flujo/domain/blueprint/loader.py`
- `uv run pytest tests/unit/domain/validation/test_validation_new_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a453748832c8be7672095f52c4a