### PR TITLE
test(cli): ensure validate fails outside project

### DIFF
--- a/tests/cli/test_validate_requires_project.py
+++ b/tests/cli/test_validate_requires_project.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+
+def test_validate_errors_without_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "flujo.cli.main", "validate", "--format=json"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    out = (result.stdout or "") + (result.stderr or "")
+    assert "Not a Flujo project" in out


### PR DESCRIPTION
## Summary
- add CLI test verifying `flujo validate` errors when project markers are missing

## Testing
- `uv run pytest tests/cli/test_validate_requires_project.py -q`
- `make test-fast` *(fails: KeyboardInterrupt during run_targeted_tests.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e9b1ac28832ca350eca6a7aa05cb