### PR TITLE
Add nul-safe persistence fallback

### DIFF
--- a/flujo/state/backends/postgres.py
+++ b/flujo/state/backends/postgres.py
@@ -6,7 +6,7 @@ import importlib
 import importlib.util
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, TypeVar, cast
 
 from flujo.state.backends.base import StateBackend, _to_jsonable
 from flujo.type_definitions.common import JSONObject
@@ -23,6 +23,7 @@ else:  # pragma: no cover - runtime checked import
 # Advisory lock key used to serialize schema migrations across concurrent workers/pods.
 # Must fit in signed bigint; keep stable for all deployments.
 MIGRATION_LOCK_KEY = 0xF1F0C0DE
+_T = TypeVar("_T")
 
 
 def _load_asyncpg() -> Any:
@@ -51,9 +52,9 @@ def _sanitize_json_strings(value: Any) -> Any:
     return value
 
 
-def _sanitize_text_param(value: Any) -> Any:
+def _sanitize_text_param(value: _T) -> _T:
     if isinstance(value, str):
-        return _strip_nul_chars(value)
+        return cast(_T, _strip_nul_chars(value))
     return value
 
 

--- a/tests/unit/test_postgres_step_atomicity.py
+++ b/tests/unit/test_postgres_step_atomicity.py
@@ -1,56 +1,80 @@
+import json
+
 import pytest
 
-from flujo.state.backends.postgres import PostgresBackend
+from flujo.state.backends.postgres import PostgresBackend, _jsonb
 
 
 class _FakeTransaction:
     def __init__(self, conn: "_FakeConnection") -> None:
         self.conn = conn
-        self.rolled_back = False
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "_FakeTransaction":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
-        if exc_type:
-            self.rolled_back = True
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is not None:
+            self.conn.rollback_count += 1
         return False
 
 
 class _FakeConnection:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        fail_on_update: bool = False,
+        fail_first_insert: bool = False,
+    ) -> None:
         self.calls = 0
-        self.transaction_obj = _FakeTransaction(self)
+        self.rollback_count = 0
+        self.insert_attempts = 0
+        self.updated_run_id: str | None = None
+        self.fail_on_update = fail_on_update
+        self.fail_first_insert = fail_first_insert
+        self.fallback_output_json: str | None = None
+        self.fallback_raw_response_json: str | None = None
 
     def transaction(self) -> _FakeTransaction:
-        return self.transaction_obj
+        return _FakeTransaction(self)
 
-    async def execute(self, *args, **kwargs):
+    async def execute(self, query: str, *args, **kwargs):  # type: ignore[no-untyped-def]
         self.calls += 1
-        if self.calls == 2:
-            raise RuntimeError("boom")
+        if "INSERT INTO steps" in query:
+            self.insert_attempts += 1
+            if self.fail_first_insert and self.insert_attempts == 1:
+                raise RuntimeError("unsupported \x00 payload")
+            if self.insert_attempts == 2:
+                self.fallback_output_json = args[4]
+                self.fallback_raw_response_json = args[5]
+            return "INSERT 0 1"
+        if "UPDATE runs SET updated_at = NOW()" in query:
+            self.updated_run_id = args[0]
+            if self.fail_on_update:
+                raise RuntimeError("boom")
+            return "UPDATE 1"
+        return "OK"
 
 
 class _FakePool:
     def __init__(self, conn: _FakeConnection) -> None:
         self.conn = conn
 
-    def acquire(self):
+    def acquire(self) -> "_FakePool":
         return self
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> _FakeConnection:
         return self.conn
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
 
 @pytest.mark.asyncio
-async def test_postgres_step_persistence_atomicity():
-    """Step persistence should rollback when mid-transaction failure occurs."""
+async def test_postgres_step_persistence_atomicity() -> None:
+    """Step persistence should rollback when post-insert failure occurs."""
 
     backend = PostgresBackend("postgres://example", auto_migrate=False)
-    conn = _FakeConnection()
+    conn = _FakeConnection(fail_on_update=True)
     backend._pool = _FakePool(conn)  # type: ignore[assignment]
     backend._initialized = True  # Skip schema verify path
 
@@ -66,8 +90,63 @@ async def test_postgres_step_persistence_atomicity():
         "created_at": None,
     }
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="boom"):
         await backend.save_step_result(step_data)
 
