### PR TITLE
CLI: Zero-config warnings + optional init; clearer credential hints

### DIFF
--- a/tests/cli/test_zero_config_and_credentials.py
+++ b/tests/cli/test_zero_config_and_credentials.py
@@ -55,3 +55,16 @@ pipeline = Pipeline.from_step(Step(name="boom", agent=BoomAgent()))
         out = res.stdout
         # Expect our credentials hint one-liner (specific env names may vary; check key phrase)
         assert "Credentials hint:" in out  # noqa: S101
+
+
+def test_zero_config_non_interactive_dry_run_succeeds(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        yaml_path = Path("pipeline.yaml")
+        _write_yaml(yaml_path)
+        # Non-interactive JSON mode should not prompt, and should succeed without flujo.toml
+        res = runner.invoke(app, ["run", str(yaml_path), "--dry-run", "--json"])
+        assert res.exit_code == 0  # noqa: S101
+        # Output should be JSON with validated:true
+        out = res.stdout.strip()
+        assert "validated" in out  # noqa: S101


### PR DESCRIPTION
Summary\n- Zero-config mode: running without flujo.toml now prints clear, actionable warnings in TTY.\n- Warns if HITL is present and the state backend is in-memory (non-durable).\n- Scans step agents for providers and warns about missing API keys (OPENAI_API_KEY, etc.).\n- Offers to create a minimal flujo.toml in interactive mode (sqlite default); non-interactive logs a concise warning.\n\nWhy\n- Without flujo.toml, env_file isn’t loaded, so API keys in .env aren’t picked up; model calls silently fail or no-op. Users were confused until adding flujo.toml.\n- This PR improves UX while preserving policy-driven separation (CLI layer only).\n\nFiles\n- flujo/cli/main.py: adds warnings + optional init; does not alter execution semantics.\n\nTests\n- Behavior gated for non-TTY/JSON/test modes to avoid noisy CI.\n\nNotes\n- Follow-ups could add a dedicated CLI flag to auto-init or silence warnings if desired (e.g., --init-if-missing / --no-config-warn).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-phase zero-config UX when no config is found: interactive prompts to create a minimal config and clearer warnings about ephemeral state and HITL durability.

* **Improvements**
  * Scans pipelines to infer required model providers and prints env-var credential hints (suppressed for JSON/non-interactive). Emits credential hints on auth-like failures without blocking core execution.

* **Chores**
  * Exposed test-friendly public wrappers for CLI utilities and defaults to simplify testing/monkeypatching.

* **Tests**
  * Added CLI tests covering zero-config dry-run and credential-hint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->