### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -48,7 +48,7 @@ from .recipes.factories import (
 # Ensure framework primitives are registered at import time
 from . import framework as _framework  # noqa: F401
 
-__version__ = "0.4.38"  # HITL-in-loop resume fix + sink_to YAML wiring
+__version__ = "0.6.1"  # CI hardening, test stability, serialization improvements
 
 __all__ = [
     "Flujo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # --------------------------------------------------------------------------- #
 [project]
 name = "flujo"
-version = "0.4.38"  # HITL-in-loop resume fix + sink_to YAML wiring
+version = "0.6.1"  # CI hardening, test stability, serialization improvements
 description = "A modern, type-safe framework for building AI-powered applications with structured outputs and robust error handling."
 readme = "README.md"
 license = {text = "AGPL-3.0"}


### PR DESCRIPTION
## Release v0.6.1

Bumps version from 0.4.38 to 0.6.1.

### Changes since v0.6.0
- CI hardening and workflow fixes
- Test stability improvements (serial markers, isolation fixtures)
- Serialization improvements
- Behavioral test fixes
- Performance threshold adjustments

### Files Changed
- `pyproject.toml`: version bump
- `flujo/__init__.py`: `__version__` bump

Once merged, tag `v0.6.1` will be created to trigger PyPI publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.6.1

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->