### PR TITLE
Fix(Blueprint): wire sink_to for uses import path; docs for HITL loop resume semantics

### DIFF
--- a/flujo/domain/blueprint/loader.py
+++ b/flujo/domain/blueprint/loader.py
@@ -1801,6 +1801,7 @@ def _make_step_from_blueprint(
                             name=model.name,
                             updates_context=model.updates_context,
                             validate_fields=model.validate_fields,
+                            sink_to=model.sink_to,
                             **(
                                 step_config.model_dump()
                                 if hasattr(step_config, "model_dump")


### PR DESCRIPTION
## Summary

This PR addresses two related items:

1) Fix(Blueprint): Wire `sink_to` through the YAML blueprint loader for `uses: "pkg.mod:fn"` callable path.
2) Docs(Guide): Add a focused section describing HITL-in-loop pause/resume semantics and exit condition evaluation to avoid nested loops.

---

## Background

- A reviewer reported that the new `sink_to` feature was not being populated for YAML pipelines when the step was created via the `uses: "module:attr"` path. Although other paths correctly forwarded `sink_to` (agents registry, plain Step, agent string imports), the direct callable import path was missing `sink_to`, causing YAML workflows to drop configured sinks.
- Separately, recent loop/HITL work ensures that resuming after a HITL pause within a loop does not create nested loop instances and that exit conditions are evaluated in the parent loop context. To make those semantics clear and discoverable, a succinct doc snippet was added to the team guide.

---

## Changes

### 1) Blueprint Loader: `sink_to` wiring (uses: "pkg.mod:fn")
- File: `flujo/domain/blueprint/loader.py:1799`
- Change: Forward `model.sink_to` to `Step.from_callable(...)` when `uses` resolves to a directly imported callable (e.g., `mypkg.mod:fn` or `mypkg.mod.fn`). This brings parity with other loader paths that already passed `sink_to`:
  - `uses: agents.<name>` (callable)
  - `agent: "pkg.mod:fn"` (string function import)
  - Registry-backed callables (wrapped with params)
  - Plain `Step(...)` constructor path
  - HITL path keeps dedicated handling under the `hitl` kind

Result: YAML like:
```yaml
- kind: step
  name: increment
  uses: mypkg.mod:increment_async
  sink_to: counter
```
now yields a `Step` whose `sink_to` is correctly set to `"counter"` and is honored at runtime.

### 2) Team Guide: HITL-in-loop resume semantics
- File: `FLUJO_TEAM_GUIDE.md:1721`
- Section: “HITL In Loops – Resume Semantics (Updated)”
- Summary:
  - Control-flow exceptions (e.g., `PausedException`) must be re-raised by the loop policy; never converted to failure results.
  - On resume, the loop continues the same iteration/body index (tracked via `scratchpad['loop_step_index']`, `scratchpad['loop_iteration']`) instead of spawning nested loop instances.
  - Exit condition/expression is evaluated in the parent loop context immediately after iteration completion; true → exit immediately.
  - Iteration execution remains idempotent via `ContextManager.isolate()` and safe merge; pause records minimal resume state only.
  - `sink_to` parity: simple steps’ `sink_to` fields are honored inside loop iterations and also applied when resuming from cache hits.

---

## Rationale

- Completing `sink_to` wiring across all blueprint paths ensures consistent behavior for YAML-driven pipelines and matches the documented `sink_to` workflow.
- The doc addition codifies the corrected loop/HITL behavior so contributors know where the policy lives, what state is recorded on pause, and how resume proceeds without nested loops.

---

## Validation

- Local run: `make install && make test-fast` passed
  - PASS: 931 tests
  - Logs: `output/controlled_test_run_20251004_143930.log`
  - JSON: `output/results_20251004_143930.json`

No other code changes were necessary. The team guide update is documentation-only.

---

## Files Touched

- `flujo/domain/blueprint/loader.py:1799` — Forward `sink_to` for `uses: "module:attr"` callable path
- `FLUJO_TEAM_GUIDE.md:1721` — Add resume semantics and sink_to parity notes for loop/HITL

---

## Checklist
- [x] Format and lint pass
- [x] Type-check passes
- [x] Fast test suite passes
- [x] Behavior documented in team guide



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved result routing for callable steps so outputs consistently respect configured sinks, including dynamically imported or declarative agents. No API changes.

- Documentation
  - Added an updated guide on HITL resume semantics within loops, covering source of truth, anti-patterns to avoid, pause/resume behavior, idempotent context handling, parent loop exit checks, tracer notes, and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->