### PR TITLE
Release(version): bump to 0.6.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,9 +343,9 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          pip install sigstore==3.0.1
+          pip install sigstore==4.2.0
           for f in dist/*; do
-            sigstore sign --yes "$f" --output-signature "$f.sig" --output-certificate "$f.crt"
+            sigstore sign --overwrite "$f" --output-signature "$f.sig" --output-certificate "$f.crt"
           done
 
       - name: Upload build artifacts

--- a/flujo/__init__.py
+++ b/flujo/__init__.py
@@ -48,7 +48,7 @@ from .recipes.factories import (
 # Ensure framework primitives are registered at import time
 from . import framework as _framework  # noqa: F401
 
-__version__ = "0.6.10"  # Keep in sync with pyproject.toml
+__version__ = "0.6.11"  # Keep in sync with pyproject.toml
 
 __all__ = [
     "Flujo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # --------------------------------------------------------------------------- #
 [project]
 name = "flujo"
-version = "0.6.10"  # Keep in sync with flujo.__version__
+version = "0.6.11"  # Keep in sync with flujo.__version__
 description = "A modern, type-safe framework for building AI-powered applications with structured outputs and robust error handling."
 readme = "README.md"
 license = {text = "AGPL-3.0"}


### PR DESCRIPTION
## Summary
- bump project version from 0.6.10 to 0.6.11
- keep pyproject.toml and flujo/__init__.py in sync
- push release tag v0.6.11

## Notes
- tag-triggered release workflows are running for v0.6.11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.6.11.
  * Updated CI signing tool to a newer release.
  * Changed CI artifact signing to overwrite existing signatures/certificates to streamline releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->