-    assert conn.transaction_obj.rolled_back is True
-    assert conn.calls == 2  # second execute raised, no further statements run
+    assert conn.insert_attempts == 1
+    assert conn.calls == 2
+    assert conn.rollback_count >= 1
+
+
+def test_jsonb_strips_raw_nul_recursively() -> None:
+    payload = {
+        "k\x00ey": "va\x00lue",
+        "nested": ["a\x00", {"inner\x00": "b\x00"}],
+        "tuple_value": ("x\x00",),
+        "literal": "a\\u0000b",
+    }
+    encoded = _jsonb(payload)
+    assert encoded is not None
+
+    decoded = json.loads(encoded)
+    assert "key" in decoded
+    assert decoded["key"] == "value"
+    assert decoded["nested"][0] == "a"
+    assert decoded["nested"][1]["inner"] == "b"
+    assert decoded["tuple_value"][0] == "x"
+    # Literal escaped sequence should remain untouched (it's not a raw NUL char).
+    assert decoded["literal"] == "a\\u0000b"
+
+
+@pytest.mark.asyncio
+async def test_postgres_step_persistence_fallback_placeholder() -> None:
+    backend = PostgresBackend("postgres://example", auto_migrate=False)
+    conn = _FakeConnection(fail_first_insert=True)
+    backend._pool = _FakePool(conn)  # type: ignore[assignment]
+    backend._initialized = True  # Skip schema verify path
+
+    step_data = {
+        "run_id": "r1",
+        "step_name": "s",
+        "step_index": 0,
+        "output": {"bad": "a\x00b"},
+        "raw_response": {"bad": "a\x00b"},
+        "cost_usd": 0.0,
+        "token_counts": 0,
+        "execution_time_ms": 0,
+        "created_at": None,
+    }
+
+    await backend.save_step_result(step_data)
+
+    assert conn.insert_attempts == 2
+    assert conn.updated_run_id == "r1"
+    assert conn.fallback_output_json is not None
+    assert conn.fallback_raw_response_json is not None
+
+    output_payload = json.loads(conn.fallback_output_json)
+    raw_response_payload = json.loads(conn.fallback_raw_response_json)
+    assert output_payload["output_redacted"] is True
+    assert raw_response_payload["raw_response_redacted"] is True
+    assert output_payload["_flujo_persistence"]["degraded"] is True
+    assert output_payload["_flujo_persistence"]["reason"] == "postgres_step_persistence_fallback"

--- a/tests/unit/test_state_manager_step_persistence.py
+++ b/tests/unit/test_state_manager_step_persistence.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from flujo.application.core.state.state_manager import StateManager
+from flujo.domain.models import StepResult
+from flujo.exceptions import PipelineAbortSignal
+
+
+@pytest.mark.asyncio
+async def test_record_step_result_is_non_fatal_on_backend_error() -> None:
+    backend = Mock()
+    backend.save_step_result = AsyncMock(side_effect=RuntimeError("db write failed"))
+    state_manager: StateManager = StateManager(state_backend=backend)
+
+    step_result = StepResult(name="step_a", success=True, output={"ok": True})
+    await state_manager.record_step_result("run-1", step_result, 0)
+
+    backend.save_step_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_record_step_result_reraises_control_flow_errors() -> None:
+    backend = Mock()
+    backend.save_step_result = AsyncMock(side_effect=PipelineAbortSignal("abort"))
+    state_manager: StateManager = StateManager(state_backend=backend)
+
+    step_result = StepResult(name="step_a", success=True, output={"ok": True})
+    with pytest.raises(PipelineAbortSignal):
+        await state_manager.record_step_result("run-1", step_result, 0)


### PR DESCRIPTION
Summary
- note work done per instructions about sanitizing Postgres writes, fallback on step persistence, and state manager suppressing non-fatal DB errors (per plan context)
- include warnings about sanitization continuing execution toward telemetry mention

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Control-flow errors now propagate while non-fatal exceptions are logged as telemetry warnings.
  * Inputs and persisted data are sanitized to remove raw NULs while preserving escaped literals; run IDs containing raw NULs are rejected.
  * Persistence paths improved for stronger atomicity and a resilient fallback when initial writes fail.

* **Tests**
  * Added extensive tests covering sanitization, atomicity, fallback behavior, and control-flow error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->