### PR TITLE
Feat(validation): suppress V-A5 when templated input consumes previous output

### DIFF
--- a/tests/cli/test_validate_formatters_and_baseline.py
+++ b/tests/cli/test_validate_formatters_and_baseline.py
@@ -193,7 +193,8 @@ def test_validate_baseline_deltas_and_update(tmp_path: Path) -> None:
     )
     payload4 = json.loads(res4.stdout or "{}")
     w4 = payload4.get("warnings") or []
-    assert any(w.get("step_name") == "A" and w.get("rule_id") == "V-A5" for w in w4)
+    # With improved V-A5 logic, A's output is considered consumed via templating,
+    # so only B's template warning remains new relative to the trimmed baseline.
     assert any(w.get("step_name") == "B" and w.get("rule_id") == "V-T1" for w in w4)
 
 

--- a/tests/domain/dsl/test_pipeline_validation_va5_templated_input.py
+++ b/tests/domain/dsl/test_pipeline_validation_va5_templated_input.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from flujo.domain.dsl import Pipeline
+
+
+def _validate(yaml_text: str):
+    p = Pipeline.from_yaml_text(yaml_text)
+    return p.validate_graph()
+
+
+def test_va5_suppressed_when_input_references_previous_by_name() -> None:
+    yaml_text = """
+version: "0.1"
+name: "va5_by_name"
+steps:
+  - name: a
+    agent: "flujo.builtins.passthrough"
+    input: "Hello"
+  - name: b
+    agent: "flujo.builtins.passthrough"
+    input: "{{ steps.a.output }}"
+"""
+    report = _validate(yaml_text)
+    assert not any(f.rule_id == "V-A5" for f in report.warnings)
+
+
+def test_va5_suppressed_when_input_references_previous_keyword() -> None:
+    yaml_text = """
+version: "0.1"
+name: "va5_previous_step"
+steps:
+  - name: a
+    agent: "flujo.builtins.passthrough"
+    input: "Hello"
+  - name: b
+    agent: "flujo.builtins.passthrough"
+    input: "{{ previous_step }}"
+"""
+    report = _validate(yaml_text)
+    assert not any(f.rule_id == "V-A5" for f in report.warnings)
+
+
+def test_va5_warns_when_no_template_consumes_previous() -> None:
+    yaml_text = """
+version: "0.1"
+name: "va5_no_reference"
+steps:
+  - name: a
+    agent: "flujo.builtins.passthrough"
+    input: "Hello"
+  - name: b
+    agent: "flujo.builtins.passthrough"
+    input: "Static"
+"""
+    report = _validate(yaml_text)
+    assert any(f.rule_id == "V-A5" for f in report.warnings)


### PR DESCRIPTION
Summary
- Suppresses false-positive V-A5 ("Unused previous output") when the next step’s templated input clearly consumes the previous step output via:
  - {{ previous_step ... }}
  - {{ steps.<prev_step_name> ... }} (dot or bracket forms)

Motivation
- Pipelines routinely pass data with templating; current V-A5 heuristic cannot see this and warns, creating noisy CI.
- This change improves signal: warn only when we can’t detect clear consumption.

Changes
- flujo/domain/dsl/pipeline.py
  - Add _templated_input_consumes_prev() heuristic and skip V-A5 if it returns True.
- tests/domain/dsl/test_pipeline_validation_va5_templated_input.py
  - New unit tests: by-name, previous_step keyword, negative case.
- tests/cli/test_validate_formatters_and_baseline.py
  - Align baseline-delta expectations with suppressed V-A5 when templated consumption is obvious.

Behavior
- Conservative suppression: if we can’t positively match a reference to previous output, V-A5 still fires.
- No changes to V-A5 when updates_context: true is used or when no templated input exists.

Validation
- Lint/typecheck/format: make lint, make typecheck, make format all passed.
- Targeted tests: domain/dsl and CLI validation tests passed locally.

Backwards Compatibility
- Only reduces warnings in clear cases; no breaking changes.

Docs
- Suggest adding a short note to the V-A5 rule docs describing the suppression heuristic and template patterns recognized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reduced false-positive V-A5 warnings by recognizing when a step’s templated input clearly consumes the previous step’s output (e.g., using {{ previous_step }} or {{ steps.<name>.output }}). Warnings are now suppressed in these cases.

- Tests
  - Updated baseline expectations to reflect improved V-A5 behavior.
  - Added tests covering consumption via previous_step and steps.<name> templates, and a control case where no consumption occurs, ensuring accurate warning emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->